### PR TITLE
[codex] add platform-ops runtime contract manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,13 @@ When in doubt, **read `README.md` and `docs/**` first\*\*.
 
 **Cross-project ops note:** CareConnect app behavior belongs in this repo. Shared VPS standards, live service inventory, shared ingress ownership, shared host access posture, and cross-project migration/operations state belong in `/home/jer/repos/platform-ops` (historical local alias: `/home/jer/repos/projects-merge`). Use `/home/jer/repos/platform-ops/PLAT-009-shared-vps-documentation-boundary.md` as the default ownership rule. Host-side paths under `/etc/projects-merge/...` remain intentionally unchanged.
 
+Shared-touching live runtime facts for the live web service now also live in the
+repo-root `platform-ops-contract.yaml`. When changing the live canonical host,
+private bind, env-file path, release root, runtime owner, or shared health
+endpoint contract, update that manifest and the matching
+`/home/jer/repos/platform-ops` inventory/current-state surfaces in the same
+change window.
+
 ---
 
 ## Key Commands

--- a/platform-ops-contract.yaml
+++ b/platform-ops-contract.yaml
@@ -1,0 +1,28 @@
+version: 1
+repo_root: careconnect
+services:
+  - service_id: careconnect-web
+    inventory_repo: careconnect
+    runtime: docker
+    ingress: host-caddy
+    canonical_host: careconnect.ing
+    public_hosts:
+      - careconnect.ing
+    private_bind: 127.0.0.1:3300
+    container_name: careconnect-web
+    systemd_unit: null
+    env_file: /etc/projects-merge/env/careconnect-web.env
+    release_root: /srv/apps/careconnect-web/releases
+    health:
+      public:
+        url: https://careconnect.ing/api/v1/health
+        kind: json
+        expect_status:
+          - 200
+        expect_json_status:
+          - healthy
+          - degraded
+      private: null
+    boundary_entrypoints:
+      - docs/deployment/production-checklist.md
+      - docs/deployment/direct-vps-proof.md

--- a/scripts/check-root-hygiene.sh
+++ b/scripts/check-root-hygiene.sh
@@ -42,6 +42,7 @@ ALLOWED_FILES=(
   "commitlint.config.js"
   "git-conventional-commits.yaml"
   "components.json"
+  "platform-ops-contract.yaml"
 
   # Deployment
   "vercel.json"


### PR DESCRIPTION
## Summary
- add a repo-root `platform-ops-contract.yaml` for the live CareConnect web runtime contract
- add an AGENTS note requiring shared runtime facts to stay aligned with `/home/jer/repos/platform-ops`

## Why
This repo now participates in the shared VPS runtime-contract sync baseline. The manifest gives `platform-ops` a machine-readable view of the live shared-touching contract without moving deploy ownership out of the app repo.

## Validation
- `git diff --check`
- validated against `/home/jer/repos/platform-ops/scripts/checks/check-runtime-contract-sync.py --repos-root /home/jer/repos --require-manifests`
