### PR TITLE
docs(deploy): mark legacy vercel path in kcc

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,11 +1,17 @@
-# Deployment Guide: Kingston Care Connect (Vercel)
+# Deployment Guide: Kingston Care Connect (Legacy Vercel Path)
 
-This project is optimized for deployment on **Vercel**.
+> Status: Legacy deployment guide.
+>
+> The repo is being rebaselined away from Vercel dependence. Use this document
+> only if you intentionally need the old Vercel deployment path. Do not treat
+> it as the long-term production baseline.
+
+This document describes the older **Vercel** deployment path.
 
 ## 1. Prerequisites
 
 - A GitHub account (where this repo is pushed).
-- A Vercel account (Free Tier is sufficient).
+- A Vercel account (if you are intentionally using the legacy deployment path).
 - Your `OPENAI_API_KEY` (Required for the build step).
 
 ## 2. Deploy Steps
@@ -52,7 +58,7 @@ To ensure zero-downtime when creating indexes on large tables, use the provided 
 
 ## 4. Post-Deployment Verification
 
-- Visit the URL provided by Vercel (e.g., `kingston-care-connect.vercel.app`).
+- Visit the URL provided by the legacy Vercel deployment (for example, `kingston-care-connect.vercel.app`).
 - **Test Search:** Type "Food".
 - _Success:_ Results appear instantly.
 - **Test Semantic Search:** Type "I feel empty".
@@ -60,5 +66,5 @@ To ensure zero-downtime when creating indexes on large tables, use the provided 
 
 ## 4. Troubleshooting
 
-- **Build Fail:** Check Vercel Logs. If it says "Module not found", ensure `app/worker.ts` and `hooks` are committed.
+- **Build Fail:** Check Vercel logs. If it says "Module not found", ensure `app/worker.ts` and `hooks` are committed.
 - **No Lightning Bolt:** Open Browser Console (F12). Look for network errors fetching the `.onnx` model file.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "release:notes": "node scripts/generate-release-notes.js",
     "vercel:verify": "bash scripts/verify-vercel-optimization.sh",
     "vercel:optimize": "bash scripts/apply-vercel-optimization.sh",
+    "legacy:vercel:verify": "bash scripts/verify-vercel-optimization.sh",
+    "legacy:vercel:optimize": "bash scripts/apply-vercel-optimization.sh",
     "validate:security-headers": "node --import tsx scripts/validate-security-headers.ts"
   },
   "overrides": {

--- a/scripts/health-check-urls.ts
+++ b/scripts/health-check-urls.ts
@@ -39,7 +39,8 @@ async function checkUrl(
       method: "HEAD",
       signal: controller.signal,
       headers: {
-        "User-Agent": "Mozilla/5.0 (compatible; KingstonCareConnect-HealthCheck/1.0; +https://kingstoncare.vercel.app)",
+        "User-Agent":
+          "Mozilla/5.0 (compatible; KingstonCareConnect-HealthCheck/1.0; +https://github.com/jerdaw/kingston-care-connect)",
       },
     })
 
@@ -52,7 +53,7 @@ async function checkUrl(
         signal: controllerGet.signal,
         headers: {
           "User-Agent":
-            "Mozilla/5.0 (compatible; KingstonCareConnect-HealthCheck/1.0; +https://kingstoncare.vercel.app)",
+            "Mozilla/5.0 (compatible; KingstonCareConnect-HealthCheck/1.0; +https://github.com/jerdaw/kingston-care-connect)",
         },
       })
       clearTimeout(timeoutGet)


### PR DESCRIPTION
## Summary\n- mark DEPLOY.md as the legacy Vercel path\n- remove stale Vercel hostname branding from the URL health-check user agent\n- add explicit legacy vercel script aliases while preserving compatibility\n\n## Testing\n- package.json parsed successfully\n- pre-push test suite passed\n