### PR TITLE
[codex] quiet GitHub automation workflows

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -3,11 +3,47 @@ name: Bundle Size Check
 on:
   push:
     branches: [main]
+    paths:
+      - ".github/workflows/bundle-analysis.yml"
+      - "app/**"
+      - "components/**"
+      - "data/**"
+      - "hooks/**"
+      - "i18n/**"
+      - "lib/**"
+      - "messages/**"
+      - "middleware.ts"
+      - "next.config.ts"
+      - "package-lock.json"
+      - "package.json"
+      - "public/**"
+      - "scripts/compare-bundle-size.js"
+      - "scripts/report-bundle-size.js"
   pull_request:
+    paths:
+      - ".github/workflows/bundle-analysis.yml"
+      - "app/**"
+      - "components/**"
+      - "data/**"
+      - "hooks/**"
+      - "i18n/**"
+      - "lib/**"
+      - "messages/**"
+      - "middleware.ts"
+      - "next.config.ts"
+      - "package-lock.json"
+      - "package.json"
+      - "public/**"
+      - "scripts/compare-bundle-size.js"
+      - "scripts/report-bundle-size.js"
+
+concurrency:
+  group: careconnect-bundle-analysis-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write # Needed for PR comments
+  pull-requests: write # Needed for sticky PR warning comments
 
 jobs:
   analyze:
@@ -58,22 +94,81 @@ jobs:
         if: github.event_name == 'pull_request'
         id: compare
         run: |
-          node scripts/compare-bundle-size.js || echo "comparison_failed=true" >> "$GITHUB_OUTPUT"
+          if node scripts/compare-bundle-size.js; then
+            echo "comparison_failed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "comparison_failed=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Comment PR with bundle size diff
-        if: github.event_name == 'pull_request' && steps.compare.outputs.comparison_failed != 'true'
+      - name: Sync PR bundle analysis comment
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v8
+        env:
+          COMPARE_FAILED: ${{ steps.compare.outputs.comparison_failed }}
+          SHOULD_COMMENT: ${{ steps.compare.outputs.should_comment }}
+          ACTIONS_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
             const fs = require('fs');
-            const diff = fs.readFileSync('.next/analyze/bundle-diff.md', 'utf8');
+            const marker = '<!-- careconnect-bundle-analysis -->';
+            const compareFailed = process.env.COMPARE_FAILED === 'true';
+            const shouldComment = process.env.SHOULD_COMMENT === 'true';
+            const runUrl = process.env.ACTIONS_RUN_URL;
 
-            github.rest.issues.createComment({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: diff
+              per_page: 100,
             });
+
+            const existing = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
+            );
+
+            let body = null;
+
+            if (compareFailed) {
+              body = [
+                marker,
+                '## 📦 Bundle Size Analysis',
+                '',
+                '⚠️ Bundle analysis could not compare this PR against the current baseline.',
+                '',
+                `Review the [workflow run](${runUrl}) for logs and artifacts.`,
+              ].join('\n');
+            } else if (shouldComment) {
+              const diff = fs.readFileSync('.next/analyze/bundle-diff.md', 'utf8');
+              body = `${marker}\n${diff}\n\nReview the [workflow run](${runUrl}) for the full analyzer artifacts.`;
+            }
+
+            if (body && existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else if (body) {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            } else if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }
+
+      - name: Fail on comparison error
+        if: github.event_name == 'pull_request' && steps.compare.outputs.comparison_failed == 'true'
+        run: |
+          echo "Bundle analysis comparison failed. Check the workflow logs."
+          exit 1
 
       - name: Create job summary
         if: always()

--- a/.github/workflows/crisis-verification-reminder.yml
+++ b/.github/workflows/crisis-verification-reminder.yml
@@ -5,55 +5,115 @@ on:
     # Run at 9am ET on the 1st of each month
     - cron: "0 14 1 * *"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview issue sync without creating, updating, or closing issues."
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: careconnect-crisis-verification-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   create-reminder:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
 
     steps:
-      - name: Create verification reminder issue
-        uses: actions/github-script@v8
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
         with:
-          script: |
-            const today = new Date();
-            const month = today.toLocaleString('default', { month: 'long', year: 'numeric' });
+          node-version: "22"
+          cache: "npm"
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `📞 Monthly Crisis Service Verification - ${month}`,
-              body: `## Crisis Service Verification Checklist
+      - run: npm ci
 
-            Per the [Governance Protocol](docs/governance/standards.md), crisis services must be verified **monthly**.
+      - name: Resolve dry-run mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
 
-            ### Services to Verify
+      - name: Prepare bot issue sync config
+        id: config
+        shell: bash
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          CONFIG_PATH: ${{ runner.temp }}/crisis-verification-bot-issue.json
+        run: |
+          node --input-type=module <<'EOF'
+          import fs from "fs"
 
-            - [ ] Kids Help Phone (1-800-668-6868)
-            - [ ] Trans Lifeline (1-877-330-6366)
-            - [ ] Hope for Wellness Helpline (1-855-242-3310)
-            - [ ] Assaulted Women's Helpline (1-866-863-0511)
-            - [ ] Kingston Interval House (613-546-1777)
-            - [ ] Telephone Aid Line Kingston (613-544-1771)
-            - [ ] Other crisis services in \`data/services.json\` with \`intent_category: "Crisis"\`
+          const now = new Date()
+          const month = new Intl.DateTimeFormat("en-CA", {
+            timeZone: "America/Toronto",
+            month: "long",
+            year: "numeric",
+          }).format(now)
 
-            ### Verification Steps
+          const body = [
+            "## Crisis Service Verification Checklist",
+            "",
+            "Per the [Governance Protocol](docs/governance/standards.md), crisis services must be verified **monthly**.",
+            "",
+            "### Services to Verify",
+            "",
+            "- [ ] Kids Help Phone (1-800-668-6868)",
+            "- [ ] Trans Lifeline (1-877-330-6366)",
+            "- [ ] Hope for Wellness Helpline (1-855-242-3310)",
+            "- [ ] Assaulted Women's Helpline (1-866-863-0511)",
+            "- [ ] Kingston Interval House (613-546-1777)",
+            "- [ ] Telephone Aid Line Kingston (613-544-1771)",
+            '- [ ] Other crisis services in `data/services.json` with `intent_category: "Crisis"`',
+            "",
+            "### Verification Steps",
+            "",
+            "For each service:",
+            "1. [ ] Call the phone number - does it connect?",
+            "2. [ ] Check the website - does it load?",
+            "3. [ ] Verify hours match what's in our data",
+            "4. [ ] Update `provenance.verified_at` to today's date",
+            "",
+            "### After Verification",
+            "",
+            "- Commit changes to `data/services.json`",
+            "- Run `npm run generate-embeddings` if descriptions changed",
+            "- Close this issue when the current monthly cycle is complete",
+            "",
+            "---",
+            "*This issue is maintained by the monthly verification reminder workflow. The next cycle will reopen it and refresh the checklist automatically.*",
+          ].join("\n")
 
-            For each service:
-            1. [ ] Call the phone number - does it connect?
-            2. [ ] Check the website - does it load?
-            3. [ ] Verify hours match what's in our data
-            4. [ ] Update \`provenance.verified_at\` to today's date
+          const config = {
+            marker: "careconnect-crisis-verification-reminder",
+            labels: ["verification", "crisis-services", "monthly"],
+            title: `📞 Monthly Crisis Service Verification - ${month}`,
+            body,
+            legacy_matchers: [
+              {
+                title_includes: "Monthly Crisis Service Verification",
+                body_includes: "verification reminder workflow",
+              },
+            ],
+            history_limit: 6,
+            dry_run: process.env.DRY_RUN === "true",
+          }
 
-            ### After Verification
+          fs.writeFileSync(process.env.CONFIG_PATH, JSON.stringify(config, null, 2))
+          EOF
 
-            - Commit changes to \`data/services.json\`
-            - Run \`npm run generate-embeddings\` if descriptions changed
-            - Close this issue
+          echo "path=$CONFIG_PATH" >> "$GITHUB_OUTPUT"
 
-            ---
-            *Automatically created by verification reminder workflow.*
-            `,
-              labels: ['verification', 'crisis-services', 'monthly']
-            });
+      - name: Sync bot issue
+        run: node --import tsx scripts/sync-bot-issue.ts "${{ steps.config.outputs.path }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: careconnect-dependabot-auto-merge-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -40,17 +44,49 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Comment on manual review required
-        # Comment on PRs that need manual review
+      - name: Sync manual review comment
+        # Keep a single sticky warning comment for PRs that need manual review
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-major' ||
           (steps.metadata.outputs.dependency-type == 'direct:production' && steps.metadata.outputs.update-type == 'version-update:semver-minor')
         uses: actions/github-script@v8
         with:
           script: |
-            github.rest.issues.createComment({
+            const marker = '<!-- careconnect-dependabot-manual-review -->';
+            const body = [
+              marker,
+              '⚠️ **Manual Review Required**',
+              '',
+              `This ${context.payload.pull_request.title} requires manual review because it includes:`,
+              '- ${{ steps.metadata.outputs.update-type }}',
+              '- Dependency type: ${{ steps.metadata.outputs.dependency-type }}',
+              '',
+              'Please review the changes carefully and check for breaking changes before merging.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `⚠️ **Manual Review Required**\n\nThis ${context.payload.pull_request.title} requires manual review because it includes:\n- ${{ steps.metadata.outputs.update-type }}\n- Dependency type: ${{ steps.metadata.outputs.dependency-type }}\n\nPlease review the changes carefully and check for breaking changes before merging.`
+              per_page: 100,
             });
+
+            const existing = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -4,10 +4,24 @@ on:
   schedule:
     - cron: "0 8 1 * *" # 8 AM UTC on the 1st of each month
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview issue sync without creating, updating, or closing issues."
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: careconnect-health-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   url-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
     steps:
       - uses: actions/checkout@v6
 
@@ -18,46 +32,97 @@ jobs:
 
       - run: npm ci
 
+      - name: Resolve dry-run mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run URL Health Check
         id: health-check
         run: npm run health-check
         continue-on-error: true
 
       - name: Upload Report
+        if: hashFiles('data/url-health-report.json') != ''
         uses: actions/upload-artifact@v7
         with:
           name: url-health-report
           path: data/url-health-report.json
 
-      - name: Create Issue on Failure
-        if: steps.health-check.outcome == 'failure'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const reportPath = 'data/url-health-report.json';
+      - name: Prepare bot issue sync config
+        id: config
+        if: hashFiles('data/url-health-report.json') != ''
+        shell: bash
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          CONFIG_PATH: ${{ runner.temp }}/health-check-bot-issue.json
+        run: |
+          node --input-type=module <<'EOF'
+          import fs from "fs"
 
-            if (!fs.existsSync(reportPath)) {
-              console.log('No health report found. Skipping issue creation.');
-              return;
-            }
+          const report = JSON.parse(fs.readFileSync("data/url-health-report.json", "utf8"))
+          const broken = Array.isArray(report.broken) ? report.broken : []
+          const brokenList = broken
+            .map(
+              (entry) =>
+                `- [ ] **${entry.serviceName}** (ID: \`${entry.serviceId}\`)\n  - URL: ${entry.url}\n  - Error: ${entry.errorMessage || `HTTP ${entry.status}`}`
+            )
+            .join("\n")
 
-            const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8'));
+          const body =
+            broken.length > 0
+              ? [
+                  "## URL Health Check Report",
+                  "",
+                  `**Generated**: ${report.generated}`,
+                  "",
+                  "### Summary",
+                  `- ✅ Healthy: ${report.summary.healthy}`,
+                  `- 🔀 Redirects: ${report.summary.redirects}`,
+                  `- ❌ Broken: ${report.summary.broken}`,
+                  "",
+                  "### Broken URLs",
+                  "",
+                  brokenList,
+                  "",
+                  "---",
+                  "*This issue is maintained by the monthly health check workflow and closes automatically after the report is clean.*",
+                ].join("\n")
+              : ""
 
-            if (!report.broken || report.broken.length === 0) {
-              console.log('No broken links found. Skipping issue creation.');
-              return;
-            }
+          const config = {
+            marker: "careconnect-health-check-issue",
+            labels: ["automated", "data-quality"],
+            title: "🔗 Monthly Health Check: Broken URLs Detected",
+            body,
+            legacy_matchers: [
+              {
+                title_includes: "Monthly Health Check",
+                body_includes: "monthly health check workflow",
+              },
+            ],
+            close_when_resolved: true,
+            dry_run: process.env.DRY_RUN === "true",
+          }
 
-            const brokenList = report.broken
-              .map(b => `- [ ] **${b.serviceName}** (ID: \`${b.serviceId}\`)\n  - URL: ${b.url}\n  - Error: ${b.errorMessage || `HTTP ${b.status}`}`)
-              .join('\n');
+          fs.writeFileSync(process.env.CONFIG_PATH, JSON.stringify(config, null, 2))
+          EOF
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `🔗 Monthly Health Check: ${report.broken.length} Broken URLs Found`,
-              body: `## URL Health Check Report\n\n**Generated**: ${report.generated}\n\n### Summary\n- ✅ Healthy: ${report.summary.healthy}\n- 🔀 Redirects: ${report.summary.redirects}\n- ❌ Broken: ${report.summary.broken}\n\n### Broken URLs\n\n${brokenList}\n\n---\n*This issue was automatically generated by the monthly health check workflow.*`,
-              labels: ['data-quality', 'automated']
-            });
+          echo "path=$CONFIG_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Sync bot issue
+        if: steps.config.outputs.path != ''
+        run: node --import tsx scripts/sync-bot-issue.ts "${{ steps.config.outputs.path }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail if health check did not produce a report
+        if: steps.health-check.outcome == 'failure' && hashFiles('data/url-health-report.json') == ''
+        run: |
+          echo "::error::URL health check failed before writing data/url-health-report.json."
+          exit 1

--- a/.github/workflows/quarterly-verification-reminder.yml
+++ b/.github/workflows/quarterly-verification-reminder.yml
@@ -5,59 +5,126 @@ on:
     # Run at 9am ET on Jan 1, Apr 1, Jul 1, Oct 1
     - cron: "0 14 1 1,4,7,10 *"
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview issue sync without creating, updating, or closing issues."
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: careconnect-quarterly-verification-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   create-reminder:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
 
     steps:
-      - name: Create verification reminder issue
-        uses: actions/github-script@v8
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
         with:
-          script: |
-            const today = new Date();
-            const quarter = Math.floor(today.getMonth() / 3) + 1;
-            const year = today.getFullYear();
+          node-version: "22"
+          cache: "npm"
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `📋 Q${quarter} ${year} General Service Verification`,
-              body: `## Quarterly Service Verification
+      - run: npm ci
 
-            Per the [Governance Protocol](docs/governance/standards.md), general services must be verified **quarterly**.
+      - name: Resolve dry-run mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
 
-            ### Categories to Review
+      - name: Prepare bot issue sync config
+        id: config
+        shell: bash
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          CONFIG_PATH: ${{ runner.temp }}/quarterly-verification-bot-issue.json
+        run: |
+          node --input-type=module <<'EOF'
+          import fs from "fs"
 
-            - [ ] Food (food banks, meal programs)
-            - [ ] Housing (shelters, housing help)
-            - [ ] Health (clinics, dental, mental health)
-            - [ ] Legal (legal clinics)
-            - [ ] Community (newcomer services, youth hubs)
-            - [ ] Indigenous (culturally-specific services)
+          const parts = Object.fromEntries(
+            new Intl.DateTimeFormat("en-CA", {
+              timeZone: "America/Toronto",
+              year: "numeric",
+              month: "numeric",
+            })
+              .formatToParts(new Date())
+              .filter((part) => part.type !== "literal")
+              .map((part) => [part.type, part.value])
+          )
 
-            ### Verification Checklist
+          const year = Number(parts.year)
+          const month = Number(parts.month)
+          const quarter = Math.floor((month - 1) / 3) + 1
 
-            For each service:
-            - [ ] Phone number connects
-            - [ ] Website loads and is current
-            - [ ] Address is correct
-            - [ ] Hours match current operations
-            - [ ] Eligibility criteria still accurate
-            - [ ] French translation is current
+          const body = [
+            "## Quarterly Service Verification",
+            "",
+            "Per the [Governance Protocol](docs/governance/standards.md), general services must be verified **quarterly**.",
+            "",
+            "### Categories to Review",
+            "",
+            "- [ ] Food (food banks, meal programs)",
+            "- [ ] Housing (shelters, housing help)",
+            "- [ ] Health (clinics, dental, mental health)",
+            "- [ ] Legal (legal clinics)",
+            "- [ ] Community (newcomer services, youth hubs)",
+            "- [ ] Indigenous (culturally-specific services)",
+            "",
+            "### Verification Checklist",
+            "",
+            "For each service:",
+            "- [ ] Phone number connects",
+            "- [ ] Website loads and is current",
+            "- [ ] Address is correct",
+            "- [ ] Hours match current operations",
+            "- [ ] Eligibility criteria still accurate",
+            "- [ ] French translation is current",
+            "",
+            "### Process",
+            "",
+            "1. Run `npm run check-staleness` to see which services are due",
+            "2. Verify each flagged service",
+            "3. Update `provenance.verified_at` in `data/services.json`",
+            "4. Commit changes",
+            "5. Close this issue when the current quarterly cycle is complete",
+            "",
+            "---",
+            "*This issue is maintained by the quarterly verification workflow. The next cycle will reopen it and refresh the checklist automatically.*",
+          ].join("\n")
 
-            ### Process
+          const config = {
+            marker: "careconnect-quarterly-verification-reminder",
+            labels: ["verification", "quarterly"],
+            title: `📋 Q${quarter} ${year} General Service Verification`,
+            body,
+            legacy_matchers: [
+              {
+                title_includes: "General Service Verification",
+                body_includes: "quarterly verification workflow",
+              },
+            ],
+            history_limit: 8,
+            dry_run: process.env.DRY_RUN === "true",
+          }
 
-            1. Run \`npm run check-staleness\` to see which services are due
-            2. Verify each flagged service
-            3. Update \`provenance.verified_at\` in \`data/services.json\`
-            4. Commit changes
-            5. Close this issue
+          fs.writeFileSync(process.env.CONFIG_PATH, JSON.stringify(config, null, 2))
+          EOF
 
-            ---
-            *Automatically created by quarterly verification workflow.*
-            `,
-              labels: ['verification', 'quarterly']
-            });
+          echo "path=$CONFIG_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Sync bot issue
+        run: node --import tsx scripts/sync-bot-issue.ts "${{ steps.config.outputs.path }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/staleness-check.yml
+++ b/.github/workflows/staleness-check.yml
@@ -4,7 +4,17 @@ on:
   schedule:
     # Run at 9am ET on the 1st of each month
     - cron: "0 14 1 * *"
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview issue sync without creating, updating, or closing issues."
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: careconnect-staleness-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-staleness:
@@ -26,51 +36,92 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve dry-run mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run staleness check
         id: staleness
         run: npx tsx scripts/check-staleness.ts
 
-      - name: Create issue if stale services found
-        if: steps.staleness.outputs.stale_count > 0
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const staleIds = '${{ steps.staleness.outputs.stale_ids }}'.split(',');
-            const staleCount = parseInt('${{ steps.staleness.outputs.stale_count }}');
+      - name: Prepare bot issue sync config
+        id: config
+        shell: bash
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+          STALE_COUNT: ${{ steps.staleness.outputs.stale_count }}
+          STALE_IDS: ${{ steps.staleness.outputs.stale_ids }}
+          CONFIG_PATH: ${{ runner.temp }}/staleness-bot-issue.json
+        run: |
+          node --input-type=module <<'EOF'
+          import fs from "fs"
 
-            const body = `## 🔴 Stale Services Detected
+          const staleCount = Number(process.env.STALE_COUNT || "0")
+          const staleIds = (process.env.STALE_IDS || "")
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean)
 
-            **${staleCount} service(s)** have not been verified in over 6 months.
+          const body =
+            staleCount > 0
+              ? [
+                  "## 🔴 Stale Services Detected",
+                  "",
+                  `**${staleCount} service(s)** have not been verified in over 6 months.`,
+                  "",
+                  "Per the [Governance Protocol](docs/governance/standards.md), services not verified in >6 months should be downgraded to L0 (hidden).",
+                  "",
+                  "### Services Requiring Attention",
+                  "",
+                  ...staleIds.map((id) => `- [ ] \`${id}\``),
+                  "",
+                  "### Actions Required",
+                  "",
+                  "For each service above:",
+                  "1. Verify the service is still operating (call phone, check website)",
+                  "2. Update `provenance.verified_at` in `data/services.json`",
+                  '3. OR downgrade `verification_level` to "L0" if no longer valid',
+                  "",
+                  "### Verification Checklist",
+                  "",
+                  "- [ ] Phone number connects",
+                  "- [ ] Website loads",
+                  "- [ ] Hours are current",
+                  "- [ ] Address is correct",
+                  "- [ ] French translation is current",
+                  "",
+                  "---",
+                  "*This issue is maintained by the staleness check workflow and closes automatically when no stale services remain.*",
+                ].join("\n")
+              : ""
 
-            Per the [Governance Protocol](docs/governance/standards.md), services not verified in >6 months should be downgraded to L0 (hidden).
+          const config = {
+            marker: "careconnect-staleness-check-issue",
+            labels: ["data-quality", "governance"],
+            title: "🔴 Monthly Staleness Check: Stale Services Detected",
+            body,
+            legacy_matchers: [
+              {
+                title_includes: "Monthly Staleness Check",
+                body_includes: "staleness check workflow",
+              },
+            ],
+            close_when_resolved: true,
+            dry_run: process.env.DRY_RUN === "true",
+          }
 
-            ### Services Requiring Attention
+          fs.writeFileSync(process.env.CONFIG_PATH, JSON.stringify(config, null, 2))
+          EOF
 
-            ${staleIds.map(id => `- [ ] \`${id}\``).join('\n')}
+          echo "path=$CONFIG_PATH" >> "$GITHUB_OUTPUT"
 
-            ### Actions Required
-
-            For each service above:
-            1. Verify the service is still operating (call phone, check website)
-            2. Update \`provenance.verified_at\` in \`data/services.json\`
-            3. OR downgrade \`verification_level\` to "L0" if no longer valid
-
-            ### Verification Checklist
-
-            - [ ] Phone number connects
-            - [ ] Website loads
-            - [ ] Hours are current
-            - [ ] Address is correct
-            - [ ] French translation is current
-
-            ---
-            *This issue was automatically created by the staleness check workflow.*
-            `;
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `🔴 Monthly Staleness Check: ${staleCount} stale service(s) found`,
-              body: body,
-              labels: ['data-quality', 'governance']
-            });
+      - name: Sync bot issue
+        run: node --import tsx scripts/sync-bot-issue.ts "${{ steps.config.outputs.path }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,9 @@ sequenceDiagram
 
 - **URL Health Bot**: Monthly check of all service URLs (`scripts/health-check-urls.ts`).
 - **Phone Validator**: Connectivity checks using Twilio Lookup API (`scripts/validate-phones.ts`).
-- **Automation**: GitHub Actions (`.github/workflows/health-check.yml`) create issues for human review upon detection of failures.
+- **Automation**: GitHub Actions maintain quiet-by-default governance issues.
+- **Finding Workflows**: Health and staleness workflows reuse one bot issue per lane, update it while action is needed, and close it automatically after the condition clears.
+- **Reminder Workflows**: Monthly/quarterly verification reminders reuse one issue per lane, reopen it for the new cycle, and keep a compact recent-cycle history instead of opening a new issue every run.
 
 ### Database Security & Row Level Security (RLS)
 

--- a/docs/development/bundle-size-tracking.md
+++ b/docs/development/bundle-size-tracking.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Bundle size tracking is **enforced in CI** to prevent performance regressions from JavaScript bundle bloat. The system automatically compares bundle sizes between PRs and the main branch, posting detailed reports as PR comments.
+Bundle size tracking is **enforced in CI** to prevent performance regressions from JavaScript bundle bloat. The system automatically compares bundle sizes between PRs and the main branch, keeps routine reports in the GitHub Actions job summary, and only creates a sticky PR comment when there is an actionable regression or the analyzer itself fails.
 
 ## How It Works
 
@@ -10,8 +10,8 @@ Bundle size tracking is **enforced in CI** to prevent performance regressions fr
 
 The `.github/workflows/bundle-analysis.yml` workflow runs on:
 
-- **Push to main**: Establishes baseline bundle sizes
-- **Pull requests**: Compares against baseline and posts diff report
+- **Push to main**: Establishes baseline bundle sizes when bundle-affecting files change
+- **Pull requests**: Compares against baseline for bundle-affecting changes, updates the job summary, and only comments when action is needed
 
 ### Workflow Steps
 
@@ -31,7 +31,10 @@ The `.github/workflows/bundle-analysis.yml` workflow runs on:
    - Identifies page-level changes
    - Generates markdown diff report
 
-5. **Post PR Comment**: Automated comment with size diff table
+5. **Sync PR Warning Comment**: Only for actionable regressions or analyzer failures
+   - Routine passes do not create inbox-noise comments
+   - Existing warning comments are updated in place, not recreated
+   - Warning comments are deleted automatically after the regression is resolved
 
 6. **Create Job Summary**: GitHub Actions summary with results
 
@@ -49,12 +52,15 @@ The `.github/workflows/bundle-analysis.yml` workflow runs on:
 | Raw     | 1.2 MB  | 1.15 MB  | ⚠️ +50 KB (+4.35%) |
 | Gzipped | 350 KB  | 340 KB   | ⚠️ +10 KB (+2.94%) |
 
-### 🔍 Significant Changes
+### Status
+
+⚠️ Action required: detected a significant gzipped bundle regression.
+
+### ⚠️ Significant Regressions
 
 | Page         | Current (gzip) | Baseline (gzip) | Diff                |
 | ------------ | -------------- | --------------- | ------------------- |
 | `/dashboard` | 45 KB          | 35 KB           | ⚠️ +10 KB (+28.57%) |
-| `/search`    | 60 KB          | 65 KB           | ✅ -5 KB (-7.69%)   |
 
 ### 📊 Largest Pages (Top 5)
 
@@ -70,6 +76,12 @@ The `.github/workflows/bundle-analysis.yml` workflow runs on:
 - **⚠️ Warning**: Size increased significantly (>10 KB or >5%)
 - **✅ Improvement**: Size decreased
 - **📊 Neutral**: Minor or no change
+
+### Notification Behavior
+
+- **No PR comment**: No actionable bundle regression was detected
+- **Sticky PR comment**: A significant gzipped bundle regression needs attention
+- **Failed workflow + sticky PR comment**: The comparison automation itself failed and needs investigation
 
 ## Thresholds
 
@@ -201,7 +213,8 @@ const withAnalyzer = withBundleAnalyzer({
 Located in `.github/workflows/bundle-analysis.yml`:
 
 - **Artifact Retention**: 30 days
-- **Permissions**: Read contents, write PR comments
+- **Permissions**: Read contents, write sticky PR warning comments
+- **Concurrency**: Cancels older in-flight bundle runs for the same PR/branch
 - **Triggers**: Push to main, all PRs
 
 ### Comparison Script
@@ -219,11 +232,17 @@ Located in `scripts/compare-bundle-size.js`:
 
 **Solution**: Merge PR to establish baseline. Future PRs will compare against it.
 
+### No PR comment appeared
+
+**Cause**: This is the expected quiet path. Routine bundle checks now stay in the job summary unless a significant gzipped regression or analyzer failure is detected.
+
+**Solution**: No action needed. Open the workflow summary or artifacts if you want the full report.
+
 ### Workflow failing on "Compare bundle sizes"
 
 **Cause**: `compare-bundle-size.js` script error.
 
-**Solution**: Check job logs. The step has `continue-on-error: true`, so it won't block PR.
+**Solution**: Check job logs and the sticky warning comment link. The workflow fails in this case so the broken automation is visible.
 
 ### Bundle size looks wrong
 

--- a/docs/development/dependency-management.md
+++ b/docs/development/dependency-management.md
@@ -123,7 +123,7 @@ When reviewing a Dependabot PR:
 
 1. Dependabot opens PR (e.g., "chore(deps): bump next-intl from 3.0.0 to 3.1.0")
 2. CI runs automatically
-3. Auto-merge workflow comments "Manual Review Required"
+3. Auto-merge workflow posts or updates one sticky "Manual Review Required" comment
 
 **Action needed:**
 

--- a/lib/github/bot-issue-sync.ts
+++ b/lib/github/bot-issue-sync.ts
@@ -1,0 +1,450 @@
+export interface GitHubIssueSummary {
+  number: number
+  title: string
+  body: string
+  state: "open" | "closed"
+  labels: string[]
+  authorLogin: string
+  createdAt: string
+  updatedAt: string
+  url?: string
+}
+
+export interface LegacyIssueMatcher {
+  title_includes?: string
+  body_includes?: string
+  labels?: string[]
+}
+
+export interface BotIssueSyncConfig {
+  marker: string
+  labels: string[]
+  title: string
+  body: string
+  legacy_matchers?: LegacyIssueMatcher[]
+  close_when_resolved?: boolean
+  history_limit?: number
+  dry_run?: boolean
+}
+
+export interface UpdateIssueInput {
+  title?: string
+  body?: string
+  labels?: string[]
+  state?: "open" | "closed"
+}
+
+export interface BotIssueClient {
+  listIssues(requiredLabels: string[]): Promise<GitHubIssueSummary[]>
+  createIssue(input: { title: string; body: string; labels: string[] }): Promise<GitHubIssueSummary>
+  updateIssue(issueNumber: number, input: UpdateIssueInput): Promise<GitHubIssueSummary>
+}
+
+export interface BotIssueSyncResult {
+  action: "created" | "updated" | "reopened" | "closed" | "noop"
+  dryRun: boolean
+  canonicalIssueNumber?: number
+  canonicalIssueUrl?: string
+  duplicateIssueNumbers: number[]
+  historyEntries: string[]
+}
+
+interface GitHubApiIssue {
+  number: number
+  title: string
+  body?: string | null
+  state: "open" | "closed"
+  labels: Array<{ name?: string | null }>
+  user?: { login?: string | null }
+  created_at: string
+  updated_at: string
+  html_url?: string
+  pull_request?: unknown
+}
+
+const BOT_AUTHOR_LOGIN = "github-actions[bot]"
+const HISTORY_START = "<!-- careconnect-bot-issue-history:start -->"
+const HISTORY_END = "<!-- careconnect-bot-issue-history:end -->"
+
+function markerComment(marker: string): string {
+  return `<!-- ${marker} -->`
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function hasAllLabels(issue: GitHubIssueSummary, labels: string[]): boolean {
+  return labels.every((label) => issue.labels.includes(label))
+}
+
+function issueMatchesLegacy(issue: GitHubIssueSummary, matchers: LegacyIssueMatcher[] | undefined): boolean {
+  if (!matchers || matchers.length === 0) {
+    return false
+  }
+
+  return matchers.some((matcher) => {
+    if (matcher.title_includes && !issue.title.includes(matcher.title_includes)) {
+      return false
+    }
+
+    if (matcher.body_includes && !issue.body.includes(matcher.body_includes)) {
+      return false
+    }
+
+    if (matcher.labels && !matcher.labels.every((label) => issue.labels.includes(label))) {
+      return false
+    }
+
+    return true
+  })
+}
+
+function issueMatchesConfig(issue: GitHubIssueSummary, config: BotIssueSyncConfig): boolean {
+  if (issue.authorLogin !== BOT_AUTHOR_LOGIN) {
+    return false
+  }
+
+  const marker = markerComment(config.marker)
+  if (issue.body.includes(marker)) {
+    return true
+  }
+
+  if (!hasAllLabels(issue, config.labels)) {
+    return false
+  }
+
+  return issueMatchesLegacy(issue, config.legacy_matchers)
+}
+
+function compareIssueRecency(left: GitHubIssueSummary, right: GitHubIssueSummary): number {
+  const leftCreated = new Date(left.createdAt).getTime()
+  const rightCreated = new Date(right.createdAt).getTime()
+
+  if (leftCreated !== rightCreated) {
+    return rightCreated - leftCreated
+  }
+
+  return right.number - left.number
+}
+
+function mergeLabels(existing: string[], required: string[]): string[] {
+  return Array.from(new Set([...existing, ...required])).sort((left, right) => left.localeCompare(right))
+}
+
+function stripHistorySection(body: string): string {
+  const historyPattern = new RegExp(`${escapeRegExp(HISTORY_START)}[\\s\\S]*?${escapeRegExp(HISTORY_END)}`, "g")
+  return body.replace(historyPattern, "").trim()
+}
+
+function stripMarker(body: string, marker: string): string {
+  const markerPattern = new RegExp(`^${escapeRegExp(markerComment(marker))}\\s*`, "m")
+  return body.replace(markerPattern, "").trim()
+}
+
+function normalizeBaseBody(body: string, marker: string): string {
+  return stripHistorySection(stripMarker(body, marker)).trim()
+}
+
+function extractHistoryEntries(body: string): string[] {
+  const historyPattern = new RegExp(`${escapeRegExp(HISTORY_START)}([\\s\\S]*?)${escapeRegExp(HISTORY_END)}`)
+  const match = body.match(historyPattern)
+
+  if (!match) {
+    return []
+  }
+
+  const historyBlock = match[1] ?? ""
+
+  return historyBlock
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .map((line) => line.slice(2))
+}
+
+function dedupePreserveOrder(values: string[]): string[] {
+  const seen = new Set<string>()
+  const deduped: string[] = []
+
+  for (const value of values) {
+    if (!value || seen.has(value)) {
+      continue
+    }
+
+    seen.add(value)
+    deduped.push(value)
+  }
+
+  return deduped
+}
+
+function buildHistoryEntries(
+  config: BotIssueSyncConfig,
+  canonicalIssue: GitHubIssueSummary | undefined,
+  matches: GitHubIssueSummary[]
+): string[] {
+  if (!config.history_limit || config.history_limit <= 0) {
+    return []
+  }
+
+  const sortedMatches = [...matches].sort(compareIssueRecency)
+  const carriedTitles: string[] = []
+
+  if (canonicalIssue && canonicalIssue.title !== config.title) {
+    carriedTitles.push(canonicalIssue.title)
+  }
+
+  for (const issue of sortedMatches) {
+    if (canonicalIssue && issue.number === canonicalIssue.number) {
+      continue
+    }
+
+    carriedTitles.push(issue.title)
+  }
+
+  const existingEntries = canonicalIssue ? extractHistoryEntries(canonicalIssue.body) : []
+  const combined = dedupePreserveOrder([...carriedTitles, ...existingEntries]).filter((entry) => entry !== config.title)
+
+  return combined.slice(0, config.history_limit)
+}
+
+function buildManagedBody(config: BotIssueSyncConfig, historyEntries: string[]): string {
+  const sections = [markerComment(config.marker), normalizeBaseBody(config.body, config.marker)]
+
+  if (historyEntries.length > 0) {
+    sections.push(
+      [HISTORY_START, "## Recent Cycles", "", ...historyEntries.map((entry) => `- ${entry}`), HISTORY_END].join("\n")
+    )
+  }
+
+  return sections
+    .filter((section) => section.trim().length > 0)
+    .join("\n\n")
+    .trim()
+}
+
+function hasMeaningfulBody(body: string): boolean {
+  return body.trim().length > 0
+}
+
+function determineAction(
+  issue: GitHubIssueSummary | undefined,
+  desiredBody: string,
+  desiredTitle: string,
+  desiredLabels: string[],
+  duplicateIssueNumbers: number[],
+  closeWhenResolved: boolean
+): BotIssueSyncResult["action"] {
+  if (!issue) {
+    return hasMeaningfulBody(desiredBody) ? "created" : "noop"
+  }
+
+  if (!hasMeaningfulBody(desiredBody) && closeWhenResolved) {
+    return issue.state === "open" ? "closed" : duplicateIssueNumbers.length > 0 ? "closed" : "noop"
+  }
+
+  const labelsChanged = issue.labels.join(",") !== desiredLabels.join(",")
+  const titleChanged = issue.title !== desiredTitle
+  const bodyChanged = issue.body !== desiredBody
+  const stateChanged = issue.state !== "open"
+
+  if (stateChanged) {
+    return "reopened"
+  }
+
+  if (titleChanged || bodyChanged || labelsChanged || duplicateIssueNumbers.length > 0) {
+    return "updated"
+  }
+
+  return "noop"
+}
+
+export async function syncBotIssue(client: BotIssueClient, config: BotIssueSyncConfig): Promise<BotIssueSyncResult> {
+  const issues = await client.listIssues([])
+  const matches = issues.filter((issue) => issueMatchesConfig(issue, config)).sort(compareIssueRecency)
+  const canonicalIssue = matches[0]
+  const duplicateIssues = matches.slice(1)
+  const duplicateOpenIssues = duplicateIssues.filter((issue) => issue.state === "open")
+  const historyEntries = buildHistoryEntries(config, canonicalIssue, matches)
+  const desiredBody = hasMeaningfulBody(config.body) ? buildManagedBody(config, historyEntries) : ""
+  const desiredLabels = mergeLabels(canonicalIssue?.labels ?? [], config.labels)
+  const duplicateIssueNumbers = duplicateOpenIssues.map((issue) => issue.number)
+  const action = determineAction(
+    canonicalIssue,
+    desiredBody,
+    config.title,
+    desiredLabels,
+    duplicateIssueNumbers,
+    config.close_when_resolved ?? false
+  )
+
+  if (!hasMeaningfulBody(config.body) && !(config.close_when_resolved ?? false)) {
+    throw new Error("Bot issue sync received an empty body without close_when_resolved enabled.")
+  }
+
+  if (!canonicalIssue && !hasMeaningfulBody(config.body)) {
+    return {
+      action: "noop",
+      dryRun: config.dry_run ?? false,
+      duplicateIssueNumbers,
+      historyEntries,
+    }
+  }
+
+  if (config.dry_run) {
+    return {
+      action,
+      dryRun: true,
+      canonicalIssueNumber: canonicalIssue?.number,
+      canonicalIssueUrl: canonicalIssue?.url,
+      duplicateIssueNumbers,
+      historyEntries,
+    }
+  }
+
+  let activeCanonical = canonicalIssue
+
+  if (!canonicalIssue && hasMeaningfulBody(config.body)) {
+    activeCanonical = await client.createIssue({
+      title: config.title,
+      body: desiredBody,
+      labels: config.labels,
+    })
+  } else if (canonicalIssue && !hasMeaningfulBody(config.body) && (config.close_when_resolved ?? false)) {
+    if (canonicalIssue.state === "open") {
+      activeCanonical = await client.updateIssue(canonicalIssue.number, { state: "closed" })
+    }
+  } else if (canonicalIssue && hasMeaningfulBody(config.body)) {
+    const updateInput: UpdateIssueInput = {}
+
+    if (canonicalIssue.title !== config.title) {
+      updateInput.title = config.title
+    }
+
+    if (canonicalIssue.body !== desiredBody) {
+      updateInput.body = desiredBody
+    }
+
+    if (canonicalIssue.state !== "open") {
+      updateInput.state = "open"
+    }
+
+    const currentLabels = canonicalIssue.labels.join(",")
+    const nextLabels = desiredLabels.join(",")
+    if (currentLabels !== nextLabels) {
+      updateInput.labels = desiredLabels
+    }
+
+    if (Object.keys(updateInput).length > 0) {
+      activeCanonical = await client.updateIssue(canonicalIssue.number, updateInput)
+    }
+  }
+
+  for (const duplicateIssue of duplicateOpenIssues) {
+    await client.updateIssue(duplicateIssue.number, { state: "closed" })
+  }
+
+  return {
+    action,
+    dryRun: false,
+    canonicalIssueNumber: activeCanonical?.number,
+    canonicalIssueUrl: activeCanonical?.url,
+    duplicateIssueNumbers,
+    historyEntries,
+  }
+}
+
+function mapApiIssue(issue: GitHubApiIssue): GitHubIssueSummary {
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? "",
+    state: issue.state,
+    labels: issue.labels.flatMap((label) => (label.name ? [label.name] : [])),
+    authorLogin: issue.user?.login ?? "",
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at,
+    url: issue.html_url,
+  }
+}
+
+export class GitHubRestBotIssueClient implements BotIssueClient {
+  constructor(
+    private readonly owner: string,
+    private readonly repo: string,
+    private readonly token: string,
+    private readonly apiBaseUrl = "https://api.github.com"
+  ) {}
+
+  async listIssues(requiredLabels: string[]): Promise<GitHubIssueSummary[]> {
+    const issues: GitHubIssueSummary[] = []
+    let page = 1
+
+    while (true) {
+      const params = new URLSearchParams({
+        state: "all",
+        per_page: "100",
+        page: String(page),
+        sort: "created",
+        direction: "desc",
+      })
+
+      if (requiredLabels.length > 0) {
+        params.set("labels", requiredLabels.join(","))
+      }
+
+      const data = await this.request<GitHubApiIssue[]>(
+        `/repos/${this.owner}/${this.repo}/issues?${params.toString()}`,
+        { method: "GET" }
+      )
+      const issuePage = data.filter((issue) => !issue.pull_request).map(mapApiIssue)
+      issues.push(...issuePage)
+
+      if (data.length < 100) {
+        break
+      }
+
+      page += 1
+    }
+
+    return issues
+  }
+
+  async createIssue(input: { title: string; body: string; labels: string[] }): Promise<GitHubIssueSummary> {
+    const issue = await this.request<GitHubApiIssue>(`/repos/${this.owner}/${this.repo}/issues`, {
+      method: "POST",
+      body: JSON.stringify(input),
+    })
+
+    return mapApiIssue(issue)
+  }
+
+  async updateIssue(issueNumber: number, input: UpdateIssueInput): Promise<GitHubIssueSummary> {
+    const issue = await this.request<GitHubApiIssue>(`/repos/${this.owner}/${this.repo}/issues/${issueNumber}`, {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    })
+
+    return mapApiIssue(issue)
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const response = await fetch(`${this.apiBaseUrl}${path}`, {
+      ...init,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "CareConnect-BotIssueSync/1.0",
+      },
+    })
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(`GitHub API request failed (${response.status} ${response.statusText}): ${body}`)
+    }
+
+    return (await response.json()) as T
+  }
+}

--- a/scripts/compare-bundle-size.js
+++ b/scripts/compare-bundle-size.js
@@ -30,7 +30,7 @@ function formatDiff(current, baseline) {
   const sign = diff > 0 ? "+" : ""
 
   let emoji = "📊"
-  if (diff > WARN_INCREASE_BYTES && Math.abs(percent) > WARN_INCREASE_PERCENT) {
+  if (diff > WARN_INCREASE_BYTES || parseFloat(percent) > WARN_INCREASE_PERCENT) {
     emoji = "⚠️"
   } else if (diff < 0) {
     emoji = "✅"
@@ -52,6 +52,22 @@ function loadBundleData(filePath) {
   } catch {
     return null
   }
+}
+
+function setGitHubOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return
+  }
+
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`)
+}
+
+function isSignificantChange(diff) {
+  return Math.abs(diff.diff) > WARN_INCREASE_BYTES || Math.abs(parseFloat(diff.percent)) > WARN_INCREASE_PERCENT
+}
+
+function isActionableRegression(diff) {
+  return diff.diff > WARN_INCREASE_BYTES || parseFloat(diff.percent) > WARN_INCREASE_PERCENT
 }
 
 function compareBundles() {
@@ -106,16 +122,33 @@ function compareBundles() {
   report += `| Raw | ${formatBytes(currentGlobal.raw)} | ${formatBytes(baselineGlobal.raw)} | ${rawDiff.emoji} ${rawDiff.formatted} |\n`
   report += `| Gzipped | ${formatBytes(currentGlobal.gzip)} | ${formatBytes(baselineGlobal.gzip)} | ${gzipDiff.emoji} ${gzipDiff.formatted} |\n\n`
 
-  // Significant changes
-  const significantChanges = pageComparisons.filter(
-    (p) => Math.abs(p.diff.diff) > WARN_INCREASE_BYTES || Math.abs(parseFloat(p.diff.percent)) > WARN_INCREASE_PERCENT
-  )
+  const significantRegressions = pageComparisons.filter((p) => p.diff.diff > 0 && isActionableRegression(p.diff))
+  const significantImprovements = pageComparisons.filter((p) => p.diff.diff < 0 && isSignificantChange(p.diff))
+  const hasActionableRegression = isActionableRegression(gzipDiff) || significantRegressions.length > 0
 
-  if (significantChanges.length > 0) {
-    report += "### 🔍 Significant Changes\n\n"
+  if (hasActionableRegression) {
+    report += "### Status\n\n"
+    report += "⚠️ Action required: detected a significant gzipped bundle regression.\n\n"
+  } else {
+    report += "### Status\n\n"
+    report += "✅ No actionable gzipped bundle regression detected.\n\n"
+  }
+
+  if (significantRegressions.length > 0) {
+    report += "### ⚠️ Significant Regressions\n\n"
     report += "| Page | Current (gzip) | Baseline (gzip) | Diff |\n"
     report += "|------|----------------|-----------------|------|\n"
-    significantChanges.forEach((p) => {
+    significantRegressions.forEach((p) => {
+      report += `| \`${p.page}\` | ${formatBytes(p.current)} | ${formatBytes(p.baseline)} | ${p.diff.emoji} ${p.diff.formatted} |\n`
+    })
+    report += "\n"
+  }
+
+  if (significantImprovements.length > 0) {
+    report += "### ✅ Significant Improvements\n\n"
+    report += "| Page | Current (gzip) | Baseline (gzip) | Diff |\n"
+    report += "|------|----------------|-----------------|------|\n"
+    significantImprovements.forEach((p) => {
       report += `| \`${p.page}\` | ${formatBytes(p.current)} | ${formatBytes(p.baseline)} | ${p.diff.emoji} ${p.diff.formatted} |\n`
     })
     report += "\n"
@@ -132,14 +165,7 @@ function compareBundles() {
   })
   report += "\n"
 
-  // Warnings
-  const hasLargeIncrease =
-    rawDiff.diff > WARN_INCREASE_BYTES * 2 ||
-    gzipDiff.diff > WARN_INCREASE_BYTES * 2 ||
-    parseFloat(rawDiff.percent) > WARN_INCREASE_PERCENT * 2 ||
-    parseFloat(gzipDiff.percent) > WARN_INCREASE_PERCENT * 2
-
-  if (hasLargeIncrease) {
+  if (hasActionableRegression) {
     report += "### ⚠️ Warning\n\n"
     report += `Bundle size increased significantly. Consider:\n`
     report += `- Reviewing new dependencies added\n`
@@ -159,7 +185,7 @@ function compareBundles() {
   console.log("Bundle comparison report generated at:", OUTPUT_PATH)
   console.log("\n" + report)
 
-  return { hasLargeIncrease, gzipDiff, rawDiff }
+  return { hasActionableRegression }
 }
 
 // Run comparison
@@ -172,14 +198,11 @@ try {
       "## 📦 Bundle Size Analysis\n\n✅ Bundle analysis complete. No baseline for comparison.\n\nThis will serve as the baseline for future PRs.\n"
     fs.writeFileSync(OUTPUT_PATH, message)
     console.log(message)
+    setGitHubOutput("should_comment", false)
     process.exit(0)
   }
 
-  // Exit with error if bundle size increased significantly (optional - can be removed if too strict)
-  // if (result.hasLargeIncrease) {
-  //   console.error("Bundle size increased significantly!")
-  //   process.exit(1)
-  // }
+  setGitHubOutput("should_comment", result.hasActionableRegression)
 
   process.exit(0)
 } catch (err) {

--- a/scripts/sync-bot-issue.ts
+++ b/scripts/sync-bot-issue.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node --import tsx
+import { appendFileSync, readFileSync } from "fs"
+import path from "path"
+
+import { z } from "zod"
+
+import {
+  GitHubRestBotIssueClient,
+  syncBotIssue,
+  type BotIssueSyncConfig,
+  type LegacyIssueMatcher,
+} from "../lib/github/bot-issue-sync"
+import { logger } from "../lib/logger"
+
+const legacyMatcherSchema = z.object({
+  title_includes: z.string().min(1).optional(),
+  body_includes: z.string().min(1).optional(),
+  labels: z.array(z.string().min(1)).optional(),
+})
+
+const configSchema = z.object({
+  marker: z.string().min(1),
+  labels: z.array(z.string().min(1)).min(1),
+  title: z.string().min(1),
+  body: z.string(),
+  legacy_matchers: z.array(legacyMatcherSchema).optional(),
+  close_when_resolved: z.boolean().optional(),
+  history_limit: z.number().int().positive().optional(),
+  dry_run: z.boolean().optional(),
+})
+
+function setGitHubOutput(name: string, value: string | number | boolean): void {
+  if (!process.env.GITHUB_OUTPUT) {
+    return
+  }
+
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`)
+}
+
+function parseRepository(): { owner: string; repo: string } {
+  const repository = process.env.GITHUB_REPOSITORY
+
+  if (!repository || !repository.includes("/")) {
+    throw new Error("GITHUB_REPOSITORY must be set to owner/repo for bot issue sync.")
+  }
+
+  const [owner, repo] = repository.split("/")
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`)
+  }
+
+  return { owner, repo }
+}
+
+function parseConfig(configPath: string): BotIssueSyncConfig {
+  const rawConfig = JSON.parse(readFileSync(configPath, "utf-8")) as {
+    legacy_matchers?: LegacyIssueMatcher[]
+  }
+
+  return configSchema.parse(rawConfig)
+}
+
+async function main(): Promise<void> {
+  logger.setContext({ component: "scripts/sync-bot-issue" })
+
+  const configArg = process.argv[2]
+  if (!configArg) {
+    throw new Error("Usage: node --import tsx scripts/sync-bot-issue.ts <config-path>")
+  }
+
+  const configPath = path.resolve(process.cwd(), configArg)
+  const config = parseConfig(configPath)
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+
+  if (!token) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN must be set for bot issue sync.")
+  }
+
+  const { owner, repo } = parseRepository()
+  const client = new GitHubRestBotIssueClient(owner, repo, token)
+  const result = await syncBotIssue(client, config)
+
+  logger.info("Bot issue sync completed", result)
+
+  setGitHubOutput("action", result.action)
+  setGitHubOutput("dry_run", result.dryRun)
+
+  if (result.canonicalIssueNumber) {
+    setGitHubOutput("canonical_issue_number", result.canonicalIssueNumber)
+  }
+
+  if (result.canonicalIssueUrl) {
+    setGitHubOutput("canonical_issue_url", result.canonicalIssueUrl)
+  }
+
+  setGitHubOutput("duplicate_issue_numbers", result.duplicateIssueNumbers.join(","))
+}
+
+main().catch((error) => {
+  logger.error("Bot issue sync failed", error)
+  process.exit(1)
+})

--- a/tests/lib/github/bot-issue-sync.test.ts
+++ b/tests/lib/github/bot-issue-sync.test.ts
@@ -1,0 +1,219 @@
+/** @vitest-environment node */
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  syncBotIssue,
+  type BotIssueClient,
+  type BotIssueSyncConfig,
+  type GitHubIssueSummary,
+  type UpdateIssueInput,
+} from "@/lib/github/bot-issue-sync"
+
+class FakeBotIssueClient implements BotIssueClient {
+  constructor(readonly issues: GitHubIssueSummary[]) {}
+
+  readonly created: Array<{ title: string; body: string; labels: string[] }> = []
+  readonly updates: Array<{ issueNumber: number; input: UpdateIssueInput }> = []
+
+  async listIssues(requiredLabels: string[]): Promise<GitHubIssueSummary[]> {
+    return this.issues
+      .filter((issue) => requiredLabels.every((label) => issue.labels.includes(label)))
+      .map((issue) => ({ ...issue, labels: [...issue.labels] }))
+  }
+
+  async createIssue(input: { title: string; body: string; labels: string[] }): Promise<GitHubIssueSummary> {
+    this.created.push(input)
+
+    const issue: GitHubIssueSummary = {
+      number: Math.max(0, ...this.issues.map((candidate) => candidate.number)) + 1,
+      title: input.title,
+      body: input.body,
+      state: "open",
+      labels: [...input.labels],
+      authorLogin: "github-actions[bot]",
+      createdAt: "2026-04-20T12:00:00.000Z",
+      updatedAt: "2026-04-20T12:00:00.000Z",
+      url: `https://example.test/issues/${Math.max(0, ...this.issues.map((candidate) => candidate.number)) + 1}`,
+    }
+
+    this.issues.unshift(issue)
+    return { ...issue, labels: [...issue.labels] }
+  }
+
+  async updateIssue(issueNumber: number, input: UpdateIssueInput): Promise<GitHubIssueSummary> {
+    this.updates.push({ issueNumber, input })
+
+    const issue = this.issues.find((candidate) => candidate.number === issueNumber)
+    if (!issue) {
+      throw new Error(`Issue ${issueNumber} not found`)
+    }
+
+    if (input.title !== undefined) {
+      issue.title = input.title
+    }
+
+    if (input.body !== undefined) {
+      issue.body = input.body
+    }
+
+    if (input.state !== undefined) {
+      issue.state = input.state
+    }
+
+    if (input.labels !== undefined) {
+      issue.labels = [...input.labels]
+    }
+
+    issue.updatedAt = "2026-04-20T13:00:00.000Z"
+    return { ...issue, labels: [...issue.labels] }
+  }
+}
+
+function makeIssue(overrides: Partial<GitHubIssueSummary> = {}): GitHubIssueSummary {
+  return {
+    number: overrides.number ?? 1,
+    title: overrides.title ?? "📞 Monthly Crisis Service Verification - April 2026",
+    body:
+      overrides.body ??
+      "## Crisis Service Verification Checklist\n\n---\n*Automatically created by verification reminder workflow.*\n",
+    state: overrides.state ?? "open",
+    labels: overrides.labels ?? ["verification", "crisis-services", "monthly"],
+    authorLogin: overrides.authorLogin ?? "github-actions[bot]",
+    createdAt: overrides.createdAt ?? "2026-04-01T14:00:00.000Z",
+    updatedAt: overrides.updatedAt ?? "2026-04-01T14:00:00.000Z",
+    url: overrides.url ?? `https://example.test/issues/${overrides.number ?? 1}`,
+  }
+}
+
+function makeConfig(overrides: Partial<BotIssueSyncConfig> = {}): BotIssueSyncConfig {
+  return {
+    marker: "careconnect-crisis-reminder",
+    labels: ["verification", "crisis-services", "monthly"],
+    title: "📞 Monthly Crisis Service Verification - April 2026",
+    body: "## Crisis Service Verification Checklist\n\nCurrent cycle checklist.",
+    legacy_matchers: [{ title_includes: "Monthly Crisis Service Verification", labels: ["verification", "monthly"] }],
+    ...overrides,
+  }
+}
+
+describe("syncBotIssue", () => {
+  let client: FakeBotIssueClient
+
+  beforeEach(() => {
+    client = new FakeBotIssueClient([])
+  })
+
+  it("creates a managed issue when none exists", async () => {
+    const result = await syncBotIssue(client, makeConfig())
+
+    expect(result.action).toBe("created")
+    expect(client.created).toHaveLength(1)
+    expect(client.created[0]!.body).toContain("<!-- careconnect-crisis-reminder -->")
+    expect(client.created[0]!.labels).toEqual(["verification", "crisis-services", "monthly"])
+  })
+
+  it("updates an existing open issue matched through legacy rules", async () => {
+    client = new FakeBotIssueClient([makeIssue({ labels: ["verification", "crisis-services", "monthly", "triage"] })])
+
+    const result = await syncBotIssue(
+      client,
+      makeConfig({ body: "## Crisis Service Verification Checklist\n\nUpdated." })
+    )
+
+    expect(result.action).toBe("updated")
+    expect(client.updates).toHaveLength(1)
+    expect(client.updates[0]!.input.body).toContain("<!-- careconnect-crisis-reminder -->")
+    expect(client.updates[0]!.input.labels).toEqual(["crisis-services", "monthly", "triage", "verification"])
+  })
+
+  it("reopens a closed matching issue instead of creating a new one", async () => {
+    client = new FakeBotIssueClient([makeIssue({ state: "closed" })])
+
+    const result = await syncBotIssue(client, makeConfig())
+
+    expect(result.action).toBe("reopened")
+    expect(client.created).toHaveLength(0)
+    expect(client.updates).toHaveLength(1)
+    expect(client.updates[0]!.input.state).toBe("open")
+  })
+
+  it("closes older duplicate open issues while keeping the newest canonical issue", async () => {
+    client = new FakeBotIssueClient([
+      makeIssue({ number: 13, createdAt: "2026-04-01T14:00:00.000Z", body: "legacy current" }),
+      makeIssue({
+        number: 8,
+        createdAt: "2026-03-01T14:00:00.000Z",
+        title: "📞 Monthly Crisis Service Verification - March 2026",
+      }),
+    ])
+
+    const result = await syncBotIssue(client, makeConfig())
+
+    expect(result.action).toBe("updated")
+    expect(result.duplicateIssueNumbers).toEqual([8])
+    expect(client.updates.some((update) => update.issueNumber === 8 && update.input.state === "closed")).toBe(true)
+  })
+
+  it("auto-closes a finding issue when the condition is resolved", async () => {
+    client = new FakeBotIssueClient([
+      makeIssue({
+        number: 21,
+        title: "🔗 Monthly Health Check: Broken URLs Detected",
+        body: "<!-- careconnect-health-check -->\n\nBroken URLs still open.",
+        labels: ["automated", "data-quality"],
+      }),
+    ])
+
+    const result = await syncBotIssue(client, {
+      marker: "careconnect-health-check",
+      labels: ["automated", "data-quality"],
+      title: "🔗 Monthly Health Check: Broken URLs Detected",
+      body: "",
+      legacy_matchers: [{ title_includes: "Monthly Health Check" }],
+      close_when_resolved: true,
+    })
+
+    expect(result.action).toBe("closed")
+    expect(client.updates).toEqual([{ issueNumber: 21, input: { state: "closed" } }])
+  })
+
+  it("maintains compact cycle history and trims to the configured limit", async () => {
+    client = new FakeBotIssueClient([
+      makeIssue({
+        number: 13,
+        title: "📞 Monthly Crisis Service Verification - April 2026",
+        body: "<!-- careconnect-crisis-reminder -->\n\n## Crisis Service Verification Checklist\n\nApril checklist.",
+        createdAt: "2026-04-01T14:00:00.000Z",
+      }),
+      makeIssue({
+        number: 8,
+        title: "📞 Monthly Crisis Service Verification - March 2026",
+        createdAt: "2026-03-01T14:00:00.000Z",
+        state: "closed",
+      }),
+      makeIssue({
+        number: 1,
+        title: "📞 Monthly Crisis Service Verification - February 2026",
+        createdAt: "2026-02-01T14:00:00.000Z",
+        state: "closed",
+      }),
+    ])
+
+    const result = await syncBotIssue(
+      client,
+      makeConfig({
+        title: "📞 Monthly Crisis Service Verification - May 2026",
+        history_limit: 2,
+      })
+    )
+
+    expect(result.historyEntries).toEqual([
+      "📞 Monthly Crisis Service Verification - April 2026",
+      "📞 Monthly Crisis Service Verification - March 2026",
+    ])
+    expect(client.updates[0]!.input.body).toContain("## Recent Cycles")
+    expect(client.updates[0]!.input.body).toContain("- 📞 Monthly Crisis Service Verification - April 2026")
+    expect(client.updates[0]!.input.body).toContain("- 📞 Monthly Crisis Service Verification - March 2026")
+    expect(client.updates[0]!.input.body).not.toContain("February 2026")
+  })
+})


### PR DESCRIPTION
## Summary
- make PR and scheduled GitHub automation quiet by default
- add a reusable bot-issue sync helper for sticky issue reconciliation
- convert health, staleness, and verification reminder workflows to reuse one issue per lane

## Why
Routine GitHub Actions comments and repeated reminder issues were creating unnecessary inbox noise. CareConnect still needs governance-visible maintenance workflows, but they should only surface actionable work and should not accumulate duplicate bot issues.

## Validation
- `npm run lint`
- `npm run type-check`
- `npx vitest run tests/lib/github/bot-issue-sync.test.ts`
- `npx vitest run tests/unit/documentation-hygiene.test.ts`
- `git push` pre-push hook: full `npm test`
- targeted `prettier --check` on changed workflow/code/doc files
- live GitHub API dry-run against existing reminder issues via `scripts/sync-bot-issue.ts`
