### PR TITLE
fix: reduce URL health check inconclusives

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -54,6 +54,53 @@ jobs:
           name: url-health-report
           path: data/url-health-report.json
 
+      - name: Write job summary
+        if: hashFiles('data/url-health-report.json') != ''
+        shell: bash
+        run: |
+          node --input-type=module <<'EOF'
+          import fs from "fs"
+
+          const report = JSON.parse(fs.readFileSync("data/url-health-report.json", "utf8"))
+          const broken = Array.isArray(report.broken) ? report.broken : []
+          const inconclusive = Array.isArray(report.inconclusive) ? report.inconclusive : []
+
+          const summaryLines = [
+            "## URL Health Check",
+            "",
+            `- ✅ Healthy: ${report.summary.healthy}`,
+            `- 🔀 Redirects: ${report.summary.redirects}`,
+            `- ⚠️ Inconclusive: ${report.summary.inconclusive ?? 0}`,
+            `- ❌ Broken: ${report.summary.broken}`,
+          ]
+
+          if (broken.length > 0) {
+            summaryLines.push("", "### Broken URLs")
+            for (const entry of broken.slice(0, 10)) {
+              summaryLines.push(
+                `- **${entry.serviceName}**: ${entry.errorMessage || `HTTP ${entry.status}`}`,
+                `  - Public URL: ${entry.url}`
+              )
+            }
+          }
+
+          if (inconclusive.length > 0) {
+            summaryLines.push("", "### Inconclusive URLs")
+            for (const entry of inconclusive.slice(0, 10)) {
+              const result = entry.status === "error" ? `${entry.errorCode ? `${entry.errorCode}: ` : ""}${entry.errorMessage}` : `HTTP ${entry.status}`
+              summaryLines.push(
+                `- **${entry.serviceName}**: ${result}`,
+                `  - Public URL: ${entry.url}`
+              )
+              if (entry.probeUrl && entry.probeUrl !== entry.url) {
+                summaryLines.push(`  - Override Probe: ${entry.probeUrl}`)
+              }
+            }
+          }
+
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summaryLines.join("\n")}\n`)
+          EOF
+
       - name: Prepare bot issue sync config
         id: config
         if: hashFiles('data/url-health-report.json') != ''
@@ -70,7 +117,15 @@ jobs:
           const brokenList = broken
             .map(
               (entry) =>
-                `- [ ] **${entry.serviceName}** (ID: \`${entry.serviceId}\`)\n  - URL: ${entry.url}\n  - Error: ${entry.errorMessage || `HTTP ${entry.status}`}`
+                [
+                  `- [ ] **${entry.serviceName}** (ID: \`${entry.serviceId}\`)`,
+                  `  - URL: ${entry.url}`,
+                  entry.probeUrl && entry.probeUrl !== entry.url ? `  - Override Probe: ${entry.probeUrl}` : null,
+                  `  - Error: ${entry.errorMessage || `HTTP ${entry.status}`}`,
+                  entry.notes ? `  - Note: ${entry.notes}` : null,
+                ]
+                  .filter(Boolean)
+                  .join("\n")
             )
             .join("\n")
 

--- a/lib/health/url-health-probes.ts
+++ b/lib/health/url-health-probes.ts
@@ -1,0 +1,57 @@
+export type UrlHealthProbeSource = "service_url" | "official_override"
+
+export interface UrlHealthProbeConfig {
+  probeUrl: string
+  source: UrlHealthProbeSource
+  reason?: string
+}
+
+interface UrlHealthProbeOverride {
+  probeUrl: string
+  reason: string
+}
+
+const OFFICIAL_URL_HEALTH_PROBE_OVERRIDES: Record<string, UrlHealthProbeOverride> = {
+  "crisis-telehealth-ontario": {
+    probeUrl: "https://www.ontario.ca/page/your-health",
+    reason:
+      "Health811 occasionally blocks automated requests on the chat domain; verify against Ontario's official service overview instead.",
+  },
+  "law-society-referral-service": {
+    probeUrl: "https://lsrs.lso.ca/lsrs/",
+    reason:
+      "The Law Society Referral Service intake portal is a more stable official probe target than the public information page.",
+  },
+  "ontario-victim-support-line": {
+    probeUrl: "https://www.ontario.ca/page/victimwitness-assistance-program",
+    reason:
+      "Verify against Ontario's official Victim Support Line documentation when the directory host rate-limits automation.",
+  },
+  "red-cross-kingston": {
+    probeUrl: "https://www.redcross.ca/in-your-community/ontario/community-support-services",
+    reason:
+      "The Ontario community support services page is the most stable official Red Cross landing page for automation checks.",
+  },
+  "resolve-counselling": {
+    probeUrl: "https://resolvecounselling.org/contact-us/",
+    reason:
+      "Resolve's homepage intermittently times out from CI; the official contact page is a more reliable probe target.",
+  },
+}
+
+export function resolveUrlHealthProbe(serviceId: string, serviceUrl: string): UrlHealthProbeConfig {
+  const override = OFFICIAL_URL_HEALTH_PROBE_OVERRIDES[serviceId]
+
+  if (!override) {
+    return {
+      probeUrl: serviceUrl,
+      source: "service_url",
+    }
+  }
+
+  return {
+    probeUrl: override.probeUrl,
+    source: "official_override",
+    reason: override.reason,
+  }
+}

--- a/scripts/health-check-urls.ts
+++ b/scripts/health-check-urls.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync, existsSync } from "fs"
 import path from "path"
 
 import { classifyUrlCheckOutcome, type UrlCheckOutcome, type UrlHealthClassification } from "@/lib/health/url-health"
+import { resolveUrlHealthProbe, type UrlHealthProbeSource } from "@/lib/health/url-health-probes"
 
 interface Service {
   id: string
@@ -14,9 +15,13 @@ interface HealthCheckResult extends UrlCheckOutcome {
   serviceId: string
   serviceName: string
   url: string
+  probeUrl: string
+  probeSource: UrlHealthProbeSource
+  probeReason?: string
   classification: UrlHealthClassification
   finalUrl?: string
   responseTime?: number
+  notes?: string
 }
 
 const SERVICES_PATH = path.join(process.cwd(), "data/services.json")
@@ -109,6 +114,54 @@ async function checkUrl(
   }
 }
 
+function formatOutcome(outcome: Pick<HealthCheckResult, "status" | "errorCode" | "errorMessage">): string {
+  if (outcome.status === "error") {
+    return `${outcome.errorCode ? `${outcome.errorCode}: ` : ""}${outcome.errorMessage}`
+  }
+
+  return `HTTP ${outcome.status}`
+}
+
+async function checkService(service: Service): Promise<HealthCheckResult> {
+  const primaryResult = await checkUrl(service.url!)
+  const probe = resolveUrlHealthProbe(service.id, service.url!)
+
+  if (primaryResult.classification !== "inconclusive" || probe.source === "service_url") {
+    return {
+      serviceId: service.id,
+      serviceName: service.name,
+      url: service.url!,
+      probeUrl: service.url!,
+      probeSource: "service_url",
+      ...primaryResult,
+    }
+  }
+
+  const overrideResult = await checkUrl(probe.probeUrl)
+  if (overrideResult.classification === "healthy") {
+    return {
+      serviceId: service.id,
+      serviceName: service.name,
+      url: service.url!,
+      probeUrl: probe.probeUrl,
+      probeSource: probe.source,
+      probeReason: probe.reason,
+      ...overrideResult,
+      notes: `Primary URL remained inconclusive (${formatOutcome(primaryResult)}); official override probe succeeded.`,
+    }
+  }
+
+  return {
+    serviceId: service.id,
+    serviceName: service.name,
+    url: service.url!,
+    probeUrl: service.url!,
+    probeSource: "service_url",
+    ...primaryResult,
+    notes: `Official override probe (${probe.probeUrl}) was ${formatOutcome(overrideResult)}.`,
+  }
+}
+
 async function main() {
   console.log(`${YELLOW}🔗 Running URL health check...${RESET}\n`)
 
@@ -126,13 +179,8 @@ async function main() {
   let checked = 0
 
   for (const service of servicesWithUrls) {
-    const result = await checkUrl(service.url!)
-    results.push({
-      serviceId: service.id,
-      serviceName: service.name,
-      url: service.url!,
-      ...result,
-    })
+    const result = await checkService(service)
+    results.push(result)
 
     checked++
     const statusIcon =
@@ -144,11 +192,16 @@ async function main() {
     const statusText =
       result.status === "error"
         ? `${result.errorCode ? `${result.errorCode}: ` : ""}${result.errorMessage}`
-        : `HTTP ${result.status}${result.finalUrl && result.finalUrl !== service.url ? ` → ${result.finalUrl}` : ""}`
+        : `HTTP ${result.status}${result.finalUrl && result.finalUrl !== result.probeUrl ? ` → ${result.finalUrl}` : ""}`
+    const probeText =
+      result.probeSource === "official_override"
+        ? ` via override ${result.probeUrl}${result.probeReason ? ` (${result.probeReason})` : ""}`
+        : ""
+    const notesText = result.notes ? ` ${result.notes}` : ""
 
     // Using a more readable multi-line output for CI/Terminal
     console.log(
-      `${statusIcon} [${checked}/${servicesWithUrls.length}] ${service.name}: ${statusText} (${result.responseTime}ms)`
+      `${statusIcon} [${checked}/${servicesWithUrls.length}] ${service.name}: ${statusText}${probeText}${notesText} (${result.responseTime}ms)`
     )
 
     // Rate limiting: 500ms between requests to avoid being blocked
@@ -174,6 +227,9 @@ async function main() {
     for (const result of broken) {
       console.log(`  - ${result.serviceName}`)
       console.log(`    URL: ${result.url}`)
+      if (result.probeSource === "official_override") {
+        console.log(`    Override Probe: ${result.probeUrl}`)
+      }
       console.log(`    Error: ${result.errorMessage || `HTTP ${result.status}`}\n`)
     }
   }
@@ -183,6 +239,9 @@ async function main() {
     for (const result of inconclusive) {
       console.log(`  - ${result.serviceName}`)
       console.log(`    URL: ${result.url}`)
+      if (result.probeSource === "official_override") {
+        console.log(`    Override Probe: ${result.probeUrl}`)
+      }
       console.log(
         `    Result: ${
           result.status === "error"

--- a/tests/lib/health/url-health-probes.test.ts
+++ b/tests/lib/health/url-health-probes.test.ts
@@ -1,0 +1,25 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest"
+
+import { resolveUrlHealthProbe } from "@/lib/health/url-health-probes"
+
+describe("resolveUrlHealthProbe", () => {
+  it("defaults to probing the public service URL", () => {
+    expect(resolveUrlHealthProbe("kids-help-phone", "https://kidshelpphone.ca/")).toEqual({
+      probeUrl: "https://kidshelpphone.ca/",
+      source: "service_url",
+    })
+  })
+
+  it("returns official override probes for bot-hostile services", () => {
+    expect(resolveUrlHealthProbe("crisis-telehealth-ontario", "https://health811.ontario.ca")).toMatchObject({
+      probeUrl: "https://www.ontario.ca/page/your-health",
+      source: "official_override",
+    })
+
+    expect(resolveUrlHealthProbe("law-society-referral-service", "https://findlegalhelp.ca")).toMatchObject({
+      probeUrl: "https://lsrs.lso.ca/lsrs/",
+      source: "official_override",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add official probe overrides for services whose public URLs are bot-hostile or CI-fragile
- keep public service URLs intact while only using overrides when the primary URL is inconclusive
- add a health-check job summary so monthly runs are easier to review without opening raw logs

## Testing
- npm run lint
- npm run type-check
- npx vitest run tests/lib/health/url-health.test.ts tests/lib/health/url-health-probes.test.ts
- targeted probe of the prior inconclusive set (reduced from 8 to 3 locally)