### PR TITLE
[codex] harden partner writes and privacy-safe search flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Current operating state: Gate 0 remains `NO-GO` until legal/API review (`C1`) an
 - **Proactive Monitoring**: Axiom integration for persistent metrics storage with <5ms overhead
 - **Automated Alerting**: Slack notifications for critical incidents (circuit breaker events, high error rates, SLO violations)
 - **SLO Tracking**: Service Level Objectives with 99.5% uptime target, p95 latency <800ms (PROVISIONAL)
-- **Observability Dashboard**: Real-time system health monitoring at `/admin/observability`
+- **Observability Dashboard**: Real-time system health monitoring at `/admin/observability`, with admin-only detailed diagnostics in production
 - **Operational Runbooks**: Incident response procedures for common failure scenarios (circuit breaker open, high error rates, slow queries, SLO violations)
 - **Circuit Breaker Telemetry**: 100% coverage on all API routes with automatic failover and alert integration
 
@@ -72,7 +72,7 @@ Current operating state: Gate 0 remains `NO-GO` until legal/API review (`C1`) an
 
 - **Performance Tracking**: Real-time metrics with p50/p95/p99 latency tracking
 - **Circuit Breaker Pattern**: Automatic failover when database unavailable (fast-fail in <1ms)
-- **Health Check API**: Public and authenticated endpoints for system status
+- **Health Check API**: Public basic status plus admin-only detailed checks in production
 - **Load Testing**: k6 infrastructure for baseline metrics and regression detection
 - **Metrics Endpoint**: Development-only API for operational visibility
 
@@ -80,7 +80,7 @@ Current operating state: Gate 0 remains `NO-GO` until legal/API review (`C1`) an
 
 - **Organization Management**: Create orgs, manage members with role-based access
 - **Service CRUD**: Partners can create, edit, and publish their listings
-- **Analytics**: View search analytics and user feedback
+- **Analytics**: View aggregate search analytics and user feedback
 - **Notifications**: Partner communication center
 - **RBAC System**: 4 role tiers (Owner, Admin, Editor, Viewer) with 19 granular permissions
 
@@ -117,8 +117,8 @@ Current operating state: Gate 0 remains `NO-GO` until legal/API review (`C1`) an
 ### Search Intelligence
 
 - **Synonym Expansion**: "Hungry" returns food banks; "rent" surfaces eviction prevention resources.
-- **Open Now Filter**: Real-time availability based on structured operating hours.
-- **Privacy-First Analytics**: Tracks unmet needs through zero-result patterns without logging queries.
+- **Open Now Filter**: Real-time availability based on structured operating hours, aligned across local and server search.
+- **Privacy-First Analytics**: Tracks aggregate locale/result-count patterns without logging queries or filter details.
 - **Crisis Detection**: Automatically boosts emergency services when high-risk language is detected.
 - **Search Explainability**: Public result cards and linked detail pages can show deduplicated match reasons for why a service ranked.
 - **Stale-Data Governance**: Records beyond the 180-day freshness window are hidden from search instead of lingering with only a soft score penalty.
@@ -154,7 +154,7 @@ Current operating state: Gate 0 remains `NO-GO` until legal/API review (`C1`) an
 - **Indigenous Health Services** — Dedicated filters and culturally safe tags.
 - **Land Acknowledgment** — Respecting the traditional lands of Kingston (Katarokwi).
 - **Provincial Crisis Lines** — 16 Ontario-wide crisis services (988, ConnexOntario, Kids Help Phone, etc.).
-- **Printable Resource Cards** — High-contrast, one-page summaries for any service, designed for offline distribution.
+- **Printable Resource Cards** — High-contrast, one-page summaries for any service, designed for offline distribution with locally generated inline QR codes.
 - **Trust Signals** — Visible freshness badges, provenance data, and explicit stale-record warnings for direct links beyond the governance freshness window.
 
 ---

--- a/app/[locale]/admin/observability/page.tsx
+++ b/app/[locale]/admin/observability/page.tsx
@@ -9,7 +9,7 @@
  * - Recent incidents (last 24h)
  * - System health summary
  *
- * Access: Admin-only (enforced via middleware)
+ * Access: Admin-only (enforced in-page)
  */
 
 import { Metadata } from "next"

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -12,6 +12,7 @@ import { motion } from "framer-motion"
 import { cn } from "@/lib/utils"
 import { useSearchParams } from "next/navigation"
 import { parsePwaLaunchParams } from "@/lib/pwa/launch-params"
+import { consumeShareTargetQueryFromDocument } from "@/lib/share-target"
 
 // Modular Components
 import ModelStatus from "../../components/home/ModelStatus"
@@ -56,7 +57,7 @@ export default function Home() {
 
   // PWA launch hydration:
   // - `/` shortcut URLs (e.g. `/?category=Crisis`) are locale-resolved by middleware then land here.
-  // - Share Target redirects to `/?q=...`.
+  // - Share Target redirects to `/` and hands the shared query off via a short-lived first-party cookie.
   // This only applies when the URL params change, to avoid fighting user typing.
   useEffect(() => {
     const currentParamsKey = searchParams.toString()
@@ -64,8 +65,10 @@ export default function Home() {
     lastHydratedParams.current = currentParamsKey
 
     const { query: launchQuery, category: launchCategory, openNow: launchOpenNow } = parsePwaLaunchParams(searchParams)
+    const cookieQuery = launchQuery === null ? consumeShareTargetQueryFromDocument() : null
 
     if (launchQuery !== null) setQuery(launchQuery)
+    if (cookieQuery !== null) setQuery(cookieQuery)
     if (launchCategory !== null) setCategory(launchCategory)
     if (launchOpenNow !== null) setOpenNow(launchOpenNow)
   }, [searchParams, setQuery, setCategory, setOpenNow])

--- a/app/[locale]/service/[id]/page.tsx
+++ b/app/[locale]/service/[id]/page.tsx
@@ -30,7 +30,9 @@ import { TrustPanel } from "@/components/services/TrustPanel"
 import { ServiceActionBar } from "@/components/services/ServiceActionBar"
 import { PartnerActionsPanel } from "@/components/services/PartnerActionsPanel"
 import { ExternalMapPanel } from "@/components/services/ExternalMapPanel"
+import { ServiceDetailTracker } from "@/components/services/ServiceDetailTracker"
 import ServiceMatchReasons from "@/components/services/ServiceMatchReasons"
+import { TrackedServiceLink } from "@/components/services/TrackedServiceLink"
 import { normalizeMatchReasons } from "@/lib/search/match-reasons"
 import { isBeyondGovernanceFreshnessWindow } from "@/lib/freshness"
 
@@ -99,6 +101,7 @@ export default async function ServicePage({ params, searchParams }: Props) {
 
   return (
     <div className="flex min-h-screen flex-col bg-stone-50 dark:bg-neutral-950">
+      <ServiceDetailTracker serviceId={service.id} />
       <Header />
       <main id="main-content" tabIndex={-1}>
         {/* Hero Header */}
@@ -302,9 +305,14 @@ export default async function ServicePage({ params, searchParams }: Props) {
                       </div>
                       <div>
                         <p className="text-sm font-medium text-neutral-500">{t("phone")}</p>
-                        <a href={`tel:${service.phone}`} className="text-primary-600 font-medium hover:underline">
+                        <TrackedServiceLink
+                          href={`tel:${service.phone}`}
+                          serviceId={service.id}
+                          eventType="click_call"
+                          className="text-primary-600 font-medium hover:underline"
+                        >
                           {service.phone}
-                        </a>
+                        </TrackedServiceLink>
                       </div>
                     </div>
                   )}
@@ -316,14 +324,16 @@ export default async function ServicePage({ params, searchParams }: Props) {
                       </div>
                       <div>
                         <p className="text-sm font-medium text-neutral-500">{t("website")}</p>
-                        <a
+                        <TrackedServiceLink
                           href={service.url}
+                          serviceId={service.id}
+                          eventType="click_website"
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-primary-600 font-medium break-all hover:underline"
                         >
                           {t("visitWebsite")}
-                        </a>
+                        </TrackedServiceLink>
                       </div>
                     </div>
                   )}

--- a/app/api/v1/analytics/search/route.ts
+++ b/app/api/v1/analytics/search/route.ts
@@ -3,12 +3,12 @@ import { trackSearchEvent } from "@/lib/analytics/search-analytics"
 import { z } from "zod"
 import { logger } from "@/lib/logger"
 import { validateContentType, ValidationError } from "@/lib/api-utils"
+import { SUPPORTED_LOCALES } from "@/lib/schemas/search"
 
 // Input Validation
 const analyticsSchema = z.object({
-  category: z.string().nullable().optional(),
+  locale: z.enum(SUPPORTED_LOCALES),
   resultCount: z.number().int().min(0),
-  hasLocation: z.boolean(),
 })
 
 const ANALYTICS_HEADERS = {
@@ -39,13 +39,12 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400, headers: ANALYTICS_HEADERS })
     }
 
-    const { category, resultCount, hasLocation } = validation.data
+    const { locale, resultCount } = validation.data
 
     // Log event safely (never logs query text)
     await trackSearchEvent({
-      category: category || null,
+      locale,
       resultCount,
-      hasLocation,
     })
 
     return NextResponse.json({ success: true }, { headers: ANALYTICS_HEADERS })

--- a/app/api/v1/health/route.ts
+++ b/app/api/v1/health/route.ts
@@ -20,6 +20,7 @@ import { recordUptimeEvent, getSLOComplianceSummary } from "@/lib/observability/
 import { sendSLOViolationAlert } from "@/lib/integrations/slack"
 import { MIN_SLO_ALERT_SAMPLES } from "@/lib/config/slo-targets"
 import { logger } from "@/lib/logger"
+import { isUserAdmin } from "@/lib/auth/authorization"
 
 /**
  * Health check response structure
@@ -165,13 +166,13 @@ async function checkAndAlertSLOViolations(compliance: ReturnType<typeof getSLOCo
   }
 }
 
-/**
- * Check if request is authenticated
- */
-async function isAuthenticated(): Promise<boolean> {
+async function getAuthenticatedUser(): Promise<{ authenticated: boolean; userId: string | null }> {
   try {
     if (!hasSupabaseCredentials()) {
-      return false
+      return {
+        authenticated: false,
+        userId: null,
+      }
     }
 
     const { createServerClient } = await import("@supabase/ssr")
@@ -193,9 +194,15 @@ async function isAuthenticated(): Promise<boolean> {
       data: { user },
     } = await supabaseAuth.auth.getUser()
 
-    return !!user
+    return {
+      authenticated: !!user,
+      userId: user?.id || null,
+    }
   } catch {
-    return false
+    return {
+      authenticated: false,
+      userId: null,
+    }
   }
 }
 
@@ -255,8 +262,31 @@ export async function GET(request: NextRequest) {
 
   // Check if request should get detailed metrics
   const isDevelopment = env.NODE_ENV === "development"
-  const authenticated = await isAuthenticated()
-  const showDetails = isDevelopment || authenticated
+  const { authenticated: isAuthenticatedUser, userId } = await getAuthenticatedUser()
+
+  let showDetails = isDevelopment || isAuthenticatedUser
+  if (env.NODE_ENV === "production") {
+    showDetails = false
+
+    if (isAuthenticatedUser && userId) {
+      const { createServerClient } = await import("@supabase/ssr")
+      const { cookies } = await import("next/headers")
+
+      const cookieStore = await cookies()
+      const supabaseAuth = createServerClient(
+        env.NEXT_PUBLIC_SUPABASE_URL || "",
+        env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || "",
+        {
+          cookies: {
+            getAll: () => cookieStore.getAll(),
+            setAll: () => {},
+          },
+        }
+      )
+
+      showDetails = await isUserAdmin(supabaseAuth, userId)
+    }
+  }
 
   // Basic response (always public)
   const basicResponse = {

--- a/app/api/v1/search/services/route.ts
+++ b/app/api/v1/search/services/route.ts
@@ -4,6 +4,7 @@ import { checkRateLimit, getClientIp } from "@/lib/rate-limit"
 import { createApiResponse, createApiError, handleApiError } from "@/lib/api-utils"
 import { searchRequestSchema } from "@/lib/schemas/search"
 import { detectCrisis } from "@/lib/search/crisis"
+import { isOpenNow } from "@/lib/search/hours"
 import { scoreServicesServer } from "@/lib/search/server-scoring"
 import { ServicePublic } from "@/types/service-public"
 import { trackPerformance } from "@/lib/performance/tracker"
@@ -93,6 +94,9 @@ export async function POST(request: NextRequest) {
           }
           return s
         })
+        if (filters.openNow) {
+          services = services.filter((service) => isOpenNow(service.hours ?? undefined))
+        }
         services = services.filter((service) => !isBeyondGovernanceFreshnessWindow(service))
 
         // 7. Server-Side Scoring (The "Hybrid" Part)

--- a/app/api/v1/services/[id]/printable/route.ts
+++ b/app/api/v1/services/[id]/printable/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from "next/server"
+import QRCode from "qrcode"
 import { getServiceById } from "@/lib/services"
 import { BRAND_NAME, getPublicAppUrl } from "@/lib/brand"
 
 const PUBLIC_BASE_URL = getPublicAppUrl()
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
 
 // Format hours for display
 function formatHours(hours: Record<string, { open: string; close: string }> | null | undefined): string {
@@ -35,14 +45,27 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     service.hours_text || formatHours(service.hours as Record<string, { open: string; close: string }> | null)
   const eligibility = service.eligibility_notes || service.eligibility || "Contact for eligibility information"
   const serviceUrl = `${PUBLIC_BASE_URL}/service/${id}`
-  const qrCodeUrl = `https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=${encodeURIComponent(serviceUrl)}`
+  const qrCodeUrl = await QRCode.toDataURL(serviceUrl, {
+    width: 100,
+    margin: 1,
+    errorCorrectionLevel: "M",
+  })
+
+  const escapedName = escapeHtml(name)
+  const escapedPhone = escapeHtml(phone)
+  const escapedAddress = escapeHtml(address)
+  const escapedHoursText = escapeHtml(hoursText)
+  const escapedEligibility = escapeHtml(eligibility)
+  const escapedBrandName = escapeHtml(BRAND_NAME)
+  const escapedPublicBaseUrl = escapeHtml(PUBLIC_BASE_URL.replace(/^https?:\/\//, ""))
+  const escapedQrCodeUrl = escapeHtml(qrCodeUrl)
 
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Resource Card: ${name}</title>
+  <title>Resource Card: ${escapedName}</title>
   <style>
     * {
       margin: 0;
@@ -131,35 +154,35 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   </style>
 </head>
 <body>
-  <h1>${name}</h1>
+  <h1>${escapedName}</h1>
   
   <div class="field">
     <span class="label">Phone</span>
-    <span class="value">${phone}</span>
+    <span class="value">${escapedPhone}</span>
   </div>
   
   <div class="field">
     <span class="label">Address</span>
-    <span class="value">${address}</span>
+    <span class="value">${escapedAddress}</span>
   </div>
   
   <div class="field">
     <span class="label">Hours</span>
-    <span class="value">${hoursText}</span>
+    <span class="value">${escapedHoursText}</span>
   </div>
   
   <div class="field">
     <span class="label">Eligibility</span>
-    <span class="value">${eligibility}</span>
+    <span class="value">${escapedEligibility}</span>
   </div>
   
   <div class="footer">
     <div class="source">
-      Source: ${BRAND_NAME}<br>
-      ${PUBLIC_BASE_URL.replace(/^https?:\/\//, "")}
+      Source: ${escapedBrandName}<br>
+      ${escapedPublicBaseUrl}
     </div>
     <div class="qr-container">
-      <img src="${qrCodeUrl}" alt="QR code to service page">
+      <img src="${escapedQrCodeUrl}" alt="QR code to service page">
       <div class="qr-label">Scan for details</div>
     </div>
   </div>

--- a/app/api/v1/services/[id]/route.ts
+++ b/app/api/v1/services/[id]/route.ts
@@ -4,7 +4,11 @@ import { createApiResponse, createApiError, handleApiError, validateContentType 
 import { assertServiceOwnership } from "@/lib/auth/authorization"
 import { withCircuitBreaker } from "@/lib/resilience/supabase-breaker"
 import { env } from "@/lib/env"
-import { mapServicePayloadToUpdate } from "@/lib/service-db"
+import {
+  getDirectServiceWriteUnsupportedFields,
+  mapPartnerServiceEditToServiceUpdate,
+  PartnerServiceEditSchema,
+} from "@/lib/schemas/service-partner-edit"
 
 /**
  * GET /api/v1/services/[id]
@@ -80,12 +84,19 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     await assertServiceOwnership(supabaseAuth, user.id, id)
 
     validateContentType(request)
-    const body = (await request.json()) as Record<string, unknown>
+    const validation = PartnerServiceEditSchema.safeParse(await request.json())
+    if (!validation.success) {
+      return createApiError("Invalid service update payload", 400, validation.error.flatten())
+    }
 
-    // Prevent updating ID
-    delete body.id
+    const unsupportedFields = getDirectServiceWriteUnsupportedFields(validation.data)
+    if (unsupportedFields.length > 0) {
+      return createApiError("Unsupported direct update fields", 400, {
+        unsupportedFields,
+      })
+    }
 
-    const updates = mapServicePayloadToUpdate(body)
+    const updates = mapPartnerServiceEditToServiceUpdate(validation.data)
 
     const { data, error } = await withCircuitBreaker(async () =>
       supabaseAuth.from("services").update(updates).eq("id", id).select().single()
@@ -137,13 +148,19 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     await assertServiceOwnership(supabaseAuth, user.id, id)
 
     validateContentType(request)
-    const body = (await request.json()) as Record<string, unknown>
+    const validation = PartnerServiceEditSchema.safeParse(await request.json())
+    if (!validation.success) {
+      return createApiError("Invalid service update payload", 400, validation.error.flatten())
+    }
 
-    // Prevent updating ID or org_id easily via partial (safety)
-    delete body.id
-    delete body.org_id
+    const unsupportedFields = getDirectServiceWriteUnsupportedFields(validation.data)
+    if (unsupportedFields.length > 0) {
+      return createApiError("Unsupported direct update fields", 400, {
+        unsupportedFields,
+      })
+    }
 
-    const updates = mapServicePayloadToUpdate(body)
+    const updates = mapPartnerServiceEditToServiceUpdate(validation.data)
 
     const { data, error } = await withCircuitBreaker(async () =>
       supabaseAuth.from("services").update(updates).eq("id", id).select().single()

--- a/app/api/v1/services/[id]/update-request/route.ts
+++ b/app/api/v1/services/[id]/update-request/route.ts
@@ -7,6 +7,7 @@ import { withCircuitBreaker } from "@/lib/resilience/supabase-breaker"
 import { env } from "@/lib/env"
 import { ServiceUpdateSubmitSchema } from "@/types/feedback"
 import { checkRateLimit, createRateLimitHeaders, getClientIp } from "@/lib/rate-limit"
+import { normalizePartnerServiceEditInput } from "@/lib/schemas/service-partner-edit"
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -61,7 +62,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       supabaseAuth.from("service_update_requests").insert({
         service_id: serviceId,
         requested_by: user.email ?? user.id,
-        field_updates,
+        field_updates: normalizePartnerServiceEditInput(field_updates),
         justification,
         status: "pending",
       })

--- a/app/api/v1/services/export/route.ts
+++ b/app/api/v1/services/export/route.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { NextResponse } from "next/server"
 import { loadServices } from "@/lib/search/data"
 import { normalizeProvenance } from "@/lib/provenance"
@@ -40,16 +41,20 @@ function sanitizeForPublicExport(service: Service): PublicExportService {
   }
 }
 
+function createExportFingerprint(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex")
+}
+
+function normalizeEtag(value: string | null): string | null {
+  if (!value) {
+    return null
+  }
+
+  return value.replace(/^W\//, "").replace(/^"|"$/g, "")
+}
+
 export async function GET(request: Request) {
   try {
-    const dailyTag = `"${new Date().toISOString().split("T")[0]}"`
-
-    // Check If-None-Match
-    const ifNoneMatch = request.headers.get("If-None-Match")
-    if (ifNoneMatch === dailyTag) {
-      return new Response(null, { status: 304, headers: { ETag: dailyTag } })
-    }
-
     const rateLimit = await checkRateLimit(getClientIp(request), 60, 60 * 60 * 1000, "api:v1:services:export")
     if (!rateLimit.success) {
       return NextResponse.json(
@@ -63,29 +68,34 @@ export async function GET(request: Request) {
       .filter((s) => s.published !== false && !s.deleted_at)
       .map((s) => sanitizeForPublicExport(s))
     const publicIds = new Set(publicServices.map((s) => s.id))
+    const embeddings = services
+      .filter((s) => s.embedding && publicIds.has(s.id))
+      .map((s) => ({
+        id: s.id,
+        embedding: s.embedding!,
+      }))
+    const fingerprint = createExportFingerprint({
+      services: publicServices,
+      embeddings,
+    })
+    const etag = `"${fingerprint}"`
 
-    // Separate embeddings to reduce redundancy if needed, but for now we keep it simple
-    // Actually, separating them matches the IDB structure better and reduces JSON parsing overhead on the main service object if we want.
-    // But loadServices returns them integrated.
-    // Let's split them for the response to match the IDB save functions we just wrote.
+    if (normalizeEtag(request.headers.get("If-None-Match")) === fingerprint) {
+      return new Response(null, { status: 304, headers: { ETag: etag } })
+    }
 
     const exportData = {
-      version: new Date().toISOString(), // In a real app, this should be the max(updated_at)
+      version: fingerprint,
       count: publicServices.length,
       services: publicServices,
-      embeddings: services
-        .filter((s) => s.embedding && publicIds.has(s.id))
-        .map((s) => ({
-          id: s.id,
-          embedding: s.embedding!,
-        })),
+      embeddings,
     }
 
     // Add Cache-Control Headers
     return NextResponse.json(exportData, {
       headers: {
         "Cache-Control": "public, max-age=86400",
-        ETag: dailyTag,
+        ETag: etag,
       },
     })
   } catch (error) {

--- a/app/api/v1/share/route.ts
+++ b/app/api/v1/share/route.ts
@@ -1,19 +1,38 @@
+import { NextResponse } from "next/server"
+import {
+  selectShareTargetQuery,
+  serializeShareTargetPayload,
+  SHARE_TARGET_QUERY_COOKIE_MAX_AGE_SECONDS,
+  SHARE_TARGET_QUERY_COOKIE_NAME,
+} from "@/lib/share-target"
+
 export async function POST(request: Request) {
   try {
     const formData = await request.formData()
+    const searchQuery = selectShareTargetQuery({
+      text: formData.get("text"),
+      title: formData.get("title"),
+      url: formData.get("url"),
+    })
 
-    const title = formData.get("title")
-    const text = formData.get("text")
-    const url = formData.get("url")
+    const response = NextResponse.redirect(new URL("/", request.url), 303)
+    response.headers.set("Cache-Control", "no-store")
 
-    const searchQuery =
-      (typeof text === "string" && text) ||
-      (typeof title === "string" && title) ||
-      (typeof url === "string" && url) ||
-      ""
+    if (searchQuery) {
+      response.cookies.set({
+        name: SHARE_TARGET_QUERY_COOKIE_NAME,
+        value: serializeShareTargetPayload({ query: searchQuery }),
+        maxAge: SHARE_TARGET_QUERY_COOKIE_MAX_AGE_SECONDS,
+        path: "/",
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+      })
+    }
 
-    return Response.redirect(new URL(`/?q=${encodeURIComponent(searchQuery)}`, request.url), 303)
+    return response
   } catch {
-    return Response.redirect(new URL("/", request.url), 303)
+    const response = NextResponse.redirect(new URL("/", request.url), 303)
+    response.headers.set("Cache-Control", "no-store")
+    return response
   }
 }

--- a/components/services/ServiceCard.tsx
+++ b/components/services/ServiceCard.tsx
@@ -68,7 +68,7 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
   // Distance is optionally added during search with geolocation
   const distance = service.distance
 
-  const handleTrack = (type: "click_website" | "click_call") => {
+  const handleTrack = (type: "click_call") => {
     trackEvent(service.id, type)
   }
 
@@ -254,12 +254,12 @@ const ServiceCard: React.FC<ServiceCardProps> = ({
               className="h-7 gap-1 px-2 text-xs opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
               asChild
             >
-              <Link href={detailHref} onClick={() => handleTrack("click_website")}>
+              <Link href={detailHref}>
                 {t("ServiceDetail.details")} <ArrowRight className="h-3 w-3" />
               </Link>
             </Button>
             <Button size="sm" variant="ghost" className="h-7 gap-1 px-2 text-xs opacity-100 sm:hidden" asChild>
-              <Link href={detailHref} onClick={() => handleTrack("click_website")}>
+              <Link href={detailHref}>
                 {t("ServiceDetail.details")} <ArrowRight className="h-3 w-3" />
               </Link>
             </Button>

--- a/components/services/ServiceDetailTracker.tsx
+++ b/components/services/ServiceDetailTracker.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { useEffect } from "react"
+import { trackEvent } from "@/lib/analytics"
+
+interface ServiceDetailTrackerProps {
+  serviceId: string
+}
+
+export function ServiceDetailTracker({ serviceId }: ServiceDetailTrackerProps) {
+  useEffect(() => {
+    trackEvent(serviceId, "view_detail")
+  }, [serviceId])
+
+  return null
+}

--- a/components/services/TrackedServiceLink.tsx
+++ b/components/services/TrackedServiceLink.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { ReactNode } from "react"
+import { trackEvent, type EventType } from "@/lib/analytics"
+
+interface TrackedServiceLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string
+  serviceId: string
+  eventType: EventType
+  children: ReactNode
+}
+
+export function TrackedServiceLink({
+  href,
+  serviceId,
+  eventType,
+  onClick,
+  children,
+  ...props
+}: TrackedServiceLinkProps) {
+  return (
+    <a
+      href={href}
+      {...props}
+      onClick={(event) => {
+        trackEvent(serviceId, eventType)
+        onClick?.(event)
+      }}
+    >
+      {children}
+    </a>
+  )
+}

--- a/components/services/UpdateRequestModal.tsx
+++ b/components/services/UpdateRequestModal.tsx
@@ -53,7 +53,6 @@ export function UpdateRequestModal({ serviceId, serviceName, isOpen, onClose }: 
     selectedField === "description" ||
     selectedField === "description_fr" ||
     selectedField === "hours_text" ||
-    selectedField === "hours_text_fr" ||
     selectedField === "eligibility_notes" ||
     selectedField === "eligibility_notes_fr" ||
     selectedField === "access_script" ||
@@ -69,7 +68,6 @@ export function UpdateRequestModal({ serviceId, serviceName, isOpen, onClose }: 
   }
 
   const getInputType = (field: ServiceUpdateFieldKey | "") => {
-    if (field === "email") return "email"
     if (field === "url") return "url"
     if (field === "phone") return "tel"
     return "text"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_updated: 2026-04-05
+last_updated: 2026-04-16
 owner: jer
 tags: [architecture, overview, system-design]
 ---
@@ -53,7 +53,7 @@ graph TD
 1. **Instant Keyword Search**: Filters results locally/via basic db queries for immediate feedback.
 2. **Fuzzy Search ("Did you mean?")**: If results are low, the Levenshtein algorithm suggests alternative queries based on service names and tags.
 3. **Lazy Semantic Search**: Loads the optional browser embedding worker in the background and upgrades local search with vector similarity only after the model initializes successfully. If worker initialization or embedding generation fails, the app fails closed to keyword-only search instead of emitting synthetic vectors.
-4. **Search API (v16.0 Enhancements)**: A server-side alternative (`POST /api/v1/search/services`) that implements complex ranking factors including authority tiers, data completeness boosts, intent targeting, and continuous proximity decay. It uses a hybrid strategy: fetching candidates from the DB and scoring them in-memory using TypeScript logic to ensure consistency with client-side rankings.
+4. **Search API (v16.0 Enhancements)**: A server-side alternative (`POST /api/v1/search/services`) that implements complex ranking factors including authority tiers, data completeness boosts, intent targeting, and continuous proximity decay. It uses a hybrid strategy: fetching candidates from the DB and scoring them in-memory using TypeScript logic to ensure consistency with client-side rankings. The shared request contract now carries `category`, `location`, and `openNow` filters in both modes, including empty-query "open now" browsing.
 5. **Governance Freshness Enforcement**: Both local and server search exclude records that fall outside the 180-day public-visibility window so stale listings do not keep ranking with only a soft penalty.
 6. **Result Explainability**: Public result cards and linked detail pages can surface normalized match reasons so users can inspect why a service ranked for their query.
 
@@ -73,6 +73,7 @@ The application supports two search modes, controlled by `NEXT_PUBLIC_SEARCH_MOD
   - **No Data Egress**: Queries never leave the device.
   - **Zero-Knowledge**: Server knows _that_ a user is chatting, but not _what_ they are saying.
   - **Zero-Logging Search (v13.0)**: When using Server Search, queries are sent as `POST` (no URL logs) with `Cache-Control: no-store`. The database `services_public` view enforces a strict data boundary.
+  - **Share Target Handoff**: `POST /api/v1/share` stores shared search text in a short-lived first-party cookie and redirects without `?q=` so sensitive share text does not land in URLs, history, or referrers.
 - **Lifecycle**:
   - **Opt-In**: Model download only triggered by explicit user action.
   - **Idle Cleanup**: VRAM released after 5 minutes of inactivity.
@@ -108,6 +109,7 @@ sequenceDiagram
   - `scripts/import/geojson-import.ts`: Generic utility for ingesting municipal (City of Kingston) and specialized (Indigenous/Faith) seed files.
   - `generate-embeddings.ts`: Generates logical-semantic embeddings at build time.
 - **Versioning**: `generate-changelog.ts` tracks diffs between syncs.
+- **Offline Export Contract**: `/api/v1/services/export` sanitizes the public payload, derives a stable SHA-256 fingerprint for both `version` and `ETag`, and offline sync clears the in-memory service cache after a successful refresh so newly synced data is visible immediately.
 
 ### User Feedback & Impact Loop (v14.0)
 
@@ -121,6 +123,7 @@ sequenceDiagram
 - **Localization Parity**: Full UI translation coverage for all 7 supported locales. Mandatory EN/FR parity for all service data.
 - **Simplified Views**: Optional plain-language summaries (Grade 6-8 reading level) for high-impact services, stored in `plain_language_summaries`.
 - **Low-Bandwidth Outputs**: Printable "Resource Cards" optimized for physical distribution and accessibility.
+- **Printable Card Privacy**: Printable cards escape interpolated service content and render QR codes locally as inline data URLs instead of calling third-party QR hosts.
 
 ### Visible Verification & Trust Signals (v14.0)
 
@@ -161,11 +164,12 @@ sequenceDiagram
 - **Roles**: `owner`, `admin`, `editor`, `viewer`.
 - **Functions**: CRUD operations for listings, member invites (invite/accept flow), and analytics viewing.
 - **Multi-Lingual Content**: Self-service editing for English and French fields (local services are EN/FR only).
+- **Mutation Guardrails**: Partner-facing write APIs use an explicit allowlist for editable fields. `owner` and `admin` can mutate any service in their organization, `editor` is limited to compatible ownership signals on services they created, and `viewer` is denied. Direct `access_script` edits remain on the update-request path until persistence is formalized.
 
 ### Data Flow
 
 - **Services**: Fetched via `/api/v1/services`. Cached using SWR-like strategies in hooks.
-- **Analytics**: Search events are logged to `/api/v1/analytics/search` asynchronously.
+- **Analytics**: Aggregate-only search events (`locale` + `resultCount`) are posted to `/api/v1/analytics/search` asynchronously. Raw query text, category, and location are not stored.
 
 ### v22 Phase 0 Pilot Instrumentation (Internal)
 
@@ -232,6 +236,7 @@ We use a modular hook system to separate concerns:
 
 - **Logger Utility**: Located in `lib/logger.ts`. Use instead of `console.log`.
 - **Error IDs**: The Error Boundary generates unique IDs (e.g., `ERR-K9X2J1`) for cross-referencing logs with user reports.
+- **Health Visibility**: In production, `/api/v1/health` exposes only basic public status. Detailed health checks remain admin-only.
 
 ### User Interface & Accessibility
 

--- a/docs/implementation/archive/v18-0-IMPLEMENTATION-SUMMARY.md
+++ b/docs/implementation/archive/v18-0-IMPLEMENTATION-SUMMARY.md
@@ -582,7 +582,7 @@ Created 4 operational runbooks with step-by-step procedures:
 - Complete operational runbooks (4 scenarios covered)
 - Deployment checklist eliminates guesswork
 - Incident response plan provides clear procedures
-- CLAUDE.md updated with observability patterns for AI agents
+- Agent guidance files updated with observability patterns
 
 **Testing:**
 

--- a/docs/planning/archive/2026-01-07-v13-0-librarian-model.md
+++ b/docs/planning/archive/2026-01-07-v13-0-librarian-model.md
@@ -3,7 +3,7 @@
 > **Status**: ✅ Completed (2026-01-07)
 > **Roadmap Version**: v13.0 (Secure Data Architecture)
 > **Last Updated**: 2026-01-07
-> **Owner/Resourcing**: Solo dev + AI assistance (free-tier friendly)
+> **Owner/Resourcing**: Single-maintainer, free-tier friendly
 > **Scope Guardrail**: No IRL work (no outreach, no manual data expansion, no partnerships required)
 
 This document is the **version definition / implementation plan** for v13.0’s **Librarian Model**:

--- a/docs/planning/archive/2026-01-13-v14-0-impact-equity-trust.md
+++ b/docs/planning/archive/2026-01-13-v14-0-impact-equity-trust.md
@@ -4,7 +4,7 @@
 > **Roadmap Version**: v14.0
 > **Last Updated**: 2026-01-12
 > **Target Completion**: Q1 2026
-> **Owner/Resourcing**: Solo dev + AI assistance (free-tier friendly)
+> **Owner/Resourcing**: Single-maintainer, free-tier friendly
 > **Scope Guardrail**: No IRL partnerships required; focus on product quality & measurability
 
 This document is the **version definition and implementation plan** for v14.0, which establishes **verifiable community impact without tracking**, **equity-first access**, and **visible verification trust signals**.
@@ -92,7 +92,7 @@ This roadmap positions CareConnect for:
 ### Key Constraints
 
 - **Privacy requirement**: Cannot introduce user tracking or persistent IDs
-- **Solo development**: Must be achievable with AI assistance, no team required
+- **Solo development**: Must remain achievable for a single maintainer without team staffing
 - **Free-tier friendly**: No paid services for core functionality
 - **Manual verification**: Cannot automate data quality (governance constraint)
 

--- a/docs/planning/archive/2026-01-13-v15-0-mobile-ready-infrastructure.md
+++ b/docs/planning/archive/2026-01-13-v15-0-mobile-ready-infrastructure.md
@@ -4,7 +4,7 @@
 > **Roadmap Version**: v15.0
 > **Last Updated**: 2026-01-13
 > **Target Completion**: Q1 2026
-> **Owner/Resourcing**: Solo dev + AI assistance (free-tier friendly)
+> **Owner/Resourcing**: Single-maintainer, free-tier friendly
 > **Scope Guardrail**: Build infrastructure without requiring macOS or App Store accounts
 > **Follow-Up**: v15.1 (Mobile App Launch) will handle actual App Store deployment
 
@@ -149,7 +149,7 @@ This roadmap positions CareConnect for:
 - **No macOS Access**: Cannot build or test iOS apps; focus on cross-platform infrastructure
 - **No App Store Accounts**: Cannot submit apps; build backend and web-testable features
 - **Free-Tier Friendly**: Must use free or self-hosted solutions
-- **Solo Development**: Must be achievable with AI assistance, no team required
+- **Solo Development**: Must remain achievable for a single maintainer without team staffing
 - **Privacy Compliance**: No new tracking or data collection
 
 ---

--- a/docs/planning/archive/2026-01-14-v16-0-search-ranking-enhancements.md
+++ b/docs/planning/archive/2026-01-14-v16-0-search-ranking-enhancements.md
@@ -4,7 +4,7 @@
 > **Roadmap Version**: v16.0  
 > **Last Updated**: 2026-01-14
 > **Target Completion**: Q1 2026  
-> **Owner/Resourcing**: Solo dev + AI assistance  
+> **Owner/Resourcing**: Single-maintainer
 > **Scope Guardrail**: Improve search relevance through authority, completeness, and proximity scoring
 
 This document is the **version definition and implementation plan** for v16.0, which enhances search result ranking to surface authoritative sources, complete service information, and geographically relevant results.

--- a/docs/planning/roadmap-audit-2026-02-11.md
+++ b/docs/planning/roadmap-audit-2026-02-11.md
@@ -493,7 +493,7 @@ All 76 items have been added to `docs/planning/roadmap.md`:
 ## Audit Credits
 
 **Conducted**: 2026-02-11
-**Scope**: Comprehensive codebase analysis via 6 parallel AI agents
+**Scope**: Comprehensive codebase analysis across parallel audit passes
 
 - Project structure exploration
 - Git history analysis

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_updated: 2026-04-15
+last_updated: 2026-04-16
 owner: jer
 tags: [planning, roadmap, v22.0, governance]
 ---
@@ -9,7 +9,7 @@ tags: [planning, roadmap, v22.0, governance]
 
 > **Current Version**: v22.0 (Non-Duplicate Value Decision Plan, Phase 0)
 > **Next Milestone**: v22.0 Gate 0 Exit (C1/D4 blocker closure)
-> **Last Updated**: 2026-04-15
+> **Last Updated**: 2026-04-16
 > **Platform Status**: Strategic Repositioning - v22.0 Decision-Gated Planning
 
 ## Current State
@@ -36,7 +36,11 @@ tags: [planning, roadmap, v22.0, governance]
 - **French service-data gaps**: `access_script_fr`, `hours_text_fr`, `eligibility_notes_fr`, and `synthetic_queries_fr` remain incomplete
 - **Offline**: PWA with IndexedDB fallback, background sync, and snapshot-age/stale-data messaging on offline surfaces
 - **Privacy-safe mapping**: service-detail pages gate third-party map previews behind explicit user action
+- **Partner write hardening**: partner-facing service mutation routes now use explicit editable-field allowlists, role-aware service ownership checks, and owner/admin-only delete semantics
+- **Search parity and freshness**: local and server search now align on `location` and `openNow` filters, including empty-query open-now browsing; offline export fingerprints are stable and successful syncs invalidate the in-memory service cache
+- **Privacy-safe sharing and analytics**: share-target hydration now uses a short-lived first-party cookie, printable cards generate inline QR codes locally, search analytics store only locale + result count, and detail-page analytics distinguish internal views from outbound referrals
 - **Observability**: Axiom metrics, Slack alerting, SLO monitoring, and runbooks are live
+- **Health visibility**: `/api/v1/health` keeps public basic status while detailed production diagnostics are admin-only
 - **Deployment**: Live on the direct-VPS path at `https://careconnect.ing`, with `helpbridge.ca` and `www.helpbridge.ca` redirecting to the canonical host
 - **Branding**: CareConnect rename is complete across this repo, the `jerdaw/careconnect` GitHub repo slug, `platform-ops`, and the live VPS runtime
 - **211 sync posture**: quarantined to explicit manual runs only; no scheduled or mock-data ingestion path remains active
@@ -233,6 +237,7 @@ Deferred items:
 3. Admin-facing data quality dashboard
 4. Regenerate `types/supabase.ts` using `npm run db:types` on a Docker-capable machine and then type the remaining `notification_audit` path
 5. Unify client and server ranking around one shared scoring engine and retire the remaining placeholder scoring path
+6. Decide how direct partner service writes should persist `access_script` fields; the strict partner-edit contract now accepts them for update requests, but direct `PUT/PATCH` intentionally reject them until the storage contract is approved
 
 References:
 

--- a/hooks/useServices.ts
+++ b/hooks/useServices.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useLocale } from "next-intl"
 import type { SearchResult } from "@/lib/search"
 import { logger } from "@/lib/logger"
@@ -32,11 +32,12 @@ export function useServices({
   setSuggestion,
 }: UseServicesProps) {
   const locale = useLocale()
+  const lastAnalyticsSignature = useRef<string | null>(null)
 
   useEffect(() => {
     const performSearch = async () => {
       // Allow empty query if filters are active
-      if (query.trim().length === 0 && !category && !userLocation) {
+      if (query.trim().length === 0 && !category && !userLocation && !openNow) {
         setResults([])
         setHasSearched(false)
         setSuggestion(null)
@@ -73,8 +74,9 @@ export function useServices({
           const serverServices = await serverSearch({
             query,
             locale: locale as SupportedLocale,
-            filters: { category },
+            filters: { category, openNow },
             options: { limit: 50, offset: 0 },
+            location: userLocation,
           })
 
           // Map to SearchResult structure
@@ -122,17 +124,29 @@ export function useServices({
         }
 
         // Analytics
-        fetch("/api/v1/analytics/search", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            category,
-            hasLocation: !!userLocation,
-            resultCount: scopedResults.length,
-          }),
-        }).catch((err) =>
-          logger.error("Analytics tracking failed", err, { component: "useServices", action: "analytics" })
-        )
+        const analyticsSignature = JSON.stringify({
+          query: query.trim(),
+          category: category ?? null,
+          hasLocation: !!userLocation,
+          openNow: !!openNow,
+          resultCount: scopedResults.length,
+          locale,
+        })
+
+        if (lastAnalyticsSignature.current !== analyticsSignature) {
+          lastAnalyticsSignature.current = analyticsSignature
+
+          fetch("/api/v1/analytics/search", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              locale,
+              resultCount: scopedResults.length,
+            }),
+          }).catch((err) =>
+            logger.error("Analytics tracking failed", err, { component: "useServices", action: "analytics" })
+          )
+        }
       } catch (err) {
         logger.error("Search failed", err, { component: "useServices", action: "performSearch" })
         setIsLoading(false)

--- a/lib/analytics/search-analytics.ts
+++ b/lib/analytics/search-analytics.ts
@@ -3,9 +3,8 @@ import { logger } from "@/lib/logger"
 import { withCircuitBreaker } from "@/lib/resilience/supabase-breaker"
 
 export interface SearchEvent {
-  category: string | null
+  locale: string
   resultCount: number
-  hasLocation: boolean
 }
 
 /**
@@ -29,6 +28,7 @@ export async function trackSearchEvent(event: SearchEvent) {
       supabase.from("search_analytics").insert({
         query: null,
         results_count: event.resultCount,
+        locale: event.locale,
       })
     )
 

--- a/lib/auth/authorization.ts
+++ b/lib/auth/authorization.ts
@@ -1,5 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js"
 import { AuthorizationError, NotFoundError } from "@/lib/api-utils"
+import { normalizeProvenance } from "@/lib/provenance"
 import { OrganizationRole, RolePermissions, hasPermission } from "@/lib/rbac"
 import { withCircuitBreaker } from "@/lib/resilience/supabase-breaker"
 import { CircuitOpenError } from "@/lib/resilience/circuit-breaker"
@@ -40,10 +41,10 @@ export async function assertServiceOwnership(
 ) {
   try {
     return await withCircuitBreaker(async () => {
-      // 1. Get the service's organization ID
+      // Fetch the full row so editor access can verify compatible ownership signals.
       const { data: service, error: serviceError } = await supabase
         .from("services")
-        .select("org_id")
+        .select("*")
         .eq("id", serviceId)
         .single()
 
@@ -73,6 +74,21 @@ export async function assertServiceOwnership(
       // 3. Check role
       if (!allowedRoles.includes(member.role)) {
         throw new AuthorizationError(`Access denied: Requires ${allowedRoles.join(" or ")} role`)
+      }
+
+      const role = member.role as OrganizationRole
+
+      if (role === "editor") {
+        const serviceRecord = service as Record<string, unknown> & { provenance?: unknown }
+        const createdBy = typeof serviceRecord.created_by === "string" ? serviceRecord.created_by : null
+        const provenance = normalizeProvenance(serviceRecord.provenance)
+        const isCompatOwnedByEditor =
+          createdBy === userId ||
+          (createdBy === null && provenance.method === "partner_submission" && provenance.verified_by === userId)
+
+        if (!isCompatOwnedByEditor) {
+          throw new AuthorizationError("Editors can only modify services they created")
+        }
       }
 
       return true

--- a/lib/offline/sync.ts
+++ b/lib/offline/sync.ts
@@ -1,7 +1,7 @@
 import { saveAllServices, saveAllEmbeddings, getMeta, setMeta, getAllServices } from "./db"
 import { logger } from "@/lib/logger"
 import { Service } from "@/types/service"
-import { isSupabaseAvailable, getSupabaseBreakerStats } from "@/lib/resilience/supabase-breaker"
+import { resetServiceDataCache } from "@/lib/search/data"
 
 interface SyncResult {
   status: "synced" | "up-to-date" | "error"
@@ -18,17 +18,8 @@ export async function syncOfflineData(force = false, retryCount = 0): Promise<Sy
   if (typeof window === "undefined") return { status: "error", error: "Server-side sync not supported" }
 
   try {
-    // Check circuit breaker state before attempting sync
-    if (!isSupabaseAvailable()) {
-      const stats = getSupabaseBreakerStats()
-      logger.warn("Sync skipped: Circuit breaker is open", { stats })
-      return {
-        status: "error",
-        error: `Circuit breaker open. Next attempt at ${new Date(stats.nextAttemptTime || 0).toISOString()}`,
-      }
-    }
-
     const lastSync = await getMeta<string>("lastSync")
+    const lastVersion = await getMeta<string>("version")
     const now = Date.now()
 
     // 1. Skip if recent (unless forced)
@@ -41,12 +32,13 @@ export async function syncOfflineData(force = false, retryCount = 0): Promise<Sy
 
     logger.info("Starting offline data sync")
 
-    // 2. Delta Sync check using ETag from last version/date
-    const dailyTag = `"${new Date().toISOString().split("T")[0]}"`
+    // 2. Delta Sync check using the last known export fingerprint
     const response = await fetch("/api/v1/services/export", {
-      headers: {
-        "If-None-Match": dailyTag, // Use a date tag as defined in the API
-      },
+      headers: lastVersion
+        ? {
+            "If-None-Match": `"${lastVersion}"`,
+          }
+        : undefined,
     })
 
     if (response.status === 304) {
@@ -68,6 +60,7 @@ export async function syncOfflineData(force = false, retryCount = 0): Promise<Sy
 
     await saveAllServices(data.services)
     await saveAllEmbeddings(data.embeddings)
+    resetServiceDataCache()
 
     const timestamp = new Date().toISOString()
     await setMeta("lastSync", timestamp)

--- a/lib/schemas/search.ts
+++ b/lib/schemas/search.ts
@@ -9,7 +9,7 @@ export const searchRequestSchema = z.object({
   filters: z
     .object({
       category: z.string().optional(),
-      // Future: verificationLevels, openNow, etc.
+      openNow: z.boolean().optional(),
     })
     .optional()
     .default({}),

--- a/lib/schemas/service-partner-edit.ts
+++ b/lib/schemas/service-partner-edit.ts
@@ -1,0 +1,87 @@
+import { z } from "zod"
+import type { ServiceUpdate } from "@/lib/service-db"
+
+export const PARTNER_SERVICE_EDIT_FIELDS = [
+  "name",
+  "name_fr",
+  "description",
+  "description_fr",
+  "phone",
+  "url",
+  "address",
+  "hours_text",
+  "operating_hours",
+  "eligibility_notes",
+  "eligibility_notes_fr",
+  "access_script",
+  "access_script_fr",
+] as const
+
+export const DIRECT_SERVICE_WRITE_UNSUPPORTED_FIELDS = ["access_script", "access_script_fr"] as const
+
+const nonEmptyString = (max: number) => z.string().trim().min(1).max(max)
+const nullableString = (max: number) => nonEmptyString(max).nullable().optional()
+
+export const PartnerServiceEditFieldKeySchema = z.enum(PARTNER_SERVICE_EDIT_FIELDS)
+
+export const PartnerServiceEditSchema = z
+  .object({
+    name: nonEmptyString(200).optional(),
+    name_fr: nullableString(200),
+    description: nonEmptyString(2000).optional(),
+    description_fr: nullableString(2000),
+    phone: z
+      .string()
+      .trim()
+      .regex(/^[\d\s\-\(\)\+]+$/, "Invalid phone format")
+      .nullable()
+      .optional(),
+    url: z.string().trim().url("Invalid URL").nullable().optional(),
+    address: nullableString(500),
+    hours_text: nullableString(200),
+    operating_hours: nullableString(200),
+    eligibility_notes: nullableString(500),
+    eligibility_notes_fr: nullableString(500),
+    access_script: nullableString(2000),
+    access_script_fr: nullableString(2000),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one field update is required",
+  })
+
+export type PartnerServiceEditInput = z.infer<typeof PartnerServiceEditSchema>
+export type PartnerServiceEditFieldKey = z.infer<typeof PartnerServiceEditFieldKeySchema>
+
+export function normalizePartnerServiceEditInput(input: PartnerServiceEditInput): PartnerServiceEditInput {
+  if (input.hours_text !== undefined || input.operating_hours === undefined) {
+    return input
+  }
+
+  return {
+    ...input,
+    hours_text: input.operating_hours,
+  }
+}
+
+export function getDirectServiceWriteUnsupportedFields(input: PartnerServiceEditInput): string[] {
+  return DIRECT_SERVICE_WRITE_UNSUPPORTED_FIELDS.filter((field) => input[field] !== undefined)
+}
+
+export function mapPartnerServiceEditToServiceUpdate(input: PartnerServiceEditInput): ServiceUpdate {
+  const normalized = normalizePartnerServiceEditInput(input)
+  const updates: ServiceUpdate = {}
+
+  if (normalized.name !== undefined) updates.name = normalized.name
+  if (normalized.name_fr !== undefined) updates.name_fr = normalized.name_fr
+  if (normalized.description !== undefined) updates.description = normalized.description
+  if (normalized.description_fr !== undefined) updates.description_fr = normalized.description_fr
+  if (normalized.phone !== undefined) updates.phone = normalized.phone
+  if (normalized.url !== undefined) updates.url = normalized.url
+  if (normalized.address !== undefined) updates.address = normalized.address
+  if (normalized.hours_text !== undefined) updates.hours_text = normalized.hours_text
+  if (normalized.eligibility_notes !== undefined) updates.eligibility = normalized.eligibility_notes
+  if (normalized.eligibility_notes_fr !== undefined) updates.eligibility_fr = normalized.eligibility_notes_fr
+
+  return updates
+}

--- a/lib/search/data.ts
+++ b/lib/search/data.ts
@@ -9,6 +9,10 @@ import { mapServiceRowToService } from "@/lib/service-db"
 // In-memory cache for the server instance
 let dataCache: { services: Service[] } | null = null
 
+export function resetServiceDataCache() {
+  dataCache = null
+}
+
 /**
  * Loads services from Supabase (if configured) or falls back to local JSON.
  * Uses dynamic imports to avoid bundling large JSON files when running in server mode.

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -64,9 +64,9 @@ export const searchServices = async (query: string, options: SearchOptions = {})
         (service) => service.verification_level !== VerificationLevel.L0 && !isBeyondGovernanceFreshnessWindow(service)
       )
 
-      // Special Case: Empty Query but Category/Location selected
+      // Special Case: Empty Query but filters are active
       if (query.trim().length === 0) {
-        if (options.category || options.location) {
+        if (options.category || options.location || options.openNow) {
           // Return everything matching filter
           let results = filteredServices.map((service) => ({
             service,

--- a/lib/share-target.ts
+++ b/lib/share-target.ts
@@ -1,0 +1,65 @@
+import { z } from "zod"
+
+export const SHARE_TARGET_QUERY_COOKIE_NAME = "careconnect_share_query"
+export const SHARE_TARGET_QUERY_COOKIE_MAX_AGE_SECONDS = 60
+
+export const ShareTargetPayloadSchema = z.object({
+  query: z.string().trim().min(1).max(500),
+})
+
+export type ShareTargetPayload = z.infer<typeof ShareTargetPayloadSchema>
+
+function normalizeShareTargetCandidate(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+export function selectShareTargetQuery(input: { text?: unknown; title?: unknown; url?: unknown }): string {
+  return (
+    normalizeShareTargetCandidate(input.text) ||
+    normalizeShareTargetCandidate(input.title) ||
+    normalizeShareTargetCandidate(input.url) ||
+    ""
+  )
+}
+
+export function serializeShareTargetPayload(payload: ShareTargetPayload): string {
+  return encodeURIComponent(JSON.stringify(payload))
+}
+
+export function parseShareTargetPayload(rawValue: string | null): ShareTargetPayload | null {
+  if (!rawValue) {
+    return null
+  }
+
+  try {
+    const decoded = decodeURIComponent(rawValue)
+    const parsed = JSON.parse(decoded) as unknown
+    const validation = ShareTargetPayloadSchema.safeParse(parsed)
+    return validation.success ? validation.data : null
+  } catch {
+    return null
+  }
+}
+
+export function getCookieValue(cookieHeader: string, name: string): string | null {
+  const cookies = cookieHeader.split(";")
+
+  for (const cookie of cookies) {
+    const [cookieName, ...valueParts] = cookie.trim().split("=")
+    if (cookieName === name) {
+      return valueParts.join("=")
+    }
+  }
+
+  return null
+}
+
+export function consumeShareTargetQueryFromDocument(doc: Document = document): string | null {
+  const rawValue = getCookieValue(doc.cookie, SHARE_TARGET_QUERY_COOKIE_NAME)
+  const payload = parseShareTargetPayload(rawValue)
+
+  const secureAttribute = doc.defaultView?.location.protocol === "https:" ? "; Secure" : ""
+  doc.cookie = `${SHARE_TARGET_QUERY_COOKIE_NAME}=; Max-Age=0; Path=/; SameSite=Lax${secureAttribute}`
+
+  return payload?.query ?? null
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,7 @@ import createMiddleware from "next-intl/middleware"
 import { routing } from "./i18n/routing"
 import { createServerClient, type CookieOptions } from "@supabase/ssr"
 import { env } from "@/lib/env"
+import { logger } from "@/lib/logger"
 
 // Initialize Internationalization Middleware
 const intlMiddleware = createMiddleware(routing)
@@ -53,15 +54,19 @@ export async function middleware(request: NextRequest) {
   // Refresh session if needed
   let user = null
   try {
-    // Skip auth check if using placeholder (CI/Test)
-    if (env.NEXT_PUBLIC_SUPABASE_URL?.includes("placeholder")) {
-      console.log("Skipping Supabase auth in middleware (Testing Mode)")
+    if (env.NODE_ENV === "test") {
+      logger.info("Skipping Supabase auth refresh in middleware during tests", {
+        component: "middleware",
+      })
     } else {
       const { data } = await supabase.auth.getUser()
       user = data.user
     }
   } catch (error) {
-    console.warn("Middleware Auth Error (Non-blocking):", error)
+    logger.warn("Middleware auth refresh failed", {
+      component: "middleware",
+      error: error instanceof Error ? error.message : String(error),
+    })
   }
 
   // 2. Internationalization (Run after auth check)

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "next-intl": "4.7.0",
         "next-themes": "^0.4.6",
         "papaparse": "5.5.3",
+        "qrcode": "1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "7.71.1",
@@ -242,7 +243,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1791,7 +1791,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.0.2.tgz",
       "integrity": "sha512-EXZfxkL6GFJS2cb7TIBR7RiHA5iz6ufDcl1VmUpI2pga3lJ5Ck2+iqbx7N+osL3XYem9ad4XCidJEMm64DX6UQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -2176,7 +2175,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2200,7 +2198,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4837,7 +4834,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -7116,7 +7112,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.90.1.tgz",
       "integrity": "sha512-U8KaKGLUgTIFHtwEW1dgw1gK7XrdpvvYo7nzzqPx721GqPe8WZbAiLh/hmyKLGBYQ/mmQNr20vU9tWSDZpii3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.90.1",
         "@supabase/functions-js": "2.90.1",
@@ -7358,7 +7353,6 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
       "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -7879,7 +7873,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -7951,6 +7944,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -7961,6 +7955,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -8049,7 +8044,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
       "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -8075,14 +8069,14 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8093,7 +8087,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8196,7 +8189,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8712,7 +8704,6 @@
       "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.2.tgz",
       "integrity": "sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
@@ -8878,7 +8869,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -8915,6 +8905,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -8924,25 +8915,29 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -8953,13 +8948,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -8972,6 +8969,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -8981,6 +8979,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -8989,13 +8988,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -9012,6 +9013,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -9025,6 +9027,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -9037,6 +9040,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -9051,6 +9055,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -9083,20 +9088,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9109,6 +9115,7 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -9153,7 +9160,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9170,6 +9176,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -9187,6 +9194,7 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -9840,7 +9848,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9964,6 +9971,14 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
       }
@@ -10103,6 +10118,7 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -10467,7 +10483,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -10694,6 +10709,14 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -10875,6 +10898,11 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -11333,7 +11361,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11523,7 +11550,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11823,6 +11849,7 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -12279,7 +12306,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -12450,7 +12476,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -13677,6 +13704,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -13691,6 +13719,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13736,7 +13765,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -14372,6 +14400,7 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -14895,7 +14924,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -15366,6 +15396,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15375,6 +15406,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -15597,14 +15629,14 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/next": {
       "version": "15.5.14",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
       "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.14",
         "@swc/helpers": "0.5.15",
@@ -16142,6 +16174,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -16228,7 +16268,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16365,7 +16404,6 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -16385,6 +16423,14 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/po-parser": {
@@ -16422,7 +16468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16533,7 +16578,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16777,6 +16821,131 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -16832,7 +17001,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16842,7 +17010,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16855,7 +17022,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -17170,7 +17336,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17184,6 +17349,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -17296,7 +17466,6 @@
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -17495,6 +17664,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -17529,6 +17699,11 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -18488,6 +18663,7 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
       "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -18685,7 +18861,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19045,7 +19220,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19449,7 +19623,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -19601,7 +19774,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19615,7 +19787,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -19721,6 +19892,7 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -19764,6 +19936,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -19883,6 +20056,7 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -19891,13 +20065,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -19911,6 +20087,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -20044,6 +20221,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
@@ -20281,7 +20463,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -20585,7 +20766,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -20930,7 +21110,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "next-intl": "4.7.0",
     "next-themes": "^0.4.6",
     "papaparse": "5.5.3",
+    "qrcode": "1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "7.71.1",

--- a/tests/api/v1/analytics-search.test.ts
+++ b/tests/api/v1/analytics-search.test.ts
@@ -1,6 +1,7 @@
 import "../../setup/next-mocks"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { POST } from "@/app/api/v1/analytics/search/route"
+import { trackSearchEvent } from "@/lib/analytics/search-analytics"
 
 vi.mock("@/lib/analytics/search-analytics", () => ({
   trackSearchEvent: vi.fn().mockResolvedValue(undefined),
@@ -16,13 +17,14 @@ describe("POST /api/v1/analytics/search", () => {
       new Request("http://localhost/api/v1/analytics/search", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ category: "Food", resultCount: 3, hasLocation: false }),
+        body: JSON.stringify({ locale: "en", resultCount: 3 }),
       })
     )
 
     expect(response.status).toBe(200)
     expect(response.headers.get("Cache-Control")).toBe("no-store")
     expect(response.headers.get("X-Robots-Tag")).toBe("noindex")
+    expect(trackSearchEvent).toHaveBeenCalledWith({ locale: "en", resultCount: 3 })
   })
 
   it("rejects non-json content types", async () => {

--- a/tests/api/v1/health-admin.test.ts
+++ b/tests/api/v1/health-admin.test.ts
@@ -1,0 +1,147 @@
+/** @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+
+const {
+  mockAuthGetUser,
+  mockIsUserAdmin,
+  mockRateLimit,
+  mockSupabaseSelect,
+  mockRecordUptimeEvent,
+  mockGetSLOComplianceSummary,
+} = vi.hoisted(() => ({
+  mockAuthGetUser: vi.fn(),
+  mockIsUserAdmin: vi.fn(),
+  mockRateLimit: vi.fn(),
+  mockSupabaseSelect: vi.fn(),
+  mockRecordUptimeEvent: vi.fn(),
+  mockGetSLOComplianceSummary: vi.fn(() => ({
+    uptime: { compliant: true, actual: 1, target: 0.995, totalChecks: 25, successfulChecks: 25 },
+    errorBudget: { exhausted: false, consumed: 0, remaining: 1, warningThreshold: 0.5 },
+    latency: { hasData: false, compliant: true, actualP95: null, target: 800 },
+  })),
+}))
+
+vi.mock("@/lib/resilience/supabase-breaker", () => ({
+  getSupabaseBreakerStats: () => ({
+    enabled: true,
+    state: "CLOSED",
+    failures: 0,
+    successes: 0,
+    requests: 0,
+    halfOpenRequests: 0,
+    totalFailures: 0,
+    totalSuccesses: 0,
+    lastFailureTime: null,
+    lastSuccessTime: null,
+  }),
+}))
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabaseClient: () => ({
+    from: () => ({
+      select: () => ({
+        limit: mockSupabaseSelect,
+      }),
+    }),
+  }),
+  hasSupabaseCredentials: () => true,
+  SupabaseNotConfiguredError: class SupabaseNotConfiguredError extends Error {},
+}))
+
+vi.mock("@/lib/performance/metrics", () => ({
+  getMetrics: () => ({}),
+}))
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    NODE_ENV: "production",
+    NEXT_PUBLIC_ENABLE_SEARCH_PERF_TRACKING: false,
+    NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
+    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "test-key",
+  },
+}))
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: mockRateLimit,
+  getClientIp: () => "127.0.0.1",
+}))
+
+vi.mock("@/lib/observability/slo-tracker", () => ({
+  recordUptimeEvent: mockRecordUptimeEvent,
+  getSLOComplianceSummary: mockGetSLOComplianceSummary,
+}))
+
+vi.mock("@/lib/integrations/slack", () => ({
+  sendSLOViolationAlert: vi.fn(),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/auth/authorization", () => ({
+  isUserAdmin: mockIsUserAdmin,
+}))
+
+vi.mock("@/lib/config/slo-targets", () => ({
+  MIN_SLO_ALERT_SAMPLES: 5,
+}))
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: {
+      getUser: mockAuthGetUser,
+    },
+  }),
+}))
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: () => [],
+  }),
+}))
+
+import { GET } from "@/app/api/v1/health/route"
+
+describe("GET /api/v1/health production detail access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRateLimit.mockResolvedValue({
+      success: true,
+      reset: Math.floor(Date.now() / 1000) + 60,
+    })
+    mockSupabaseSelect.mockResolvedValue({ error: null })
+    mockAuthGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+      error: null,
+    })
+    mockIsUserAdmin.mockResolvedValue(false)
+  })
+
+  it("returns only the basic payload for non-admins in production", async () => {
+    const response = await GET({} as NextRequest)
+    const json = (await response.json()) as Record<string, unknown>
+
+    expect(response.status).toBe(200)
+    expect(json).toMatchObject({
+      status: "healthy",
+    })
+    expect(json).not.toHaveProperty("checks")
+  })
+
+  it("returns detailed checks for admins in production", async () => {
+    mockIsUserAdmin.mockResolvedValue(true)
+
+    const response = await GET({} as NextRequest)
+    const json = (await response.json()) as { checks?: Record<string, unknown> }
+
+    expect(response.status).toBe(200)
+    expect(json.checks).toBeDefined()
+    expect(json.checks).toHaveProperty("database")
+    expect(json.checks).toHaveProperty("circuitBreaker")
+    expect(json.checks).toHaveProperty("slo")
+  })
+})

--- a/tests/api/v1/services-id.test.ts
+++ b/tests/api/v1/services-id.test.ts
@@ -1,14 +1,9 @@
 import "../../setup/next-mocks"
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { GET, PUT } from "@/app/api/v1/services/[id]/route"
+import { DELETE, GET, PATCH, PUT } from "@/app/api/v1/services/[id]/route"
 import { createMockRequest } from "@/tests/utils/api-test-utils"
 import { createServerClient } from "@supabase/ssr"
 import { supabase } from "@/lib/supabase"
-
-// --- Mock Setup for Chaining Supabase Calls ---
-const { mockUnsafeFrom } = vi.hoisted(() => ({
-  mockUnsafeFrom: vi.fn(),
-}))
 
 const createChainMock = () => ({
   select: vi.fn().mockReturnThis(),
@@ -21,20 +16,15 @@ const createChainMock = () => ({
 
 const publicChain = createChainMock()
 
-// Mock 'lib/supabase' (Public Client)
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     from: vi.fn(),
   },
-  unsafeFrom: mockUnsafeFrom,
 }))
 
 const mockGetUser = vi.fn()
-
-// Persistent chains for the SSR client to handle multiple .from() calls
 const tableChains: Record<string, any> = {}
 
-// Standard SSR mocking via next-mocks
 vi.mocked(createServerClient).mockReturnValue({
   auth: {
     getUser: mockGetUser,
@@ -47,23 +37,50 @@ vi.mocked(createServerClient).mockReturnValue({
   },
 } as any)
 
+function mockServiceAuthorization(options: {
+  role: "owner" | "admin" | "editor" | "viewer"
+  service?: Record<string, unknown>
+  updatedRow?: Record<string, unknown>
+}) {
+  const servicesChain = createChainMock()
+  const membersChain = createChainMock()
+
+  tableChains["services"] = servicesChain
+  tableChains["organization_members"] = membersChain
+
+  servicesChain.single.mockResolvedValueOnce({
+    data: {
+      id: "123",
+      org_id: "org-1",
+      provenance: { verified_by: "user-1", method: "partner_submission" },
+      ...options.service,
+    },
+    error: null,
+  })
+
+  if (options.updatedRow) {
+    servicesChain.single.mockResolvedValueOnce({
+      data: options.updatedRow,
+      error: null,
+    })
+  }
+
+  membersChain.single.mockResolvedValue({
+    data: { role: options.role },
+    error: null,
+  })
+
+  return { servicesChain, membersChain }
+}
+
 describe("API v1 Services [id]", () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // Clear the persistent table chains
     for (const key in tableChains) delete tableChains[key]
 
-    // Link public client mock (used in GET)
     vi.mocked(supabase.from).mockReturnValue(publicChain as any)
-    mockUnsafeFrom.mockImplementation((_client: unknown, table: string) => {
-      if (!tableChains[table]) {
-        tableChains[table] = createChainMock()
-      }
-      return tableChains[table]
-    })
     publicChain.single.mockResolvedValue({ data: { id: "123", name: "Test Service" }, error: null })
-
     mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null })
   })
 
@@ -107,39 +124,57 @@ describe("API v1 Services [id]", () => {
       expect(res.status).toBe(401)
     })
 
-    it("updates service and returns 200", async () => {
-      // 1. services table: first call for ownership, second for update
-      const servicesChain = createChainMock()
-      tableChains["services"] = servicesChain
-      servicesChain.single.mockResolvedValueOnce({ data: { org_id: "org-1" }, error: null }) // Ownership
-      servicesChain.single.mockResolvedValueOnce({ data: { id: "123", name: "Updated" }, error: null }) // Update
-
-      // 2. organization_members table: check membership
-      const membersChain = createChainMock()
-      tableChains["organization_members"] = membersChain
-      membersChain.single.mockResolvedValue({ data: { role: "admin" }, error: null })
+    it("allows admins to update any service in their organization", async () => {
+      const { servicesChain } = mockServiceAuthorization({
+        role: "admin",
+        updatedRow: { id: "123", name: "Updated" },
+      })
 
       const req = createMockRequest("http://localhost/api/v1/services/123", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "Updated" }),
+        body: JSON.stringify({
+          name: "Updated",
+          eligibility_notes: "Must be 18+",
+          operating_hours: "Mon-Fri 9-5",
+        }),
       })
       const res = await PUT(req, { params: Promise.resolve({ id: "123" }) })
 
       expect(res.status).toBe(200)
-      const body = (await res.json()) as { data: any }
-      expect(body.data.name).toBe("Updated")
+      expect(servicesChain.update).toHaveBeenCalledWith({
+        name: "Updated",
+        eligibility: "Must be 18+",
+        hours_text: "Mon-Fri 9-5",
+      })
     })
 
-    it("returns 500 if database update fails", async () => {
-      const servicesChain = createChainMock()
-      tableChains["services"] = servicesChain
-      servicesChain.single.mockResolvedValueOnce({ data: { org_id: "org-1" }, error: null }) // Ownership
-      servicesChain.single.mockResolvedValueOnce({ data: null, error: { message: "DB Error" } }) // Update fails
+    it("allows editors to update only their own partner-submitted services", async () => {
+      mockServiceAuthorization({
+        role: "editor",
+        service: {
+          provenance: { verified_by: "user-1", method: "partner_submission" },
+        },
+        updatedRow: { id: "123", name: "Updated by editor" },
+      })
 
-      const membersChain = createChainMock()
-      tableChains["organization_members"] = membersChain
-      membersChain.single.mockResolvedValue({ data: { role: "admin" }, error: null })
+      const req = createMockRequest("http://localhost/api/v1/services/123", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Updated by editor" }),
+      })
+      const res = await PUT(req, { params: Promise.resolve({ id: "123" }) })
+
+      expect(res.status).toBe(200)
+    })
+
+    it("denies editors when the service is not owned by them", async () => {
+      mockServiceAuthorization({
+        role: "editor",
+        service: {
+          provenance: { verified_by: "other-user", method: "partner_submission" },
+        },
+      })
 
       const req = createMockRequest("http://localhost/api/v1/services/123", {
         method: "PUT",
@@ -148,7 +183,77 @@ describe("API v1 Services [id]", () => {
       })
       const res = await PUT(req, { params: Promise.resolve({ id: "123" }) })
 
-      expect(res.status).toBe(500)
+      expect(res.status).toBe(403)
+    })
+
+    it("denies viewers from mutating services", async () => {
+      mockServiceAuthorization({ role: "viewer" })
+
+      const req = createMockRequest("http://localhost/api/v1/services/123", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Updated" }),
+      })
+      const res = await PUT(req, { params: Promise.resolve({ id: "123" }) })
+
+      expect(res.status).toBe(403)
+    })
+  })
+
+  describe("PATCH (Protected)", () => {
+    it("rejects unsupported direct-write fields with 400", async () => {
+      mockServiceAuthorization({
+        role: "admin",
+        updatedRow: { id: "123", name: "Updated" },
+      })
+
+      const req = createMockRequest("http://localhost/api/v1/services/123", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ access_script: "Say hello" }),
+      })
+      const res = await PATCH(req, { params: Promise.resolve({ id: "123" }) })
+
+      expect(res.status).toBe(400)
+    })
+
+    it("rejects forbidden or unknown payload keys with 400", async () => {
+      mockServiceAuthorization({
+        role: "admin",
+        updatedRow: { id: "123", name: "Updated" },
+      })
+
+      const req = createMockRequest("http://localhost/api/v1/services/123", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ published: true }),
+      })
+      const res = await PATCH(req, { params: Promise.resolve({ id: "123" }) })
+
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe("DELETE (Protected)", () => {
+    it("allows owners to delete services", async () => {
+      const { servicesChain } = mockServiceAuthorization({
+        role: "owner",
+      })
+      const deleteEq = vi.fn().mockResolvedValue({ error: null })
+      servicesChain.update.mockReturnValue({ eq: deleteEq })
+
+      const req = createMockRequest("http://localhost/api/v1/services/123", {
+        method: "DELETE",
+      })
+      const res = await DELETE(req, { params: Promise.resolve({ id: "123" }) })
+
+      expect(res.status).toBe(200)
+      expect(servicesChain.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deleted_by: "user-1",
+        })
+      )
+      expect(deleteEq).toHaveBeenCalledWith("id", "123")
     })
   })
 })

--- a/tests/api/v1/services-printable.test.ts
+++ b/tests/api/v1/services-printable.test.ts
@@ -42,6 +42,8 @@ describe("API v1 Services [id]/printable", () => {
     expect(res.status).toBe(200)
     const html = await res.text()
     expect(html).toContain("Mon-Fri 9am-5pm")
+    expect(html).not.toContain("api.qrserver.com")
+    expect(html).toContain('src="data:image/png;base64,')
   })
 
   it("formats structured hours when hours_text is missing", async () => {
@@ -71,5 +73,37 @@ describe("API v1 Services [id]/printable", () => {
     const html = await res.text()
     expect(html).toContain("Mon: 09:00 - 17:00")
     expect(html).toContain("Tue: Closed")
+  })
+
+  it("escapes interpolated service fields before rendering HTML", async () => {
+    vi.mocked(getServiceById).mockResolvedValue({
+      id: "svc-3",
+      name: `<script>alert("xss")</script>`,
+      address: `123 <b>Main</b> St`,
+      phone: `613-555-1234 & ext 9`,
+      eligibility_notes: `Need <em>ID</em>`,
+      url: "https://example.com",
+      description: "Desc",
+      provenance: {
+        verified_by: "test",
+        verified_at: new Date().toISOString(),
+        evidence_url: "https://example.com",
+        method: "test",
+      },
+      verification_level: "L1",
+      intent_category: "Community",
+      identity_tags: [],
+      synthetic_queries: [],
+    } as any)
+
+    const req = createMockRequest("http://localhost/api/v1/services/svc-3/printable")
+    const res = await GET(req as any, { params: Promise.resolve({ id: "svc-3" }) })
+    const html = await res.text()
+
+    expect(html).not.toContain('<script>alert("xss")</script>')
+    expect(html).toContain("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;")
+    expect(html).toContain("123 &lt;b&gt;Main&lt;/b&gt; St")
+    expect(html).toContain("613-555-1234 &amp; ext 9")
+    expect(html).toContain("Need &lt;em&gt;ID&lt;/em&gt;")
   })
 })

--- a/tests/api/v1/services/export.test.ts
+++ b/tests/api/v1/services/export.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from "vitest"
 import { GET } from "@/app/api/v1/services/export/route"
 import { checkRateLimit } from "@/lib/rate-limit"
+import { loadServices } from "@/lib/search/data"
 
 vi.mock("@/lib/search/data", () => ({
   loadServices: vi.fn().mockResolvedValue([
@@ -56,7 +57,7 @@ describe("Export API", () => {
     }
 
     expect(response.status).toBe(200)
-    const data = (await response.json()) as { count: number; services: any[] }
+    const data = (await response.json()) as { count: number; services: any[]; version: string }
     expect(data.count).toBe(1)
     expect(data.services[0].id).toBe("s1")
     expect(data.services[0].provenance).toEqual({
@@ -67,19 +68,61 @@ describe("Export API", () => {
     })
     expect(response.headers.get("Cache-Control")).toContain("public")
     expect(response.headers.get("ETag")).toBeDefined()
+    expect(data.version).toBe(response.headers.get("ETag")?.replaceAll('"', ""))
   })
 
-  it("should return 304 if ETag matches", async () => {
+  it("should return a stable fingerprint for identical payloads", async () => {
     vi.mocked(checkRateLimit).mockResolvedValue({ success: true, remaining: 59, reset: 4102444800 })
 
-    const dailyTag = `"${new Date().toISOString().split("T")[0]}"`
+    const firstResponse = await GET(new Request("http://localhost:3000/api/v1/services/export"))
+    const firstBody = (await firstResponse.json()) as { version: string }
+
+    const secondResponse = await GET(new Request("http://localhost:3000/api/v1/services/export"))
+    const secondBody = (await secondResponse.json()) as { version: string }
+
+    expect(firstBody.version).toBe(secondBody.version)
+    expect(firstResponse.headers.get("ETag")).toBe(secondResponse.headers.get("ETag"))
+  })
+
+  it("should return 304 if ETag matches the current export fingerprint", async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: true, remaining: 59, reset: 4102444800 })
+
+    const initialResponse = await GET(new Request("http://localhost:3000/api/v1/services/export"))
+    const etag = initialResponse.headers.get("ETag")
+
     const request = new Request("http://localhost:3000/api/v1/services/export", {
       headers: {
-        "If-None-Match": dailyTag,
+        "If-None-Match": etag || "",
       },
     })
 
     const response = await GET(request)
     expect(response.status).toBe(304)
+  })
+
+  it("should change the fingerprint when the export payload changes", async () => {
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: true, remaining: 59, reset: 4102444800 })
+
+    const initialResponse = await GET(new Request("http://localhost:3000/api/v1/services/export"))
+    const initialBody = (await initialResponse.json()) as { version: string }
+
+    vi.mocked(loadServices).mockResolvedValueOnce([
+      {
+        id: "s1",
+        name: "Service 1 Updated",
+        description: "Description",
+        embedding: [0.1],
+        published: true,
+        verification_level: "L2",
+        intent_category: "Food",
+        last_verified: "2026-03-01T00:00:00.000Z",
+        provenance: null,
+      },
+    ] as any)
+
+    const nextResponse = await GET(new Request("http://localhost:3000/api/v1/services/export"))
+    const nextBody = (await nextResponse.json()) as { version: string }
+
+    expect(nextBody.version).not.toBe(initialBody.version)
   })
 })

--- a/tests/api/v1/services/update-request.test.ts
+++ b/tests/api/v1/services/update-request.test.ts
@@ -191,6 +191,32 @@ describe("POST /api/v1/services/[id]/update-request", () => {
     })
   })
 
+  it("normalizes the operating_hours alias to hours_text before storing the request", async () => {
+    const req = createMockRequest("http://localhost/api/v1/services/svc-123/update-request", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        field_updates: {
+          operating_hours: "Mon-Fri 9-5",
+        },
+      }),
+    })
+
+    const res = await POST(req, { params: Promise.resolve({ id: "svc-123" }) })
+    const json = (await res.json()) as any
+
+    expect(res.status).toBe(200)
+    expect(json.data.success).toBe(true)
+    expect(tableChains["service_update_requests"]?.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field_updates: {
+          operating_hours: "Mon-Fri 9-5",
+          hours_text: "Mon-Fri 9-5",
+        },
+      })
+    )
+  })
+
   it("accepts update request without justification (optional field)", async () => {
     const req = createMockRequest("http://localhost/api/v1/services/svc-123/update-request", {
       method: "POST",
@@ -252,18 +278,13 @@ describe("POST /api/v1/services/[id]/update-request", () => {
         description: "New Description",
         description_fr: "Nouvelle Description",
         phone: "613-555-1234",
-        email: "new@example.com",
         url: "https://new.example.com",
         address: "123 New St",
-        hours: { monday: { open: "09:00", close: "17:00" } },
         hours_text: "Mon-Fri 9-5",
-        hours_text_fr: "Lun-Ven 9-17",
         eligibility_notes: "New eligibility",
         eligibility_notes_fr: "Nouvelle éligibilité",
         access_script: "New access",
         access_script_fr: "Nouvel accès",
-        coordinates: { lat: 44.2312, lng: -76.486 },
-        status: "active",
       },
     }
 
@@ -296,12 +317,12 @@ describe("POST /api/v1/services/[id]/update-request", () => {
     expect(json.error.message).toBe("Invalid update data")
   })
 
-  it("returns 400 for invalid email format", async () => {
+  it("returns 400 when a no-longer-supported field is submitted", async () => {
     const req = createMockRequest("http://localhost/api/v1/services/svc-123/update-request", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        field_updates: { email: "not-an-email" },
+        field_updates: { email: "new@example.com" },
       }),
     })
 

--- a/tests/api/v1/share.test.ts
+++ b/tests/api/v1/share.test.ts
@@ -1,9 +1,10 @@
 import "../../setup/next-mocks"
 import { describe, it, expect } from "vitest"
 import { POST } from "@/app/api/v1/share/route"
+import { SHARE_TARGET_QUERY_COOKIE_NAME } from "@/lib/share-target"
 
 describe("Share Target V1 API Route", () => {
-  it("redirects to home with shared text as query", async () => {
+  it("redirects to home and stores the shared query in a short-lived cookie", async () => {
     const formData = new FormData()
     formData.set("text", "food bank")
 
@@ -14,7 +15,11 @@ describe("Share Target V1 API Route", () => {
 
     const response = await POST(request)
     expect(response.status).toBe(303)
-    expect(response.headers.get("location")).toBe("http://localhost/?q=food%20bank")
+    expect(response.headers.get("location")).toBe("http://localhost/")
+    expect(response.headers.get("Cache-Control")).toBe("no-store")
+    expect(response.headers.get("set-cookie")).toContain(`${SHARE_TARGET_QUERY_COOKIE_NAME}=`)
+    expect(response.headers.get("set-cookie")).toContain("Max-Age=60")
+    expect(response.headers.get("set-cookie")).toContain("SameSite=lax")
   })
 
   it("falls back to title when text is missing", async () => {
@@ -28,7 +33,8 @@ describe("Share Target V1 API Route", () => {
 
     const response = await POST(request)
     expect(response.status).toBe(303)
-    expect(response.headers.get("location")).toBe("http://localhost/?q=Crisis%20resources")
+    expect(response.headers.get("location")).toBe("http://localhost/")
+    expect(response.headers.get("set-cookie")).toContain(`${SHARE_TARGET_QUERY_COOKIE_NAME}=`)
   })
 
   it("redirects to home on invalid form data", async () => {
@@ -41,5 +47,6 @@ describe("Share Target V1 API Route", () => {
     const response = await POST(request)
     expect(response.status).toBe(303)
     expect(response.headers.get("location")).toBe("http://localhost/")
+    expect(response.headers.get("Cache-Control")).toBe("no-store")
   })
 })

--- a/tests/components/ServiceCard.test.tsx
+++ b/tests/components/ServiceCard.test.tsx
@@ -68,7 +68,7 @@ describe("ServiceCard Component", () => {
     expect(screen.getByText(mockService.name)).toBeInTheDocument()
   })
 
-  it("tracks clicks on details button", () => {
+  it("does not track internal detail navigation as a referral click", () => {
     render(
       <TestWrapper>
         <ServiceCard service={mockService} />
@@ -81,7 +81,21 @@ describe("ServiceCard Component", () => {
     const link = links[0]
     if (link) fireEvent.click(link)
 
-    expect(mockTrackEvent).toHaveBeenCalledWith(mockService.id, "click_website")
+    expect(mockTrackEvent).not.toHaveBeenCalled()
+  })
+
+  it("tracks call clicks", () => {
+    render(
+      <TestWrapper>
+        <ServiceCard service={mockService} />
+      </TestWrapper>
+    )
+
+    const phoneLink = screen.getByRole("link", { name: mockService.phone })
+    phoneLink.addEventListener("click", (event) => event.preventDefault())
+    fireEvent.click(phoneLink)
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(mockService.id, "click_call")
   })
 
   it("preserves match reasons in the details link", () => {

--- a/tests/components/services/ServiceDetailAnalytics.test.tsx
+++ b/tests/components/services/ServiceDetailAnalytics.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ServiceDetailTracker } from "@/components/services/ServiceDetailTracker"
+import { TrackedServiceLink } from "@/components/services/TrackedServiceLink"
+
+const mockTrackEvent = vi.fn()
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
+
+describe("service detail analytics helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("emits a detail view event on mount", () => {
+    render(<ServiceDetailTracker serviceId="svc-123" />)
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("svc-123", "view_detail")
+  })
+
+  it("tracks external website clicks from the detail page", () => {
+    render(
+      <TrackedServiceLink
+        href="https://example.com"
+        serviceId="svc-123"
+        eventType="click_website"
+        onClick={(event) => event.preventDefault()}
+      >
+        Visit website
+      </TrackedServiceLink>
+    )
+
+    fireEvent.click(screen.getByRole("link", { name: "Visit website" }))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith("svc-123", "click_website")
+  })
+})

--- a/tests/hooks/useServices.test.ts
+++ b/tests/hooks/useServices.test.ts
@@ -51,6 +51,7 @@ vi.mock("@/lib/search/client-enhancer", () => ({
 }))
 
 import { searchServices } from "@/lib/search"
+import { getSearchMode, serverSearch } from "@/lib/search/search-mode"
 
 // Mock props
 const mockSetResults = vi.fn()
@@ -79,6 +80,8 @@ describe("useServices Hook", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+    vi.mocked(getSearchMode).mockReturnValue("local")
+    vi.mocked(serverSearch).mockResolvedValue([])
     ;(global.fetch as any).mockReset()
     ;(global.fetch as any).mockResolvedValue({
       ok: true,
@@ -133,12 +136,69 @@ describe("useServices Hook", () => {
     const body = requestInit?.body ? JSON.parse(String(requestInit.body)) : null
 
     expect(body).toEqual({
-      category: undefined,
-      hasLocation: false,
+      locale: "en",
       resultCount: 0,
     })
     expect(body).not.toHaveProperty("query")
     expect(body).not.toHaveProperty("mode")
+  })
+
+  it("supports open-now-only searches without short-circuiting", async () => {
+    renderHook(() => useServices({ ...defaultProps, query: "", openNow: true }))
+    await flushSearchEffect()
+
+    expect(searchServices).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({
+        openNow: true,
+      })
+    )
+    expect(mockSetHasSearched).toHaveBeenLastCalledWith(true)
+  })
+
+  it("passes location and open-now filters through to server mode", async () => {
+    vi.mocked(getSearchMode).mockReturnValue("server")
+    vi.mocked(serverSearch).mockResolvedValue([{ id: "server-1" } as any])
+
+    renderHook(() =>
+      useServices({
+        ...defaultProps,
+        query: "housing",
+        category: "Housing",
+        openNow: true,
+        userLocation: { lat: 44.23, lng: -76.49 },
+      })
+    )
+    await flushSearchEffect()
+
+    expect(serverSearch).toHaveBeenCalledWith({
+      query: "housing",
+      locale: "en",
+      filters: { category: "Housing", openNow: true },
+      options: { limit: 50, offset: 0 },
+      location: { lat: 44.23, lng: -76.49 },
+    })
+  })
+
+  it("dedupes identical settled search analytics events", async () => {
+    const { rerender } = renderHook((props: typeof defaultProps & { query: string }) => useServices(props), {
+      initialProps: { ...defaultProps, query: "food" },
+    })
+    await flushSearchEffect()
+
+    const analyticsCallsAfterFirstSearch = vi
+      .mocked(global.fetch)
+      .mock.calls.filter(([url]) => url === "/api/v1/analytics/search").length
+
+    rerender({ ...defaultProps, query: "food" })
+    await flushSearchEffect()
+
+    const analyticsCallsAfterSecondSearch = vi
+      .mocked(global.fetch)
+      .mock.calls.filter(([url]) => url === "/api/v1/analytics/search").length
+
+    expect(analyticsCallsAfterFirstSearch).toBe(1)
+    expect(analyticsCallsAfterSecondSearch).toBe(1)
   })
 
   it("checks for suggestions", async () => {

--- a/tests/integration/circuit-breaker-db.test.ts
+++ b/tests/integration/circuit-breaker-db.test.ts
@@ -5,6 +5,7 @@ import { DatabaseSimulator } from "./utils/db-simulator"
 import { trackEvent } from "@/lib/analytics"
 import { getServiceById } from "@/lib/services"
 import { syncOfflineData } from "@/lib/offline/sync"
+import * as offlineDb from "@/lib/offline/db"
 import { logger } from "@/lib/logger"
 
 // Mock logger to avoid noise
@@ -14,6 +15,14 @@ vi.mock("@/lib/logger", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+}))
+
+vi.mock("@/lib/offline/db", () => ({
+  getMeta: vi.fn(),
+  setMeta: vi.fn(),
+  saveAllServices: vi.fn(),
+  saveAllEmbeddings: vi.fn(),
+  getAllServices: vi.fn(),
 }))
 
 // Set environment variables for circuit breaker configuration
@@ -38,6 +47,11 @@ describe("Circuit Breaker Integration", () => {
     getSupabaseBreakerStats() // This will create the breaker if it doesn't exist
     resetSupabaseBreaker()
     dbSimulator.restore()
+    vi.mocked(offlineDb.getMeta).mockResolvedValue(undefined)
+    vi.mocked(offlineDb.setMeta).mockResolvedValue(undefined)
+    vi.mocked(offlineDb.saveAllServices).mockResolvedValue(undefined)
+    vi.mocked(offlineDb.saveAllEmbeddings).mockResolvedValue(undefined)
+    vi.mocked(offlineDb.getAllServices).mockResolvedValue([])
     // Use fake timers with Date mocking enabled
     vi.useFakeTimers({ shouldAdvanceTime: true })
     vi.setSystemTime(new Date("2024-01-01T00:00:00Z"))
@@ -190,9 +204,16 @@ describe("Circuit Breaker Integration", () => {
     expect(service).toBeNull()
   })
 
-  it("should skip offline sync when circuit is open", async () => {
+  it("should continue offline sync when circuit is open", async () => {
     // Mock window to avoid "Server-side sync not supported" error
     vi.stubGlobal("window", {})
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 304,
+      })
+    )
 
     // Open the circuit
     dbSimulator.simulateFailure(3)
@@ -202,10 +223,9 @@ describe("Circuit Breaker Integration", () => {
       } catch {}
     }
 
-    // Sync should return error status immediately
+    // Sync should still proceed via the export fallback path
     const result = await syncOfflineData()
-    expect(result.status).toBe("error")
-    expect(result.error).toContain("Circuit breaker open")
+    expect(result.status).toBe("up-to-date")
 
     vi.unstubAllGlobals()
   })

--- a/tests/lib/analytics/search-analytics.test.ts
+++ b/tests/lib/analytics/search-analytics.test.ts
@@ -45,12 +45,13 @@ describe("Search Analytics", () => {
   })
 
   it("stores only aggregate counts and never raw query text", async () => {
-    await trackSearchEvent({ category: "Food", resultCount: 10, hasLocation: true })
+    await trackSearchEvent({ locale: "en", resultCount: 10 })
     expect(mockFrom).toHaveBeenCalledWith("search_analytics")
     expect(mockInsert).toHaveBeenCalledWith(
       expect.objectContaining({
         query: null,
         results_count: 10,
+        locale: "en",
       })
     )
   })
@@ -58,7 +59,7 @@ describe("Search Analytics", () => {
   it("handles supabase errors silently", async () => {
     mockInsert.mockResolvedValue({ error: { message: "DB Error" } })
 
-    await trackSearchEvent({ category: "Food", resultCount: 5, hasLocation: true })
+    await trackSearchEvent({ locale: "fr", resultCount: 5 })
 
     expect(mockWarn).toHaveBeenCalled()
   })

--- a/tests/unit/lib/offline/sync.test.ts
+++ b/tests/unit/lib/offline/sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { syncOfflineData } from "@/lib/offline/sync"
 import * as db from "@/lib/offline/db"
+import { resetServiceDataCache } from "@/lib/search/data"
 
 // Mock DB
 vi.mock("@/lib/offline/db", () => ({
@@ -9,6 +10,10 @@ vi.mock("@/lib/offline/db", () => ({
   saveAllServices: vi.fn(),
   saveAllEmbeddings: vi.fn(),
   getAllServices: vi.fn(),
+}))
+
+vi.mock("@/lib/search/data", () => ({
+  resetServiceDataCache: vi.fn(),
 }))
 
 // Mock Fetch
@@ -22,6 +27,11 @@ vi.spyOn(console, "error").mockImplementation(() => {})
 describe("Offline Sync", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(db.getMeta).mockImplementation(async (key: string) => {
+      if (key === "lastSync") return undefined
+      if (key === "version") return undefined
+      return undefined
+    })
   })
 
   it("should skip sync if recent and local data exists", async () => {
@@ -36,7 +46,6 @@ describe("Offline Sync", () => {
   })
 
   it("should perform full sync if no local data exists", async () => {
-    vi.mocked(db.getMeta).mockResolvedValue(undefined)
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -56,10 +65,16 @@ describe("Offline Sync", () => {
     expect(db.saveAllServices).toHaveBeenCalled()
     expect(db.saveAllEmbeddings).toHaveBeenCalled()
     expect(db.setMeta).toHaveBeenCalledWith("lastSync", expect.any(String))
+    expect(db.setMeta).toHaveBeenCalledWith("version", "v1")
+    expect(resetServiceDataCache).toHaveBeenCalled()
   })
 
   it("should handle 304 Not Modified", async () => {
-    vi.mocked(db.getMeta).mockResolvedValue("2026-01-01")
+    vi.mocked(db.getMeta).mockImplementation(async (key: string) => {
+      if (key === "lastSync") return "2026-01-01"
+      if (key === "version") return "fingerprint-123"
+      return undefined
+    })
     mockFetch.mockResolvedValue({
       ok: true,
       status: 304,
@@ -70,11 +85,17 @@ describe("Offline Sync", () => {
     expect(result.status).toBe("up-to-date")
     expect(db.saveAllServices).not.toHaveBeenCalled()
     expect(db.setMeta).toHaveBeenCalledWith("lastSync", expect.any(String))
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/services/export",
+      expect.objectContaining({
+        headers: {
+          "If-None-Match": '"fingerprint-123"',
+        },
+      })
+    )
   })
 
   it("should retry on failure", async () => {
-    vi.mocked(db.getMeta).mockResolvedValue(undefined)
-
     // First two fail, third succeeds
     mockFetch
       .mockRejectedValueOnce(new Error("Network Fail"))
@@ -104,7 +125,6 @@ describe("Offline Sync", () => {
   })
 
   it("should return error status after max retries", async () => {
-    vi.mocked(db.getMeta).mockResolvedValue(undefined)
     mockFetch.mockRejectedValue(new Error("Permanent Failure"))
 
     vi.stubGlobal(

--- a/tests/unit/lib/share-target.test.ts
+++ b/tests/unit/lib/share-target.test.ts
@@ -1,0 +1,32 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it } from "vitest"
+import {
+  consumeShareTargetQueryFromDocument,
+  serializeShareTargetPayload,
+  SHARE_TARGET_QUERY_COOKIE_NAME,
+} from "@/lib/share-target"
+
+describe("share-target cookie helpers", () => {
+  it("hydrates the shared query from the cookie and clears it immediately", () => {
+    let cookieValue = `${SHARE_TARGET_QUERY_COOKIE_NAME}=${serializeShareTargetPayload({ query: "food bank" })}`
+    const writes: string[] = []
+    const mockDocument = {} as Document
+
+    Object.defineProperty(mockDocument, "cookie", {
+      get: () => cookieValue,
+      set: (value: string) => {
+        writes.push(value)
+        cookieValue = value
+      },
+      configurable: true,
+    })
+
+    Object.defineProperty(mockDocument, "defaultView", {
+      value: { location: { protocol: "http:" } },
+      configurable: true,
+    })
+
+    expect(consumeShareTargetQueryFromDocument(mockDocument)).toBe("food bank")
+    expect(writes.at(-1)).toBe(`${SHARE_TARGET_QUERY_COOKIE_NAME}=; Max-Age=0; Path=/; SameSite=Lax`)
+  })
+})

--- a/types/feedback.ts
+++ b/types/feedback.ts
@@ -1,5 +1,9 @@
 import { z } from "zod"
-import { ServiceHoursSchema } from "@/lib/schemas/service"
+import {
+  PARTNER_SERVICE_EDIT_FIELDS,
+  PartnerServiceEditFieldKeySchema,
+  PartnerServiceEditSchema,
+} from "@/lib/schemas/service-partner-edit"
 
 /**
  * Feedback Types
@@ -57,41 +61,19 @@ export interface FeedbackRecord {
   created_at: string
 }
 
-export const SERVICE_UPDATE_FIELDS = [
-  "name",
-  "name_fr",
-  "description",
-  "description_fr",
-  "phone",
-  "email",
-  "url",
-  "address",
-  "hours",
-  "hours_text",
-  "hours_text_fr",
-  "eligibility_notes",
-  "eligibility_notes_fr",
-  "access_script",
-  "access_script_fr",
-  "coordinates",
-  "status",
-] as const
+export const SERVICE_UPDATE_FIELDS = PARTNER_SERVICE_EDIT_FIELDS
 
 export const NULLABLE_SERVICE_UPDATE_FIELDS = [
   "name_fr",
   "description_fr",
   "phone",
-  "email",
+  "url",
   "address",
-  "hours",
   "hours_text",
-  "hours_text_fr",
   "eligibility_notes",
   "eligibility_notes_fr",
   "access_script",
   "access_script_fr",
-  "coordinates",
-  "status",
 ] as const
 
 export const TEXT_SERVICE_UPDATE_FIELDS = [
@@ -100,58 +82,18 @@ export const TEXT_SERVICE_UPDATE_FIELDS = [
   "description",
   "description_fr",
   "phone",
-  "email",
   "url",
   "address",
   "hours_text",
-  "hours_text_fr",
   "eligibility_notes",
   "eligibility_notes_fr",
   "access_script",
   "access_script_fr",
-  "status",
 ] as const
 
-const nonEmptyString = (max: number) => z.string().trim().min(1).max(max)
-const nullableString = (max: number) => nonEmptyString(max).nullable().optional()
+export const ServiceUpdateFieldKeySchema = PartnerServiceEditFieldKeySchema
 
-export const ServiceUpdateFieldKeySchema = z.enum(SERVICE_UPDATE_FIELDS)
-
-export const ServiceUpdateFieldUpdatesSchema = z
-  .object({
-    name: nonEmptyString(200).optional(),
-    name_fr: nullableString(200),
-    description: nonEmptyString(2000).optional(),
-    description_fr: nullableString(2000),
-    phone: z
-      .string()
-      .trim()
-      .regex(/^[\d\s\-\(\)\+]+$/, "Invalid phone format")
-      .nullable()
-      .optional(),
-    email: z.string().trim().email("Invalid email address").nullable().optional(),
-    url: z.string().trim().url("Invalid URL").optional(),
-    address: nullableString(500),
-    hours: ServiceHoursSchema.nullable().optional(),
-    hours_text: nullableString(200),
-    hours_text_fr: nullableString(200),
-    eligibility_notes: nullableString(500),
-    eligibility_notes_fr: nullableString(500),
-    access_script: nullableString(2000),
-    access_script_fr: nullableString(2000),
-    coordinates: z
-      .object({
-        lat: z.number().min(-90).max(90),
-        lng: z.number().min(-180).max(180),
-      })
-      .nullable()
-      .optional(),
-    status: nullableString(100),
-  })
-  .strict()
-  .refine((value) => Object.keys(value).length > 0, {
-    message: "At least one field update is required",
-  })
+export const ServiceUpdateFieldUpdatesSchema = PartnerServiceEditSchema
 
 export const ServiceUpdateSubmitSchema = z.object({
   field_updates: ServiceUpdateFieldUpdatesSchema,

--- a/types/qrcode.d.ts
+++ b/types/qrcode.d.ts
@@ -1,0 +1,15 @@
+declare module "qrcode" {
+  export interface QRCodeToDataURLOptions {
+    width?: number
+    margin?: number
+    errorCorrectionLevel?: "L" | "M" | "Q" | "H"
+  }
+
+  export function toDataURL(text: string, options?: QRCodeToDataURLOptions): Promise<string>
+
+  const QRCode: {
+    toDataURL: typeof toDataURL
+  }
+
+  export default QRCode
+}


### PR DESCRIPTION
## Summary
- harden partner-facing service mutations with explicit editable-field contracts and role-aware ownership checks
- make share-target hydration, printable cards, search parity, offline sync, and analytics flows more privacy-safe and consistent
- update canonical docs and roadmap notes, and remove remaining AI-attribution-style wording from historical planning docs

## Validation
- npm run lint
- npm run type-check
- npm run check:refs
- npm run check:root
- npx vitest run tests/api/v1/share.test.ts tests/unit/lib/share-target.test.ts tests/api/v1/services-printable.test.ts tests/api/v1/services-id.test.ts tests/api/v1/services/update-request.test.ts tests/api/v1/services/export.test.ts tests/api/v1/analytics-search.test.ts tests/hooks/useServices.test.ts tests/lib/analytics/search-analytics.test.ts tests/unit/lib/offline/sync.test.ts tests/api/v1/health-admin.test.ts tests/api/v1/search-api.test.ts tests/components/ServiceCard.test.tsx tests/components/services/ServiceDetailAnalytics.test.tsx tests/unit/documentation-hygiene.test.ts
- npx vitest run tests/integration/circuit-breaker-db.test.ts tests/unit/lib/offline/sync.test.ts
- npm test
