### PR TITLE
chore: checkpoint v22 Gate 0 maintenance

### DIFF
--- a/.agent/agent.md
+++ b/.agent/agent.md
@@ -1,13 +1,15 @@
-# CareConnect - AI Context
+# CareConnect - Agent Context
 
-This file provides context for AI agents working on the CareConnect project.
+This file provides context for automation and development agents working on the
+CareConnect project.
 
 ## Development Principles
 
 1. **Separation of Content**: No hardcoded strings in UI. Use translation files.
 2. **SSR Safety**: Always guard client-side APIs (localStorage, window) with `typeof window !== 'undefined'`.
 3. **Privacy First**: Avoid adding tracking scripts or invasive cookies.
-4. **Verified Data**: The "Kingston 150" dataset is manually curated. Update via `scripts/migrate-data.ts`.
+4. **Verified Data**: The service dataset is manually curated. Update via governed data workflows only.
+5. **Authorship**: Commits, docs, changelogs, acknowledgments, and release notes may list only actual human contributors as authors or contributors. Do not add AI tool attribution, generated-by signatures, or AI co-author trailers.
 
 ## Tech Stack
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
         run: npm run check:root
       - name: Check Repo References
         run: npm run check:refs
+      - name: Check v22 Gate 0 Evidence Intake
+        run: npm run check:v22-evidence
+      - name: Check v22 Threat Model
+        run: npm run check:v22-threat-model
       - name: Validate Security Headers
         run: npm run validate:security-headers
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ These commands require `k6` to be installed locally and available on your `PATH`
 | `npm run verify:search-ranking`                        | Verify API ranking against a running local app            |
 | `npm run verify:rls`                                   | Check public/private Supabase access boundaries           |
 | `npm run audit:pilot-readiness -- --scope-file <path>` | Export scoped pilot readiness JSON/Markdown/CSV artifacts |
+| `npm run check:v22-evidence`                           | Validate C1/D4 Gate 0 evidence-intake consistency         |
+| `npm run check:v22-threat-model`                       | Validate v22 threat-model Gate 0 consistency              |
 | `npm run check:v22-gate0`                              | Enforce the current v22 Gate 0 decision from docs         |
 | `npm run normalize:services -- --dry-run`              | Preview legacy schema normalization without writing data  |
 | `npm run ingest:import-response -- --help`             | Show draft-import CLI usage                               |

--- a/app/api/v1/pilot/events/connection/route.ts
+++ b/app/api/v1/pilot/events/connection/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest } from "next/server"
-import { createApiError, createApiResponse, handleApiError, validateContentType } from "@/lib/api-utils"
+import { createApiError, handleApiError, validateContentType } from "@/lib/api-utils"
 import { getClientIp, checkRateLimit } from "@/lib/rate-limit"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { PilotConnectionCreateSchema } from "@/lib/schemas/pilot-events"
 import { assertPermission } from "@/lib/auth/authorization"
 import { insertConnectionEvent } from "@/lib/pilot/storage"
+import { createPilotIdempotentRetryResponse, createPilotWriteSuccessResponse } from "@/lib/pilot/responses"
 
 export async function POST(request: NextRequest) {
   try {
@@ -33,11 +34,14 @@ export async function POST(request: NextRequest) {
     if (storage.missingTable) {
       return createApiError("Pilot storage not ready: missing pilot_connection_events table", 501)
     }
+    if (storage.duplicate) {
+      return createPilotIdempotentRetryResponse()
+    }
     if (storage.error) {
       return createApiError("Failed to store connection event", 500, storage.error.message)
     }
 
-    return createApiResponse({ success: true }, { status: 201, headers: { "Cache-Control": "no-store" } })
+    return createPilotWriteSuccessResponse()
   } catch (error) {
     return handleApiError(error)
   }

--- a/app/api/v1/pilot/events/contact-attempt/route.ts
+++ b/app/api/v1/pilot/events/contact-attempt/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest } from "next/server"
-import { createApiError, createApiResponse, handleApiError, validateContentType } from "@/lib/api-utils"
+import { createApiError, handleApiError, validateContentType } from "@/lib/api-utils"
 import { getClientIp, checkRateLimit } from "@/lib/rate-limit"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { PilotContactAttemptCreateSchema } from "@/lib/schemas/pilot-events"
 import { assertPermission } from "@/lib/auth/authorization"
 import { insertContactAttempt } from "@/lib/pilot/storage"
+import { createPilotIdempotentRetryResponse, createPilotWriteSuccessResponse } from "@/lib/pilot/responses"
 
 export async function POST(request: NextRequest) {
   try {
@@ -36,11 +37,15 @@ export async function POST(request: NextRequest) {
       return createApiError("Pilot storage not ready: missing pilot_contact_attempt_events table", 501)
     }
 
+    if (storage.duplicate) {
+      return createPilotIdempotentRetryResponse()
+    }
+
     if (storage.error) {
       return createApiError("Failed to store contact attempt", 500, storage.error.message)
     }
 
-    return createApiResponse({ success: true }, { status: 201, headers: { "Cache-Control": "no-store" } })
+    return createPilotWriteSuccessResponse()
   } catch (error) {
     return handleApiError(error)
   }

--- a/app/api/v1/pilot/events/data-decay-audit/route.ts
+++ b/app/api/v1/pilot/events/data-decay-audit/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest } from "next/server"
-import { createApiError, createApiResponse, handleApiError, validateContentType } from "@/lib/api-utils"
+import { createApiError, handleApiError, validateContentType } from "@/lib/api-utils"
 import { getClientIp, checkRateLimit } from "@/lib/rate-limit"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { PilotDataDecayAuditCreateSchema } from "@/lib/schemas/pilot-events"
 import { assertPermission } from "@/lib/auth/authorization"
 import { insertPilotDataDecayAudit } from "@/lib/pilot/storage"
+import { createPilotIdempotentRetryResponse, createPilotWriteSuccessResponse } from "@/lib/pilot/responses"
 
 export async function POST(request: NextRequest) {
   try {
@@ -33,11 +34,14 @@ export async function POST(request: NextRequest) {
     if (storage.missingTable) {
       return createApiError("Pilot storage not ready: missing pilot_data_decay_audits table", 501)
     }
+    if (storage.duplicate) {
+      return createPilotIdempotentRetryResponse()
+    }
     if (storage.error) {
       return createApiError("Failed to store data decay audit", 500, storage.error.message)
     }
 
-    return createApiResponse({ success: true }, { status: 201, headers: { "Cache-Control": "no-store" } })
+    return createPilotWriteSuccessResponse()
   } catch (error) {
     return handleApiError(error)
   }

--- a/app/api/v1/pilot/events/preference-fit/route.ts
+++ b/app/api/v1/pilot/events/preference-fit/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest } from "next/server"
-import { createApiError, createApiResponse, handleApiError, validateContentType } from "@/lib/api-utils"
+import { createApiError, handleApiError, validateContentType } from "@/lib/api-utils"
 import { getClientIp, checkRateLimit } from "@/lib/rate-limit"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { PilotPreferenceFitEventCreateSchema } from "@/lib/schemas/pilot-events"
 import { assertPermission } from "@/lib/auth/authorization"
 import { insertPilotPreferenceFitEvent } from "@/lib/pilot/storage"
+import { createPilotIdempotentRetryResponse, createPilotWriteSuccessResponse } from "@/lib/pilot/responses"
 
 export async function POST(request: NextRequest) {
   try {
@@ -33,11 +34,14 @@ export async function POST(request: NextRequest) {
     if (storage.missingTable) {
       return createApiError("Pilot storage not ready: missing pilot_preference_fit_events table", 501)
     }
+    if (storage.duplicate) {
+      return createPilotIdempotentRetryResponse()
+    }
     if (storage.error) {
       return createApiError("Failed to store preference fit event", 500, storage.error.message)
     }
 
-    return createApiResponse({ success: true }, { status: 201, headers: { "Cache-Control": "no-store" } })
+    return createPilotWriteSuccessResponse()
   } catch (error) {
     return handleApiError(error)
   }

--- a/app/api/v1/pilot/events/referral/route.ts
+++ b/app/api/v1/pilot/events/referral/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest } from "next/server"
-import { createApiError, createApiResponse, handleApiError, validateContentType } from "@/lib/api-utils"
+import { createApiError, handleApiError, validateContentType } from "@/lib/api-utils"
 import { getClientIp, checkRateLimit } from "@/lib/rate-limit"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { PilotReferralCreateSchema } from "@/lib/schemas/pilot-events"
 import { assertPermission } from "@/lib/auth/authorization"
 import { insertReferralEvent } from "@/lib/pilot/storage"
+import { createPilotIdempotentRetryResponse, createPilotWriteSuccessResponse } from "@/lib/pilot/responses"
 
 export async function POST(request: NextRequest) {
   try {
@@ -36,11 +37,15 @@ export async function POST(request: NextRequest) {
       return createApiError("Pilot storage not ready: missing pilot_referral_events table", 501)
     }
 
+    if (storage.duplicate) {
+      return createPilotIdempotentRetryResponse()
+    }
+
     if (storage.error) {
       return createApiError("Failed to store referral event", 500, storage.error.message)
     }
 
-    return createApiResponse({ success: true }, { status: 201, headers: { "Cache-Control": "no-store" } })
+    return createPilotWriteSuccessResponse()
   } catch (error) {
     return handleApiError(error)
   }

--- a/app/api/v1/pilot/events/service-status/route.ts
+++ b/app/api/v1/pilot/events/service-status/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest } from "next/server"
-import { createApiError, createApiResponse, handleApiError, validateContentType } from "@/lib/api-utils"
+import { createApiError, handleApiError, validateContentType } from "@/lib/api-utils"
 import { getClientIp, checkRateLimit } from "@/lib/rate-limit"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { ServiceOperationalStatusEventCreateSchema } from "@/lib/schemas/pilot-events"
 import { assertPermission } from "@/lib/auth/authorization"
 import { insertServiceOperationalStatusEvent } from "@/lib/pilot/storage"
+import { createPilotIdempotentRetryResponse, createPilotWriteSuccessResponse } from "@/lib/pilot/responses"
 
 export async function POST(request: NextRequest) {
   try {
@@ -33,11 +34,14 @@ export async function POST(request: NextRequest) {
     if (storage.missingTable) {
       return createApiError("Pilot storage not ready: missing service_operational_status_events table", 501)
     }
+    if (storage.duplicate) {
+      return createPilotIdempotentRetryResponse()
+    }
     if (storage.error) {
       return createApiError("Failed to store service status event", 500, storage.error.message)
     }
 
-    return createApiResponse({ success: true }, { status: 201, headers: { "Cache-Control": "no-store" } })
+    return createPilotWriteSuccessResponse()
   } catch (error) {
     return handleApiError(error)
   }

--- a/components/layout/AuthProvider.tsx
+++ b/components/layout/AuthProvider.tsx
@@ -5,6 +5,7 @@ import { User, Session } from "@supabase/supabase-js"
 import { hasSupabaseCredentials, supabase } from "@/lib/supabase"
 import { logger } from "@/lib/logger"
 import { useRouter } from "next/navigation"
+import { clearPilotDraftStorageOnSignOut } from "@/lib/offline/pilot-draft-cleanup"
 
 interface AuthContextType {
   user: User | null
@@ -90,6 +91,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       return
     }
 
+    await clearPilotDraftStorageOnSignOut()
     await supabase.auth.signOut()
     router.refresh()
   }

--- a/components/offline/OfflineSync.tsx
+++ b/components/offline/OfflineSync.tsx
@@ -6,6 +6,18 @@ import { syncOfflineData } from "@/lib/offline/sync"
 import { syncPendingFeedback } from "@/lib/offline/feedback"
 import { logger } from "@/lib/logger"
 
+function getClientSyncErrorType(error: unknown): string {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name || "DOMException"
+  }
+
+  if (error instanceof Error) {
+    return "Error"
+  }
+
+  return typeof error
+}
+
 export function OfflineSync() {
   const locale = useLocale()
 
@@ -37,7 +49,7 @@ export function OfflineSync() {
         if (!cancelled) {
           logger.warn("Service worker registration failed", {
             component: "OfflineSync",
-            error: err instanceof Error ? err.message : String(err),
+            errorType: getClientSyncErrorType(err),
           })
         }
       }
@@ -73,11 +85,19 @@ export function OfflineSync() {
             logger.info("Offline data synced successfully", { component: "OfflineSync", action: "initial_sync" })
           }
         })
-        .catch((err) => logger.error("Offline sync failed", err, { component: "OfflineSync" }))
+        .catch((err) =>
+          logger.warn("Offline sync failed", {
+            component: "OfflineSync",
+            errorType: getClientSyncErrorType(err),
+          })
+        )
 
       // Also try to sync pending feedback
       syncPendingFeedback().catch((err) =>
-        logger.error("Pending feedback sync failed", err, { component: "OfflineSync" })
+        logger.warn("Pending feedback sync failed", {
+          component: "OfflineSync",
+          errorType: getClientSyncErrorType(err),
+        })
       )
     }
 
@@ -100,7 +120,12 @@ export function OfflineSync() {
   // Keep the Workbox navigation fallback (`/offline`) warm for the current locale.
   // This reduces the chance of showing a stale-language cached offline page after a locale switch.
   useEffect(() => {
-    fetch("/offline").catch((err) => logger.warn("Offline fallback prewarm failed", { err, locale }))
+    fetch("/offline").catch((err) =>
+      logger.warn("Offline fallback prewarm failed", {
+        errorType: getClientSyncErrorType(err),
+        locale,
+      })
+    )
   }, [locale])
 
   return null

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -416,10 +416,22 @@ paths:
             schema:
               $ref: "#/components/schemas/PilotContactAttemptCreate"
       responses:
+        "200":
+          description: Idempotent retry accepted; the client-supplied event id was already recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
         "201":
           description: Contact attempt recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
         "400":
           description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
         "401":
           description: Unauthorized
         "403":
@@ -448,10 +460,22 @@ paths:
             schema:
               $ref: "#/components/schemas/PilotReferralCreate"
       responses:
+        "200":
+          description: Idempotent retry accepted; the client-supplied event id was already recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
         "201":
           description: Referral event recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
         "400":
           description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
         "401":
           description: Unauthorized
         "403":
@@ -486,8 +510,233 @@ paths:
       responses:
         "200":
           description: Referral event updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
         "400":
           description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "429":
+          description: Rate limited
+        "501":
+          description: Pilot storage not initialized
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /pilot/scope/services:
+    post:
+      summary: Upsert Pilot Service Scope (Internal)
+      description: |
+        Internal v22 Phase 0 endpoint for registering services in the pilot scope.
+        This endpoint records only organization, service, cycle, and SLA-tier metadata.
+      operationId: upsertPilotServiceScope
+      tags:
+        - Pilot
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PilotServiceScopeCreate"
+      responses:
+        "201":
+          description: Pilot service scope entry stored
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "400":
+          description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "429":
+          description: Rate limited
+        "501":
+          description: Pilot storage not initialized
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /pilot/events/connection:
+    post:
+      summary: Record Pilot Connection Event (Internal)
+      description: |
+        Internal v22 Phase 0 endpoint for connection-time instrumentation.
+        A client-generated `id` may be supplied for idempotent offline retries.
+      operationId: recordPilotConnectionEvent
+      tags:
+        - Pilot
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PilotConnectionCreate"
+      responses:
+        "200":
+          description: Idempotent retry accepted; the client-supplied event id was already recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "201":
+          description: Connection event recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "400":
+          description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "429":
+          description: Rate limited
+        "501":
+          description: Pilot storage not initialized
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /pilot/events/service-status:
+    post:
+      summary: Record Pilot Service Status Event (Internal)
+      description: |
+        Internal v22 Phase 0 endpoint for operational status checks.
+        A client-generated `id` may be supplied for idempotent offline retries.
+      operationId: recordPilotServiceStatusEvent
+      tags:
+        - Pilot
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PilotServiceStatusCreate"
+      responses:
+        "200":
+          description: Idempotent retry accepted; the client-supplied event id was already recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "201":
+          description: Service status event recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "400":
+          description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "429":
+          description: Rate limited
+        "501":
+          description: Pilot storage not initialized
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /pilot/events/data-decay-audit:
+    post:
+      summary: Record Pilot Data Decay Audit (Internal)
+      description: |
+        Internal v22 Phase 0 endpoint for data decay audit instrumentation.
+        A client-generated `id` may be supplied for idempotent offline retries.
+      operationId: recordPilotDataDecayAudit
+      tags:
+        - Pilot
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PilotDataDecayAuditCreate"
+      responses:
+        "200":
+          description: Idempotent retry accepted; the client-supplied event id was already recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "201":
+          description: Data decay audit recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "400":
+          description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+        "429":
+          description: Rate limited
+        "501":
+          description: Pilot storage not initialized
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /pilot/events/preference-fit:
+    post:
+      summary: Record Pilot Preference Fit Event (Internal)
+      description: |
+        Internal v22 Phase 0 endpoint for preference-fit instrumentation.
+        A client-generated `id` may be supplied for idempotent offline retries.
+      operationId: recordPilotPreferenceFitEvent
+      tags:
+        - Pilot
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PilotPreferenceFitCreate"
+      responses:
+        "200":
+          description: Idempotent retry accepted; the client-supplied event id was already recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "201":
+          description: Preference fit event recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
+        "400":
+          description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
         "401":
           description: Unauthorized
         "403":
@@ -516,12 +765,57 @@ paths:
       responses:
         "201":
           description: Decision recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotWriteSuccess"
         "400":
           description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
         "401":
           description: Unauthorized
         "403":
           description: Admin required
+        "429":
+          description: Rate limited
+        "501":
+          description: Pilot storage not initialized
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /pilot/metrics/recompute:
+    post:
+      summary: Recompute Pilot Metrics (Internal)
+      description: |
+        Internal v22 Phase 0 endpoint for recomputing pilot metric snapshots
+        and the latest scorecard for one pilot cycle and organization.
+      operationId: recomputePilotMetrics
+      tags:
+        - Pilot
+      security:
+        - cookieAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PilotMetricsRecomputeRequest"
+      responses:
+        "200":
+          description: Pilot metrics recomputed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PilotMetricsRecomputeResult"
+        "400":
+          description: Validation error
+        "415":
+          description: Unsupported media type; request body must be application/json
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
         "429":
           description: Rate limited
         "501":
@@ -568,22 +862,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      scorecard:
-                        $ref: "#/components/schemas/PilotScorecard"
-                      gate1Evaluation:
-                        type: object
-                        nullable: true
+                $ref: "#/components/schemas/PilotScorecardResponse"
         "400":
           description: Validation error
         "401":
           description: Unauthorized
         "403":
           description: Forbidden
+        "404":
+          description: Pilot scorecard not found
         "429":
           description: Rate limited
         "501":
@@ -792,6 +1079,10 @@ components:
         - attempt_outcome
         - attempted_at
       properties:
+        id:
+          type: string
+          format: uuid
+          description: Optional client-generated event id for idempotent offline retries.
         pilot_cycle_id:
           type: string
         service_id:
@@ -830,6 +1121,10 @@ components:
         - created_at
         - updated_at
       properties:
+        id:
+          type: string
+          format: uuid
+          description: Optional client-generated event id for idempotent offline retries.
         pilot_cycle_id:
           type: string
         source_org_id:
@@ -877,6 +1172,163 @@ components:
         failure_reason_code:
           type: string
           nullable: true
+
+    PilotConnectionCreate:
+      type: object
+      required:
+        - pilot_cycle_id
+        - org_id
+        - service_id
+        - connected_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Optional client-generated event id for idempotent offline retries.
+        pilot_cycle_id:
+          type: string
+        org_id:
+          type: string
+          format: uuid
+        service_id:
+          type: string
+        connected_at:
+          type: string
+          format: date-time
+        contact_attempt_event_id:
+          type: string
+          format: uuid
+          nullable: true
+        referral_event_id:
+          type: string
+          format: uuid
+          nullable: true
+      description: Exactly one of `contact_attempt_event_id` or `referral_event_id` is required.
+
+    PilotServiceScopeCreate:
+      type: object
+      required:
+        - pilot_cycle_id
+        - org_id
+        - service_id
+        - sla_tier
+      properties:
+        pilot_cycle_id:
+          type: string
+        org_id:
+          type: string
+          format: uuid
+        service_id:
+          type: string
+        sla_tier:
+          type: string
+          enum: [crisis, high_demand, standard]
+      description: Privacy-safe pilot scope metadata. Raw query text, client identifiers, and contact fields are not accepted.
+
+    PilotServiceStatusCreate:
+      type: object
+      required:
+        - pilot_cycle_id
+        - org_id
+        - service_id
+        - checked_at
+        - status_code
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Optional client-generated event id for idempotent offline retries.
+        pilot_cycle_id:
+          type: string
+        org_id:
+          type: string
+          format: uuid
+        service_id:
+          type: string
+        checked_at:
+          type: string
+          format: date-time
+        status_code:
+          type: string
+          enum: [available, temporarily_unavailable, closed, unknown]
+
+    PilotDataDecayAuditCreate:
+      type: object
+      required:
+        - pilot_cycle_id
+        - org_id
+        - service_id
+        - audited_at
+        - is_fatal
+        - verification_mode
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Optional client-generated event id for idempotent offline retries.
+        pilot_cycle_id:
+          type: string
+        org_id:
+          type: string
+          format: uuid
+        service_id:
+          type: string
+        audited_at:
+          type: string
+          format: date-time
+        is_fatal:
+          type: boolean
+        fatal_error_category:
+          type: string
+          enum:
+            - wrong_or_disconnected_phone
+            - invalid_or_defunct_intake_path
+            - materially_incorrect_eligibility
+            - service_closed_or_unavailable_but_listed_available
+          nullable: true
+        verification_mode:
+          type: string
+          enum: [web_only, web_plus_call, provider_confirmation]
+
+    PilotPreferenceFitCreate:
+      type: object
+      required:
+        - pilot_cycle_id
+        - org_id
+        - cohort_label
+        - recorded_at
+        - preferred_via_careconnect
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Optional client-generated event id for idempotent offline retries.
+        pilot_cycle_id:
+          type: string
+        org_id:
+          type: string
+          format: uuid
+        cohort_label:
+          type: string
+        recorded_at:
+          type: string
+          format: date-time
+        preferred_via_careconnect:
+          type: boolean
+
+    PilotWriteSuccess:
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+            - success
+          properties:
+            success:
+              type: boolean
+            duplicate:
+              type: boolean
+              description: Present and true when a supplied client event id was already recorded.
 
     IntegrationFeasibilityDecision:
       type: object
@@ -950,6 +1402,75 @@ components:
         m7_preference_fit_indicator:
           type: number
           nullable: true
+
+    Gate1ThresholdEvaluation:
+      type: object
+      properties:
+        failedContactRateReductionPass:
+          type: boolean
+        timeToConnectionReductionPass:
+          type: boolean
+        freshnessSlaPass:
+          type: boolean
+        referralCapturePass:
+          type: boolean
+        fatalErrorRatePass:
+          type: boolean
+        passedAll:
+          type: boolean
+
+    PilotScorecardResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+            - scorecard
+          properties:
+            scorecard:
+              $ref: "#/components/schemas/PilotScorecard"
+            gate1Evaluation:
+              allOf:
+                - $ref: "#/components/schemas/Gate1ThresholdEvaluation"
+              nullable: true
+
+    PilotMetricsRecomputeRequest:
+      type: object
+      required:
+        - pilot_cycle_id
+        - org_id
+      properties:
+        pilot_cycle_id:
+          type: string
+        org_id:
+          type: string
+          format: uuid
+      description: Privacy-safe recompute selector. Raw query text, client identifiers, and contact fields are not accepted.
+
+    PilotMetricsRecomputeResult:
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+            - success
+            - calculatedAt
+            - snapshotsWritten
+            - scorecard
+          properties:
+            success:
+              type: boolean
+            calculatedAt:
+              type: string
+              format: date-time
+              nullable: true
+            snapshotsWritten:
+              type: integer
+              minimum: 0
+            scorecard:
+              allOf:
+                - $ref: "#/components/schemas/PilotScorecard"
+              nullable: true
 
     Error:
       type: object

--- a/docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md
+++ b/docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md
@@ -1,8 +1,8 @@
 ---
-status: stable
-last_updated: 2026-06-12
+status: archived
+last_updated: 2026-06-13
 owner: jer
-tags: [implementation, v22.0, gate-0, governance, maintenance]
+tags: [implementation, archive, v22.0, gate-0, governance, maintenance]
 ---
 
 # v22.0 Autonomous Gate 0 Maintenance Pass (2026-06-12)
@@ -415,7 +415,7 @@ Commands run from the repo root:
 14. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/event-replay-policy.test.ts` - passed (`4` tests).
 15. `node node_modules/eslint/bin/eslint.js lib/pilot/event-replay-policy.ts tests/lib/pilot/event-replay-policy.test.ts` - passed.
 16. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts` - passed (`32` tests).
-17. `node node_modules/prettier/bin/prettier.cjs --check docs/runbooks/offline-local-recovery.md docs/runbooks/README.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+17. `node node_modules/prettier/bin/prettier.cjs --check docs/runbooks/offline-local-recovery.md docs/runbooks/README.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 18. `node node_modules/vitest/vitest.mjs run tests/lib/offline/pilot-draft-cleanup.test.ts tests/components/AuthProvider.test.tsx` - passed (`8` tests).
 19. `node node_modules/eslint/bin/eslint.js lib/offline/pilot-draft-cleanup.ts components/layout/AuthProvider.tsx tests/lib/offline/pilot-draft-cleanup.test.ts tests/components/AuthProvider.test.tsx` - passed.
 20. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/components/AuthProvider.test.tsx` - passed (`40` tests).
@@ -433,7 +433,7 @@ Commands run from the repo root:
 32. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/responses.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/components/AuthProvider.test.tsx tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`110` tests).
 33. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`14` tests).
 34. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-35. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+35. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 36. `node --import tsx scripts/check-references.ts` - passed (`143` files checked).
 37. `git diff --check` - passed.
 38. `bash scripts/check-v22-evidence-intake.sh` - passed.
@@ -442,7 +442,7 @@ Commands run from the repo root:
 41. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 42. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-metrics-recompute.test.ts` - passed (`21` tests).
 43. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts tests/api/pilot-metrics-recompute.test.ts` - passed.
-44. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+44. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 45. `node --import tsx scripts/check-references.ts` - passed (`143` files checked).
 46. `git diff --check` - passed.
 47. `node node_modules/typescript/bin/tsc --noEmit` - passed.
@@ -450,17 +450,17 @@ Commands run from the repo root:
 49. `bash scripts/check-v22-evidence-intake.sh` - passed.
 50. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 51. Static OpenAPI route-contract check with the bundled desktop Node runtime - passed after adding full internal pilot route path coverage.
-52. Bundled desktop Node `prettier --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+52. Bundled desktop Node `prettier --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 53. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`26` tests).
 54. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-55. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+55. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 56. `bash -n scripts/check-v22-threat-model.sh && bash scripts/check-v22-threat-model.sh` - passed.
 57. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-threat-model.test.ts` - passed (`5` tests).
 58. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-threat-model.test.ts` - passed.
 59. `npm run check:v22-threat-model` - passed.
 60. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result after threat-model guard integration: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 61. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-threat-model.test.ts tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`40` tests).
-62. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-threat-model.test.ts package.json .github/workflows/ci.yml README.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts` - passed.
+62. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-threat-model.test.ts package.json .github/workflows/ci.yml README.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts` - passed.
 63. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
 64. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-threat-model.test.ts tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/unit/openapi-pilot-events.test.ts` - passed.
 65. `node node_modules/typescript/bin/tsc --noEmit` - passed.
@@ -470,7 +470,7 @@ Commands run from the repo root:
 69. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 70. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts` - passed (`41` tests).
 71. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts` - passed.
-72. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+72. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 73. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 74. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 75. `git diff --check` - passed.
@@ -481,7 +481,7 @@ Commands run from the repo root:
 80. `node node_modules/eslint/bin/eslint.js tests/lib/pilot/storage.test.ts` - passed.
 81. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`95` tests).
 82. `node node_modules/eslint/bin/eslint.js tests/lib/pilot/storage.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/unit/openapi-pilot-events.test.ts` - passed.
-83. `node node_modules/prettier/bin/prettier.cjs --check tests/lib/pilot/storage.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts` - passed.
+83. `node node_modules/prettier/bin/prettier.cjs --check tests/lib/pilot/storage.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts` - passed.
 84. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 85. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 86. `git diff --check` - passed.
@@ -490,7 +490,7 @@ Commands run from the repo root:
 89. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 90. `node node_modules/vitest/vitest.mjs run tests/unit/documentation-hygiene.test.ts` - passed (`14` tests).
 91. `node node_modules/eslint/bin/eslint.js tests/unit/documentation-hygiene.test.ts` - passed.
-92. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-evidence/c2-retention/README.md docs/implementation/v22-0-evidence/c2-retention/C2-20260329.md tests/unit/documentation-hygiene.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+92. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-evidence/c2-retention/README.md docs/implementation/v22-0-evidence/c2-retention/C2-20260329.md tests/unit/documentation-hygiene.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 93. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 94. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 95. `git diff --check` - passed.
@@ -499,7 +499,7 @@ Commands run from the repo root:
 98. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 99. `node node_modules/vitest/vitest.mjs run tests/unit/documentation-hygiene.test.ts` - passed (`15` tests).
 100. `node node_modules/eslint/bin/eslint.js tests/unit/documentation-hygiene.test.ts` - passed.
-101. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-phase-0-baseline-report-2026-03-09.md tests/unit/documentation-hygiene.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting the maintenance log.
+101. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-phase-0-baseline-report-2026-03-09.md tests/unit/documentation-hygiene.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting the maintenance log.
 102. `git diff --check` - passed.
 103. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 104. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
@@ -508,7 +508,7 @@ Commands run from the repo root:
 107. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 108. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts` - passed (`8` tests).
 109. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts` - passed.
-110. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting the maintenance log.
+110. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting the maintenance log.
 111. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`40` tests).
 112. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed.
 113. `node node_modules/typescript/bin/tsc --noEmit` - passed.
@@ -521,7 +521,7 @@ Commands run from the repo root:
 120. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-integration-feasibility.test.ts` - passed.
 121. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-integration-feasibility.test.ts tests/api/v1/pilot-referral.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`44` tests).
 122. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-integration-feasibility.test.ts tests/api/v1/pilot-referral.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed.
-123. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-integration-feasibility.test.ts tests/api/v1/pilot-referral.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+123. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-integration-feasibility.test.ts tests/api/v1/pilot-referral.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 124. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 125. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 126. `git diff --check` - passed.
@@ -532,7 +532,7 @@ Commands run from the repo root:
 131. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts` - passed.
 132. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/schemas/pilot-events.test.ts` - passed (`64` tests).
 133. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/schemas/pilot-events.test.ts` - passed.
-134. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+134. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 135. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 136. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 137. `git diff --check` - passed.
@@ -543,7 +543,7 @@ Commands run from the repo root:
 142. `node node_modules/eslint/bin/eslint.js tests/api/pilot-instrumentation-routes.test.ts` - passed.
 143. `node node_modules/vitest/vitest.mjs run tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`114` tests).
 144. `node node_modules/eslint/bin/eslint.js tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed.
-145. `node node_modules/prettier/bin/prettier.cjs --check tests/api/pilot-instrumentation-routes.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+145. `node node_modules/prettier/bin/prettier.cjs --check tests/api/pilot-instrumentation-routes.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 146. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 147. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 148. `git diff --check` - passed.
@@ -553,7 +553,7 @@ Commands run from the repo root:
 152. `node node_modules/vitest/vitest.mjs run tests/api/pilot-metrics-recompute.test.ts` - passed (`7` tests).
 153. `node node_modules/vitest/vitest.mjs run tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/observability/pilot-metrics.test.ts tests/lib/schemas/pilot-events.test.ts` - passed (`71` tests).
 154. `node node_modules/eslint/bin/eslint.js tests/api/pilot-metrics-recompute.test.ts` - passed.
-155. `node node_modules/prettier/bin/prettier.cjs --check tests/api/pilot-metrics-recompute.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+155. `node node_modules/prettier/bin/prettier.cjs --check tests/api/pilot-metrics-recompute.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 156. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 157. `node --import tsx scripts/check-references.ts` - passed.
 158. `git diff --check` - passed.
@@ -563,7 +563,7 @@ Commands run from the repo root:
 162. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts` - passed (`15` tests).
 163. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/pilot/responses.test.ts` - passed (`122` tests).
 164. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts` - passed.
-165. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+165. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 166. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 167. `node --import tsx scripts/check-references.ts` - passed.
 168. `git diff --check` - passed.
@@ -572,7 +572,7 @@ Commands run from the repo root:
 171. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 172. `node node_modules/vitest/vitest.mjs run tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`116` tests).
 173. `node node_modules/eslint/bin/eslint.js tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed.
-174. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+174. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 175. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 176. `node --import tsx scripts/check-references.ts` - passed.
 177. `git diff --check` - passed.
@@ -582,7 +582,7 @@ Commands run from the repo root:
 181. `node node_modules/vitest/vitest.mjs run tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/pilot/responses.test.ts` - passed (`148` tests).
 182. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`38` tests).
 183. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-184. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+184. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 185. `node --import tsx scripts/check-references.ts` - passed.
 186. `git diff --check` - passed.
 187. `bash scripts/check-root-hygiene.sh` - passed.
@@ -591,7 +591,7 @@ Commands run from the repo root:
 190. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`49` tests).
 191. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`170` tests).
 192. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-193. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+193. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 194. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 195. `node --import tsx scripts/check-references.ts` - passed.
 196. `git diff --check` - passed.
@@ -601,7 +601,7 @@ Commands run from the repo root:
 200. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`50` tests).
 201. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`171` tests).
 202. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-203. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+203. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 204. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 205. `node --import tsx scripts/check-references.ts` - passed.
 206. `git diff --check` - passed.
@@ -611,7 +611,7 @@ Commands run from the repo root:
 210. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`61` tests).
 211. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`182` tests).
 212. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-213. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+213. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 214. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 215. `node --import tsx scripts/check-references.ts` - passed.
 216. `git diff --check` - passed.
@@ -621,7 +621,7 @@ Commands run from the repo root:
 220. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`85` tests).
 221. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`206` tests).
 222. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-223. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+223. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 224. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 225. `node --import tsx scripts/check-references.ts` - passed.
 226. `git diff --check` - passed.
@@ -631,7 +631,7 @@ Commands run from the repo root:
 230. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`108` tests).
 231. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`229` tests).
 232. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-233. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+233. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 234. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 235. `node --import tsx scripts/check-references.ts` - passed.
 236. `git diff --check` - passed.
@@ -641,7 +641,7 @@ Commands run from the repo root:
 240. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`118` tests).
 241. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`239` tests).
 242. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
-243. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+243. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 244. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 245. `node --import tsx scripts/check-references.ts` - passed.
 246. `git diff --check` - passed.
@@ -651,7 +651,7 @@ Commands run from the repo root:
 250. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts` - passed (`14` tests).
 251. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`20` tests).
 252. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts` - passed.
-253. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+253. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 254. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 255. `node --import tsx scripts/check-references.ts` - passed.
 256. `git diff --check` - passed.
@@ -660,7 +660,7 @@ Commands run from the repo root:
 259. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
 260. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`24` tests).
 261. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts` - passed.
-262. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+262. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 263. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 264. `node --import tsx scripts/check-references.ts` - passed.
 265. `git diff --check` - passed.
@@ -670,7 +670,7 @@ Commands run from the repo root:
 269. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts` - passed (`10` tests).
 270. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`25` tests).
 271. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts` - passed.
-272. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+272. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 273. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 274. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 275. `git diff --check` - passed.
@@ -680,7 +680,7 @@ Commands run from the repo root:
 279. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts` - passed (`15` tests).
 280. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`26` tests).
 281. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts lib/offline/pilot-draft-cleanup.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts` - passed.
-282. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts lib/offline/pilot-draft-cleanup.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/lib/offline/local-recovery-audit.test.ts`.
+282. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts lib/offline/pilot-draft-cleanup.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `tests/lib/offline/local-recovery-audit.test.ts`.
 283. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 284. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 285. `git diff --check` - passed.
@@ -689,7 +689,7 @@ Commands run from the repo root:
 288. `node node_modules/vitest/vitest.mjs run tests/lib/offline/feedback.test.ts` - passed (`10` tests).
 289. `node node_modules/vitest/vitest.mjs run tests/lib/offline/feedback.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/offline/OfflineSync.test.tsx tests/components/AuthProvider.test.tsx` - passed (`54` tests).
 290. `node node_modules/eslint/bin/eslint.js lib/offline/feedback.ts tests/lib/offline/feedback.test.ts` - passed.
-291. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/feedback.ts tests/lib/offline/feedback.test.ts docs/runbooks/offline-local-recovery.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `lib/offline/feedback.ts` and `docs/security/v22-0-offline-local-threat-model.md`.
+291. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/feedback.ts tests/lib/offline/feedback.test.ts docs/runbooks/offline-local-recovery.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `lib/offline/feedback.ts` and `docs/security/v22-0-offline-local-threat-model.md`.
 292. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 293. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 294. `git diff --check` - passed.
@@ -698,7 +698,7 @@ Commands run from the repo root:
 297. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts` - passed (`6` tests).
 298. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts` - passed (`84` tests).
 299. `node node_modules/eslint/bin/eslint.js lib/pilot/storage.ts tests/lib/pilot/storage.test.ts` - passed.
-300. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/storage.ts tests/lib/pilot/storage.test.ts docs/runbooks/pilot-event-replay.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/security/v22-0-offline-local-threat-model.md`.
+300. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/storage.ts tests/lib/pilot/storage.test.ts docs/runbooks/pilot-event-replay.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `docs/security/v22-0-offline-local-threat-model.md`.
 301. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 302. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 303. `git diff --check` - passed.
@@ -707,7 +707,7 @@ Commands run from the repo root:
 306. `node node_modules/vitest/vitest.mjs run tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx` - passed (`24` tests).
 307. `node node_modules/vitest/vitest.mjs run tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx tests/lib/offline/feedback.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/ui/OfflineBanner.test.tsx tests/components/AuthProvider.test.tsx` - passed (`70` tests) after retrying an intermittent WSL transport failure.
 308. `node node_modules/eslint/bin/eslint.js lib/offline/sync.ts components/offline/OfflineSync.tsx tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx` - passed.
-309. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/sync.ts components/offline/OfflineSync.tsx tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx docs/runbooks/offline-local-recovery.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/security/v22-0-offline-local-threat-model.md` and `docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md`.
+309. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/sync.ts components/offline/OfflineSync.tsx tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx docs/runbooks/offline-local-recovery.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `docs/security/v22-0-offline-local-threat-model.md` and `docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md`.
 310. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 311. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 312. `git diff --check` - passed.
@@ -715,7 +715,7 @@ Commands run from the repo root:
 314. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
 315. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`7` tests).
 316. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
-317. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+317. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 318. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 319. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`190` tests).
 320. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
@@ -725,7 +725,7 @@ Commands run from the repo root:
 324. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`8` tests).
 325. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`191` tests).
 326. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
-327. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/lib/pilot/readiness-audit.test.ts`.
+327. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `tests/lib/pilot/readiness-audit.test.ts`.
 328. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 329. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 330. `git diff --check` - passed.
@@ -734,7 +734,7 @@ Commands run from the repo root:
 333. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`9` tests).
 334. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`192` tests).
 335. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
-336. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+336. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 337. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 338. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 339. `git diff --check` - passed.
@@ -742,7 +742,7 @@ Commands run from the repo root:
 341. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
 342. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`11` tests).
 343. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
-344. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `lib/pilot/readiness-audit.ts`.
+344. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `lib/pilot/readiness-audit.ts`.
 345. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 346. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`194` tests).
 347. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
@@ -751,7 +751,7 @@ Commands run from the repo root:
 350. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`12` tests).
 351. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 352. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
-353. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/scripts/check-v22-evidence-intake.test.ts`.
+353. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `tests/scripts/check-v22-evidence-intake.test.ts`.
 354. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 355. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 356. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
@@ -759,7 +759,7 @@ Commands run from the repo root:
 358. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`14` tests).
 359. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 360. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
-361. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md`.
+361. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md`.
 362. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 363. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 364. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
@@ -767,7 +767,7 @@ Commands run from the repo root:
 366. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`16` tests).
 367. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 368. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
-369. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/scripts/check-v22-evidence-intake.test.ts`.
+369. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `tests/scripts/check-v22-evidence-intake.test.ts`.
 370. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 371. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 372. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
@@ -775,7 +775,7 @@ Commands run from the repo root:
 374. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`18` tests).
 375. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 376. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
-377. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+377. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 378. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 379. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 380. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
@@ -783,7 +783,7 @@ Commands run from the repo root:
 382. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`21` tests).
 383. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 384. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
-385. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md`.
+385. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting `docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md`.
 386. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 387. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 388. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
@@ -791,7 +791,7 @@ Commands run from the repo root:
 390. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`22` tests).
 391. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 392. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
-393. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+393. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 394. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 395. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 396. `git diff --check` - passed.
@@ -800,7 +800,7 @@ Commands run from the repo root:
 399. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`25` tests).
 400. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 401. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
-402. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-evidence/c1-partner-terms/ARTIFACT_INVENTORY_TEMPLATE.md docs/implementation/v22-0-evidence/c1-partner-terms/C1-20260428-artifact-inventory.md docs/implementation/v22-0-evidence/c1-partner-terms/README.md docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting the C1 prep inventory scaffold.
+402. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-evidence/c1-partner-terms/ARTIFACT_INVENTORY_TEMPLATE.md docs/implementation/v22-0-evidence/c1-partner-terms/C1-20260428-artifact-inventory.md docs/implementation/v22-0-evidence/c1-partner-terms/README.md docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed after formatting the C1 prep inventory scaffold.
 403. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 404. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 405. `git diff --check` - passed.
@@ -809,29 +809,29 @@ Commands run from the repo root:
 408. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`27` tests).
 409. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 410. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
-411. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+411. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 412. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 413. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 414. `git diff --check` - passed after retrying a transient WSL transport failure.
 415. `bash scripts/check-root-hygiene.sh` - passed.
 416. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
-417. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-evidence/c1-partner-terms/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-evidence/c1-partner-terms/README.md docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-evidence/d4-partner-ops/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+417. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-evidence/c1-partner-terms/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-evidence/c1-partner-terms/README.md docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-evidence/d4-partner-ops/README.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md` - passed.
 418. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 419. `git diff --check` - passed.
 420. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
 421. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`29` tests).
 422. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
 423. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
-424. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-evidence/d4-partner-ops/ARTIFACT_INVENTORY_TEMPLATE.md docs/implementation/v22-0-evidence/d4-partner-ops/D4-20260428-artifact-inventory.md docs/implementation/v22-0-evidence/d4-partner-ops/README.md docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md docs/implementation/v22-0-worktree-checkpoint-2026-06-13.md` - passed after formatting the D4 prep inventory scaffold, sync runbook, script tests, and maintenance ledger.
+424. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-evidence/d4-partner-ops/ARTIFACT_INVENTORY_TEMPLATE.md docs/implementation/v22-0-evidence/d4-partner-ops/D4-20260428-artifact-inventory.md docs/implementation/v22-0-evidence/d4-partner-ops/README.md docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md docs/implementation/v22-0-worktree-checkpoint-2026-06-13.md` - passed after formatting the D4 prep inventory scaffold, sync runbook, script tests, and maintenance ledger.
 425. `node node_modules/typescript/bin/tsc --noEmit` - passed.
 426. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
 427. `git diff --check` - passed.
 428. `bash scripts/check-root-hygiene.sh` - passed.
 429. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
 
-The desktop shell did not expose `npm` on WSL `PATH`, so validation used the
-Linux Node runtime at `/home/jer/.cache/codex-node-v24.14.0-linux-x64/bin/node`
-directly with repo-local `node_modules`. WSL later became intermittently
+The desktop shell did not expose `npm` on WSL `PATH`, so validation used an
+available Linux Node runtime directly with repo-local `node_modules`.
+WSL later became intermittently
 unavailable with `Wsl/Service/E_UNEXPECTED`, so the final path-coverage-only
 OpenAPI assertion was also checked with the bundled desktop Node runtime.
 

--- a/docs/implementation/archive/README.md
+++ b/docs/implementation/archive/README.md
@@ -1,6 +1,19 @@
-# Archived Implementation Summaries
+---
+status: stable
+last_updated: 2026-06-13
+owner: jer
+tags: [implementation, archive]
+---
 
-Historical implementation records from v17.4–v19.0.
-Preserved for reference and audit trail.
+# Archived Implementation Records
 
-Moved here during the v22.0 code quality remediation.
+Historical implementation records preserved for reference and audit trail.
+
+## Recent Records
+
+- [2026-06-13 v22.0 Autonomous Gate 0 Maintenance](2026-06-13-v22-0-autonomous-gate0-maintenance.md) - completed repo-local Gate 0 maintenance checkpoint while C1/D4 evidence remained externally blocked.
+
+## Historical Summaries
+
+Most older records in this directory were moved here during the v22.0 code
+quality remediation and cover v17.4-v19.0 implementation work.

--- a/docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md
+++ b/docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md
@@ -1,0 +1,845 @@
+---
+status: stable
+last_updated: 2026-06-12
+owner: jer
+tags: [implementation, v22.0, gate-0, governance, maintenance]
+---
+
+# v22.0 Autonomous Gate 0 Maintenance Pass (2026-06-12)
+
+## Purpose
+
+Make safe autonomous progress while Gate 0 remains blocked on user-owned C1
+legal evidence and D4 partner-operations evidence.
+
+This pass intentionally does not close `UA-1`, `UA-3`, `G0-3`, `G0-8`, or
+Gate 0. No partner names, legal conclusions, outreach facts, service data, or
+production instructions were generated.
+
+## Constraints
+
+1. Leave C1 and D4 pending until real evidence exists.
+2. Improve evidence discipline without requiring private operations material.
+3. Keep changes repo-local and boundary-safe.
+4. Add validation that can run before a future Gate 0 re-review.
+
+## Options Considered
+
+| Option                                            | Assessment                                                                                                              | Decision       |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------- |
+| Docs-only cleanup                                 | Low risk but weak; future reviewers could still accidentally mark prep-only evidence as closure.                        | Not sufficient |
+| Add the full Gate 0 decision guard to normal CI   | Not viable while Gate 0 intentionally remains `NO-GO`; would block unrelated safe maintenance.                          | Rejected       |
+| Add evidence-intake guard to normal validation    | Viable after targeted tests proved it passes pending-state docs while blocking false closure states.                    | Chosen         |
+| Targeted evidence-intake guard                    | Directly protects the active blocker surface without changing app behavior or gate status.                              | Chosen         |
+| Add DB-level pilot replay constraints             | Not safe autonomously because it would require a migration and live-schema preflight.                                   | Deferred       |
+| Define replay criteria in code and runbook        | Safe repo-local progress that makes the future duplicate-suppression implementation testable.                           | Chosen         |
+| Use existing event primary keys for retries       | Backward-compatible no-migration path for atomic supplied-ID retry suppression.                                         | Chosen         |
+| Suppress semantic duplicates without event IDs    | Not safe without a new stored fingerprint/unique index or a non-atomic pre-query.                                       | Rejected       |
+| Keep duplicate responses inline per route         | Works but leaves six routes open to cache/status/body drift.                                                            | Rejected       |
+| Centralize pilot write responses                  | Small, testable helper keeps create and idempotent retry responses consistent.                                          | Chosen         |
+| Add a pilot draft table/store now                 | Not justified because no current pilot draft queue exists and a new persistence surface raises risk.                    | Rejected       |
+| Add reserved-prefix draft cleanup on sign-out     | Safe no-op for current behavior that gives future pilot drafts a tested expiry and cleanup contract.                    | Chosen         |
+| Document existing pilot scope route in OpenAPI    | Safe contract alignment for an implemented internal endpoint; no runtime, data, auth, or DB change.                     | Chosen         |
+| Add supplied-ID duplicate response to scope       | Misaligned with current route semantics; scope uses upsert and returns `201` success.                                   | Rejected       |
+| Document existing metrics recompute route         | Safe contract alignment for an implemented internal endpoint and tested route behavior.                                 | Chosen         |
+| Change recompute to return `201` or snapshots     | Not a contract-alignment task; changing response semantics could affect existing clients/tests.                         | Rejected       |
+| Add a threat-model consistency guard              | Safe enforcement of the documented Gate 0 security rule without changing finding verification status.                   | Chosen         |
+| Auto-close high/medium threat-model findings      | Requires manual QA, integration, or dry-run evidence that is not available autonomously.                                | Rejected       |
+| Align remaining pilot response schemas            | Safe OpenAPI-only hardening for already-tested internal route behavior.                                                 | Chosen         |
+| Refactor pilot route response bodies              | Unnecessary for contract alignment and could create runtime/client risk.                                                | Rejected       |
+| Add pilot storage resilience coverage             | Existing storage code already uses `withCircuitBreaker`; tests can pin the contract without churn.                      | Chosen         |
+| Rewrite pilot storage around a new abstraction    | Higher risk and unnecessary while the current storage seam is small and already circuit-wrapped.                        | Rejected       |
+| Align stale C2 evidence wording                   | Safe docs consistency fix using existing C2 verification evidence already present in the repo.                          | Chosen         |
+| Re-open C2 or invent new verification evidence    | Not justified; existing C2 docs contain completed read-only verification evidence.                                      | Rejected       |
+| Clarify baseline report sign-off wording          | Safe docs consistency fix: M1/M3 execution is recorded, while formal sign-off remains non-gating.                       | Chosen         |
+| Mark baseline product/governance sign-off done    | Would invent formal sign-off evidence.                                                                                  | Rejected       |
+| Add route tests for documented success envelopes  | Safe coverage hardening for existing referral update and integration-feasibility behavior.                              | Chosen         |
+| Change response helpers for these routes          | Unnecessary; routes already return the documented envelope and no-store headers.                                        | Rejected       |
+| Add integration-feasibility error-path tests      | Safe route coverage for documented `401/429/501/500` behavior without changing runtime code.                            | Chosen         |
+| Broaden integration route behavior now            | Not needed; the existing route behavior matches the documented internal contract.                                       | Rejected       |
+| Add referral update error-path tests              | Safe route coverage for documented protected update behavior without changing runtime code.                             | Chosen         |
+| Change referral update authorization semantics    | Not safe or necessary; existing `assertPermission` behavior is already the intended protection path.                    | Rejected       |
+| Add shared instrumentation rate-limit tests       | Safe coverage for documented `429` behavior across existing internal pilot instrumentation routes.                      | Chosen         |
+| Refactor instrumentation route rate limiting      | Unnecessary; existing route behavior is consistent and only needed test coverage.                                       | Rejected       |
+| Add metrics-recompute rate-limit coverage         | Safe coverage for documented `429` behavior on the existing internal recompute route.                                   | Chosen         |
+| Change recompute limiter/auth ordering            | Not needed; the route already fails fast on rate limit before authenticated work.                                       | Rejected       |
+| Add referral create error-path tests              | Safe route coverage for existing protected create behavior without changing runtime code.                               | Chosen         |
+| Change referral create response semantics         | Not needed; existing success, retry, storage, and error envelopes are now covered by tests.                             | Rejected       |
+| Document and test pilot JSON `415` responses      | Safe contract alignment for existing shared content-type validation on internal JSON write routes.                      | Chosen         |
+| Change content-type enforcement behavior          | Not needed; current shared `validateContentType` behavior already matches the privacy-safe contract.                    | Rejected       |
+| Derive OpenAPI route coverage from filesystem     | Safe test-only guard that prevents new internal pilot routes from silently missing contract docs.                       | Chosen         |
+| Keep route documentation guard hardcoded only     | Too easy for future route additions to bypass until someone remembers to update the test inventory.                     | Rejected       |
+| Derive OpenAPI method coverage from route files   | Safe test-only guard that catches undocumented implemented `GET/POST/PATCH` pilot methods.                              | Chosen         |
+| Assume documented path implies documented method  | Too weak; a path can exist in OpenAPI while a new route method remains undocumented.                                    | Rejected       |
+| Assert OpenAPI pilot paths match implemented set  | Safe test-only guard that prevents stale pilot contract paths from outliving removed routes.                            | Chosen         |
+| Allow stale planned pilot paths in OpenAPI        | Rejected for internal routes; the public-safe contract should describe implemented behavior.                            | Rejected       |
+| Assert OpenAPI methods match route exports        | Safe test-only guard that prevents stale method docs under otherwise valid pilot paths.                                 | Chosen         |
+| Keep method coverage one-way only                 | Too weak; it catches missing methods but not stale documented methods after route changes.                              | Rejected       |
+| Validate local OpenAPI component refs             | Safe test-only guard that catches broken schema/response refs without adding a YAML parser dependency.                  | Chosen         |
+| Add a new OpenAPI parser dependency               | Not needed for this narrow guard; existing string checks can validate local refs with lower churn.                      | Rejected       |
+| Guard pilot OpenAPI operation metadata            | Safe test-only guard that keeps internal pilot operations cookie-authenticated and uniquely named.                      | Chosen         |
+| Change runtime auth from contract test work       | Not needed; this slice verifies the documented contract rather than changing authorization behavior.                    | Rejected       |
+| Derive pilot JSON-write contract checks           | Safe test-only guard that removes a hardcoded write-route list and follows implemented non-GET routes.                  | Chosen         |
+| Keep JSON-write coverage manually listed          | Too easy for future write routes to miss request-body or `415` contract checks.                                         | Rejected       |
+| Add recovery snapshot freshness status            | Safe aggregate diagnostic improvement using the existing offline stale/fresh policy.                                    | Chosen         |
+| Add raw queue inspection to recovery diagnostics  | Rejected; recovery evidence must remain aggregate-only and avoid raw payload exposure.                                  | Rejected       |
+| Add aggregate recovery recommendations            | Safe dry-run support that turns aggregate diagnostics into non-destructive next-action IDs.                             | Chosen         |
+| Add destructive recovery actions to helper        | Rejected; destructive clearing requires queue preservation evidence and owner judgment.                                 | Rejected       |
+| Return `null` for uninspectable draft counts      | Safer than a false zero when browser storage access is blocked or unavailable.                                          | Chosen         |
+| Treat inaccessible draft storage as empty         | Rejected; it could hide local draft data during recovery triage.                                                        | Rejected       |
+| Sanitize offline recovery warning metadata        | Safe privacy hardening; aggregate diagnostics do not need raw exception objects or messages.                            | Chosen         |
+| Keep raw recovery exceptions in warning logs      | Rejected; local storage/browser errors can contain details that are not needed for public-safe triage.                  | Rejected       |
+| Normalize offline feedback queue payloads         | Safe local hardening that makes stored/replayed payloads match the public feedback API schema.                          | Chosen         |
+| Replay queued feedback exactly as stored          | Rejected; legacy empty optional fields can make valid offline votes fail later API validation.                          | Rejected       |
+| Delete invalid queued feedback immediately        | Rejected for now; invalid items follow the existing retry-count policy without being sent to the API.                   | Rejected       |
+| Restrict idempotent retry suppression to PKs      | Safe storage hardening; future semantic unique constraints should not be silently treated as retries.                   | Chosen         |
+| Suppress every duplicate-key error with an ID     | Rejected; too broad once replay/fingerprint unique constraints are introduced.                                          | Rejected       |
+| Sanitize offline sync failure metadata            | Safe privacy hardening for local recovery diagnostics and background sync logs.                                         | Chosen         |
+| Return raw sync exceptions to UI callers          | Rejected; raw browser/network exceptions are not needed for recovery triage.                                            | Rejected       |
+| Validate pilot readiness scope inputs             | Safe governance hardening; malformed scope evidence should fail closed before producing audit outputs.                  | Chosen         |
+| Trust readiness scope files and DB rows as typed  | Rejected; unchecked casts can turn malformed partner scope inputs into misleading readiness reports.                    | Rejected       |
+| Neutralize readiness CSV formula prefixes         | Safe worksheet hardening for audit outputs that may be opened in spreadsheet software.                                  | Chosen         |
+| Leave readiness CSV cells unmodified              | Rejected; formula-like service names or reviewer fields could be interpreted by spreadsheet software.                   | Rejected       |
+| Reject duplicate readiness scope identities       | Safe governance hardening; repeated scope rows should not inflate readiness audit counts.                               | Chosen         |
+| Deduplicate readiness scope rows silently         | Rejected; silent dedupe can hide upstream scope-prep errors that should be corrected before review.                     | Rejected       |
+| Tighten D4 outreach CSV structure checks          | Safe evidence-discipline hardening for future closure attempts without judging outreach sufficiency.                    | Chosen         |
+| Accept any D4 outreach CSV shape                  | Rejected; malformed logs could pass structure checks while lacking dated traceability.                                  | Rejected       |
+| Validate closure submission dates and counts      | Safe evidence-discipline hardening for dated, attributable C1/D4 closure packets.                                       | Chosen         |
+| Accept free-form closure dates and count text     | Rejected; malformed dates/counts weaken auditability and can pass current placeholder-only checks.                      | Rejected       |
+| Require C1 non-pass rationale and fallback        | Safe evidence-structure hardening; non-pass clause rows need auditable rationale and fallback fields.                   | Chosen         |
+| Accept bare C1 non-pass matrix outcomes           | Rejected; a failed/conditional clause without rationale or fallback is not auditable closure evidence.                  | Rejected       |
+| Enforce C1 clause matrix header and row count     | Safe evidence-structure hardening; duplicate or malformed matrix rows make closure evidence ambiguous.                  | Chosen         |
+| Read the first matching C1 matrix row only        | Rejected; silently ignoring duplicate clause rows can hide contradictory closure evidence.                              | Rejected       |
+| Enforce D4 partner-list header, types, duplicates | Safe evidence-structure hardening; partner target counts must come from unambiguous rows.                               | Chosen         |
+| Count loose D4 partner-list type text             | Rejected; broad substring matching can count ambiguous or placeholder partner type values.                              | Rejected       |
+| Cross-check D4 submitted counts against artifacts | Safe evidence-structure hardening; submitted counts should match the attached traceability artifacts.                   | Chosen         |
+| Trust D4 submitted counts without cross-checking  | Rejected; count text can drift from partner-list and outreach-log evidence.                                             | Rejected       |
+| Require C1 artifact inventory traceability        | Safe evidence-structure hardening; C1 source artifacts need auditable mapping without storing private raw files in git. | Chosen         |
+| Trust C1 matrix source text without inventory     | Rejected; matrix source labels can drift from the attached review bundle and weaken closure auditability.               | Rejected       |
+| Require closure Submission ID filename match      | Safe evidence-structure hardening; dated closure packets should have one unambiguous identity across file and content.  | Chosen         |
+| Trust mismatched submission identifiers           | Rejected; mismatched IDs make evidence packets harder to audit and can route checks to the wrong dated artifacts.       | Rejected       |
+| Require D4 artifact inventory traceability        | Safe evidence-structure hardening; outreach source artifacts need auditable mapping without storing private raw files.  | Chosen         |
+| Trust D4 outreach source text without inventory   | Rejected; outreach-log source labels can drift from the attached execution bundle and weaken closure auditability.      | Rejected       |
+
+## Implementation
+
+1. Added `scripts/check-v22-evidence-intake.sh`.
+2. Added `npm run check:v22-evidence`.
+3. Wired the evidence-intake guard into `npm run check:v22-gate0` before the
+   final GO/NO-GO decision check.
+4. Added fixture-oriented Vitest coverage for the guard in
+   `tests/scripts/check-v22-evidence-intake.test.ts`.
+5. Hardened `scripts/check-v22-gate0-exit.sh` so `NO-GO` blocking checks must
+   match the actual non-`pass` required-check rows.
+6. Added fixture-oriented Vitest coverage for the Gate 0 decision guard in
+   `tests/scripts/check-v22-gate0-exit.test.ts`.
+7. Added `npm run check:v22-evidence` to local CI validation and GitHub static
+   analysis.
+8. Updated the intake pack, sync runbook, action tracker, and README command
+   reference.
+9. Hardened `lib/schemas/privacy-guards.ts` so pilot/integration payload
+   validation rejects raw personal contact and free-text field names in addition
+   to raw query/message/notes fields.
+10. Added focused schema coverage for the expanded privacy guard in
+    `tests/lib/schemas/privacy-guards.test.ts` and
+    `tests/lib/schemas/pilot-events.test.ts`.
+11. Updated `docs/security/v22-0-offline-local-threat-model.md` with a
+    repo-local mitigation evidence audit that preserves the unverified status of
+    local queue expiry, replay suppression, and corruption recovery findings.
+12. Added `lib/pilot/event-replay-policy.ts` with deterministic privacy-safe
+    replay fingerprints for pilot event payloads.
+13. Added `tests/lib/pilot/event-replay-policy.test.ts` coverage for stable
+    fingerprints, criteria changes, event-kind separation, and ignoring fields
+    outside the replay criteria.
+14. Added the public-safe
+    `docs/runbooks/pilot-event-replay.md` summary and linked it from the
+    runbook index.
+15. Added the public-safe `docs/runbooks/offline-local-recovery.md` summary for
+    aggregate queue audit, non-destructive re-sync, and destructive-clearing
+    safeguards, and linked it from the runbook index.
+16. Added `lib/offline/pilot-draft-cleanup.ts` with reserved-prefix pilot draft
+    TTL, expired/malformed envelope pruning, and sign-out cleanup helpers.
+17. Wired pilot draft cleanup into `components/layout/AuthProvider.tsx` before
+    Supabase sign-out.
+18. Added focused coverage in `tests/lib/offline/pilot-draft-cleanup.test.ts`
+    and `tests/components/AuthProvider.test.tsx`.
+19. Updated `docs/runbooks/offline-local-recovery.md` and
+    `docs/security/v22-0-offline-local-threat-model.md` to record F2 as
+    code-covered but not fully verified because no actual pilot draft queue or
+    manual QA evidence exists.
+20. Added `lib/offline/local-recovery-audit.ts` to build a privacy-preserving
+    local recovery snapshot with only aggregate cache, queue, draft-key, and
+    sync-metadata counts.
+21. Added `tests/lib/offline/local-recovery-audit.test.ts` coverage showing the
+    helper avoids queued payload reads and omits internal error details from
+    returned snapshots.
+22. Added optional client event UUID `id` support to pilot event create schemas.
+23. Updated pilot event storage so duplicate primary-key conflicts are treated
+    as idempotent retries only when a client event `id` was supplied.
+24. Updated pilot event create routes to return no-store `200` responses with
+    `duplicate: true` for those supplied-ID retries.
+25. Added schema, storage, and route coverage for supplied-ID idempotent retry
+    handling.
+26. Updated `docs/api/openapi.yaml` so pilot event create endpoints document
+    optional client event IDs and supplied-ID duplicate retry responses.
+27. Added `tests/unit/openapi-pilot-events.test.ts` to pin the documented pilot
+    event OpenAPI contract.
+28. Added `lib/pilot/responses.ts` to centralize no-store pilot create success
+    and idempotent retry responses.
+29. Updated pilot event create routes to use the shared pilot response helper.
+30. Added `tests/lib/pilot/responses.test.ts` for helper-level response
+    contract coverage.
+31. Documented the existing `POST /api/v1/pilot/scope/services` internal route
+    in `docs/api/openapi.yaml` with its privacy-safe payload schema.
+32. Extended `tests/unit/openapi-pilot-events.test.ts` to pin the pilot scope
+    OpenAPI contract and its current `201` success behavior.
+33. Documented the existing `POST /api/v1/pilot/metrics/recompute` internal
+    route in `docs/api/openapi.yaml` with its privacy-safe selector and current
+    success envelope.
+34. Extended `tests/unit/openapi-pilot-events.test.ts` to pin the recompute
+    OpenAPI contract, including `200` success and `501` storage-readiness
+    behavior.
+35. Added OpenAPI path-presence coverage for all implemented internal pilot
+    routes listed in the v22 Phase 0 plan.
+36. Added `scripts/check-v22-threat-model.sh` to validate that the offline/local
+    threat-model mitigation matrix and Gate 0 security outcome stay internally
+    consistent.
+37. Added `tests/scripts/check-v22-threat-model.test.ts` fixture coverage for
+    high findings with pending verification, unresolved critical findings,
+    incomplete high-finding metadata, contradictory Gate 0 security outcomes,
+    and placeholder sign-off lines.
+38. Added `npm run check:v22-threat-model`, wired it into local CI validation,
+    GitHub static analysis, and the Gate 0 release guard.
+39. Updated the README command reference and threat-model automation note.
+40. Updated `docs/api/openapi.yaml` so referral update and integration
+    feasibility success responses document their existing `success: true`
+    envelope.
+41. Updated `docs/api/openapi.yaml` so pilot scorecard responses document the
+    scorecard envelope, optional Gate 1 threshold evaluation, and existing
+    `404` not-found response.
+42. Extended `tests/unit/openapi-pilot-events.test.ts` to pin those response
+    contracts.
+43. Expanded `tests/lib/pilot/storage.test.ts` to pin circuit-breaker wrapping
+    for representative insert, update, and read storage paths.
+44. Updated the C2 retention evidence README and C2-20260329 field-level rows
+    so they reference the existing completed read-only verification evidence
+    instead of stale pending-evidence wording.
+45. Added documentation-hygiene coverage to keep C2 retention evidence aligned
+    with the Gate 0 `G0-4` pass state.
+46. Updated the Phase 0 baseline report sign-off note so it no longer says the
+    report is waiting on database execution context after M1/M3 execution was
+    recorded.
+47. Added documentation-hygiene coverage to keep baseline execution evidence
+    distinct from still-pending product/governance sign-off fields.
+48. Added route coverage proving referral update and integration-feasibility
+    success paths return the documented `success: true` envelopes with
+    `Cache-Control: no-store`.
+49. Added integration-feasibility route coverage for rate limit, unauthenticated
+    access, missing pilot storage, and storage failure responses.
+50. Added referral update route coverage for rate limit, unauthenticated access,
+    authorization failure, missing pilot storage, and storage failure responses.
+51. Added shared instrumentation-route coverage for rate-limit responses across
+    connection, scope, service-status, data-decay-audit, and preference-fit
+    writes.
+52. Added metrics-recompute route coverage for rate-limit responses and the
+    authenticated-work short-circuit.
+53. Added referral create route coverage for rate limit, unauthenticated access,
+    authorization failure, invalid payloads, missing pilot storage, storage
+    failure, and the no-store success envelope.
+54. Added pilot JSON write route coverage for unsupported media type responses
+    and documented the existing `415` contract in OpenAPI.
+55. Updated the OpenAPI pilot contract test to derive implemented pilot route
+    paths from `app/api/v1/pilot/**/route.ts`, including Next dynamic segment
+    mapping from `[id]` to `{id}`.
+56. Extended the OpenAPI pilot contract test to derive exported HTTP methods
+    from each implemented `route.ts` file and assert the matching OpenAPI
+    method block is documented.
+57. Added a symmetric OpenAPI pilot path inventory check so documented
+    `/pilot/...` paths must exactly match implemented pilot route files.
+58. Added a symmetric OpenAPI pilot method inventory check so documented HTTP
+    method blocks must exactly match exported route methods for each pilot path.
+59. Added a deduplicated local OpenAPI component reference check for
+    `#/components/schemas/*` and `#/components/responses/*` refs.
+60. Added OpenAPI pilot operation metadata checks for documented `cookieAuth`,
+    valid `operationId` fields, and unique pilot operation IDs.
+61. Replaced the hardcoded pilot JSON-write path list with derived non-GET
+    route operations, and asserted each documents an `application/json` request
+    body plus the existing `415` response.
+62. Extended the offline local recovery snapshot with `lastSyncStatus` using
+    the existing offline snapshot freshness policy, and documented the aggregate
+    diagnostic in the public recovery runbook.
+63. Added `buildOfflineLocalRecoveryPlan()` to convert aggregate recovery
+    snapshots into non-destructive recommendation IDs for dry-run notes.
+64. Made pilot draft storage counts nullable when `localStorage` or
+    `sessionStorage` cannot be inspected, and mapped unknown draft counts to the
+    non-destructive `inspect_browser_storage` recommendation.
+65. Sanitized offline local recovery and pilot draft cleanup warning metadata
+    so logs carry storage class and error type only, not raw exception objects
+    or messages.
+66. Moved sign-out draft storage lookup inside each guarded cleanup block so
+    blocked `localStorage` access does not prevent `sessionStorage` cleanup.
+67. Added offline feedback queue payload normalization through
+    `FeedbackSubmitSchema` before IndexedDB storage and before API replay.
+68. Removed empty optional strings from queued feedback payloads so offline
+    thumbs-up/down submissions do not persist invalid `category_searched`
+    values.
+69. Added sanitized sync warnings for invalid queued feedback, API rejection,
+    and DB-access failure paths without logging raw feedback text.
+70. Tightened pilot event storage idempotency so supplied-ID duplicate retries
+    are suppressed only for primary-key or `id` key conflicts, while other
+    duplicate constraints remain storage errors.
+71. Sanitized `syncOfflineData()` failure results and warning logs so they
+    return `errorType` and optional `httpStatus` instead of raw thrown objects
+    or browser/network messages.
+72. Sanitized `OfflineSync` background warning logs for service worker
+    registration, data sync, pending feedback sync, and offline fallback
+    prewarm failures.
+73. Added fail-closed validation for pilot readiness scope entries loaded from
+    JSON files or Supabase before generating audit outputs.
+74. Sanitized Supabase pilot scope load failures and invalid-scope errors so
+    readiness tooling reports field paths and error codes without raw row
+    values, partner notes, or database messages.
+75. Neutralized spreadsheet formula prefixes in pilot readiness CSV output so
+    generated verification worksheets treat formula-like text as text.
+76. Applied the pilot readiness scope validator inside
+    `buildPilotReadinessReport()` as well as the file and Supabase loaders, so
+    direct report-builder callers cannot bypass malformed-scope checks.
+77. Added duplicate pilot readiness scope identity detection for
+    `(pilot_cycle_id, org_id, service_id)` so repeated rows fail closed instead
+    of inflating audit counts.
+78. Tightened the D4 outreach log evidence-intake guard to require the
+    canonical CSV header, `YYYY-MM-DD` dates, positive attempt numbers, and
+    `source_artifact` traceability on execution rows.
+79. Updated the Gate 0 evidence intake pack and sync runbook to document the
+    machine-enforced D4 outreach CSV structure.
+80. Tightened C1 and D4 closure submission validation so required submission
+    dates must use `YYYY-MM-DD` and D4 target/contact-attempt counts must be
+    positive integers.
+81. Updated the Gate 0 evidence intake pack and sync runbook to document the
+    machine-enforced closure submission date and count structure.
+82. Tightened C1 clause-matrix validation so non-pass outcomes require both
+    `Notes / rationale` and `Required mitigation or fallback` values.
+83. Updated the Gate 0 evidence intake pack and sync runbook to document the
+    machine-enforced C1 non-pass rationale and fallback structure.
+84. Tightened C1 clause-matrix validation so closure evidence must use the
+    canonical matrix header and include exactly one row for each required
+    clause ID (`C1-1` through `C1-4`).
+85. Updated the Gate 0 evidence intake pack and sync runbook to document the
+    machine-enforced C1 matrix header and exact-row structure.
+86. Tightened D4 partner-list validation so closure evidence must use the
+    canonical partner-list header, exact partner types, and no duplicate
+    organization / partner rows.
+87. Updated the Gate 0 evidence intake pack and sync runbook to document the
+    machine-enforced D4 partner-list header, type, and duplicate-row structure.
+88. Tightened D4 closure validation so submitted target and contact-attempt
+    counts must match the attached provider rows, frontline organization rows,
+    and outreach-log execution rows.
+89. Updated the Gate 0 evidence intake pack and sync runbook to document the
+    machine-enforced D4 submission-to-artifact count consistency checks.
+90. Tightened C1 closure validation so completed legal/API review evidence must
+    include a canonical artifact inventory with non-placeholder source
+    metadata and at least one artifact marked as used in the clause matrix.
+91. Cross-checked C1 clause-matrix source artifact values against inventory
+    Artifact ID and Filename / location values marked `Used in clause matrix`
+    = `yes`.
+92. Added the reusable C1 artifact inventory template and updated the C1
+    evidence README, intake pack, and sync runbook to document the
+    machine-enforced artifact traceability checks.
+93. Normalized Markdown table header comparisons in the evidence-intake guard
+    so formatter-aligned table spacing does not fail otherwise canonical C1/D4
+    evidence headers.
+94. Added a regression fixture for formatter-aligned C1 matrix, C1 inventory,
+    and D4 partner-list headers.
+95. Normalized the existing prep-only C1 artifact inventory scaffold to match
+    the canonical inventory column names while preserving its `prep_only`
+    status.
+96. Tightened C1 and D4 closure validation so the `Submission ID` line must be
+    present and match the dated submission filename prefix.
+97. Added fixture coverage for mismatched C1 and D4 submission IDs.
+98. Updated the Gate 0 evidence intake pack and sync runbook to document the
+    machine-enforced submission-ID-to-filename consistency check.
+99. Updated the C1 and D4 evidence submission templates and README files so
+    future closure packets state the same submission-ID-to-filename rule at the
+    source.
+100. Tightened D4 closure validation so completed partner-operations evidence
+     must include a canonical artifact inventory with non-placeholder source
+     metadata and at least one artifact marked as supporting an outreach-log
+     row.
+101. Cross-checked D4 outreach-log `source_artifact` values against inventory
+     Artifact ID and Filename / location values marked `Supports outreach-log
+row` = `yes`.
+102. Added the reusable D4 artifact inventory template and updated the D4
+     evidence README, submission template, intake pack, and sync runbook to
+     document the machine-enforced artifact traceability checks.
+103. Added fixture coverage for missing D4 artifact inventories and
+     outreach-log source artifacts that are absent from the inventory.
+104. Added the
+     [v22.0 Worktree Checkpoint](v22-0-worktree-checkpoint-2026-06-13.md) to
+     group the current worktree by review theme and recommend commit
+     boundaries without creating commits.
+
+## Guard Behavior
+
+The guard is status-aware:
+
+1. Pending `UA-1/G0-3` and `UA-3/G0-8` may have only `prep_only` artifacts.
+2. Complete/pass C1 requires a non-prep C1 submission, artifact inventory, and
+   clause matrix with non-placeholder reviewer, artifact, clause, and
+   recommendation fields, plus a `Submission ID` matching the submission
+   filename.
+3. Complete/pass D4 requires a non-prep D4 submission, partner list, outreach
+   log, and artifact inventory with non-placeholder owner, target-count, dated
+   execution, and source-artifact traceability fields, plus a `Submission ID`
+   matching the submission filename.
+4. The guard checks evidence structure and doc consistency only. It does not
+   determine whether legal terms are acceptable or whether outreach evidence is
+   strategically sufficient.
+
+## Verification
+
+Commands run from the repo root:
+
+1. `bash scripts/check-v22-evidence-intake.sh` - passed; current pending C1/D4 state is internally consistent.
+2. `bash -n scripts/check-v22-evidence-intake.sh` - passed.
+3. `bash -n scripts/check-v22-gate0-exit.sh` - passed.
+4. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+5. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts` - passed (`9` tests).
+6. `node --import tsx scripts/check-references.ts` - passed (`143` files checked).
+7. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts` - passed.
+8. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+9. `bash scripts/check-root-hygiene.sh` - passed.
+10. `git diff --check` - passed.
+11. `node node_modules/prettier/bin/prettier.cjs --check ...` - passed after formatting new implementation/test artifacts.
+12. `node node_modules/vitest/vitest.mjs run tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts` - passed (`19` tests).
+13. `node node_modules/eslint/bin/eslint.js lib/schemas/privacy-guards.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts` - passed.
+14. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/event-replay-policy.test.ts` - passed (`4` tests).
+15. `node node_modules/eslint/bin/eslint.js lib/pilot/event-replay-policy.ts tests/lib/pilot/event-replay-policy.test.ts` - passed.
+16. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts` - passed (`32` tests).
+17. `node node_modules/prettier/bin/prettier.cjs --check docs/runbooks/offline-local-recovery.md docs/runbooks/README.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+18. `node node_modules/vitest/vitest.mjs run tests/lib/offline/pilot-draft-cleanup.test.ts tests/components/AuthProvider.test.tsx` - passed (`8` tests).
+19. `node node_modules/eslint/bin/eslint.js lib/offline/pilot-draft-cleanup.ts components/layout/AuthProvider.tsx tests/lib/offline/pilot-draft-cleanup.test.ts tests/components/AuthProvider.test.tsx` - passed.
+20. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/components/AuthProvider.test.tsx` - passed (`40` tests).
+21. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts` - passed (`3` tests).
+22. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts` - passed.
+23. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/components/AuthProvider.test.tsx` - passed (`43` tests).
+24. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/lib/schemas/pilot-events.test.ts` - passed (`67` tests).
+25. `node node_modules/eslint/bin/eslint.js lib/pilot/storage.ts lib/schemas/pilot-events.ts app/api/v1/pilot/events/contact-attempt/route.ts app/api/v1/pilot/events/referral/route.ts app/api/v1/pilot/events/connection/route.ts app/api/v1/pilot/events/service-status/route.ts app/api/v1/pilot/events/data-decay-audit/route.ts app/api/v1/pilot/events/preference-fit/route.ts tests/lib/pilot/storage.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/lib/schemas/pilot-events.test.ts` - passed.
+26. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/storage.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/components/AuthProvider.test.tsx tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts` - passed (`95` tests).
+27. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`13` tests).
+28. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+29. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/storage.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/components/AuthProvider.test.tsx tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`108` tests).
+30. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/responses.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts` - passed (`51` tests).
+31. `node node_modules/eslint/bin/eslint.js lib/pilot/responses.ts tests/lib/pilot/responses.test.ts app/api/v1/pilot/events/contact-attempt/route.ts app/api/v1/pilot/events/referral/route.ts app/api/v1/pilot/events/connection/route.ts app/api/v1/pilot/events/service-status/route.ts app/api/v1/pilot/events/data-decay-audit/route.ts app/api/v1/pilot/events/preference-fit/route.ts` - passed.
+32. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/lib/schemas/privacy-guards.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/responses.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/components/AuthProvider.test.tsx tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`110` tests).
+33. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`14` tests).
+34. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+35. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+36. `node --import tsx scripts/check-references.ts` - passed (`143` files checked).
+37. `git diff --check` - passed.
+38. `bash scripts/check-v22-evidence-intake.sh` - passed.
+39. `bash scripts/check-root-hygiene.sh` - passed.
+40. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+41. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+42. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-metrics-recompute.test.ts` - passed (`21` tests).
+43. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts tests/api/pilot-metrics-recompute.test.ts` - passed.
+44. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+45. `node --import tsx scripts/check-references.ts` - passed (`143` files checked).
+46. `git diff --check` - passed.
+47. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+48. `bash scripts/check-root-hygiene.sh` - passed.
+49. `bash scripts/check-v22-evidence-intake.sh` - passed.
+50. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+51. Static OpenAPI route-contract check with the bundled desktop Node runtime - passed after adding full internal pilot route path coverage.
+52. Bundled desktop Node `prettier --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+53. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`26` tests).
+54. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+55. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+56. `bash -n scripts/check-v22-threat-model.sh && bash scripts/check-v22-threat-model.sh` - passed.
+57. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-threat-model.test.ts` - passed (`5` tests).
+58. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-threat-model.test.ts` - passed.
+59. `npm run check:v22-threat-model` - passed.
+60. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result after threat-model guard integration: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+61. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-threat-model.test.ts tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`40` tests).
+62. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-threat-model.test.ts package.json .github/workflows/ci.yml README.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts` - passed.
+63. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+64. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-threat-model.test.ts tests/scripts/check-v22-gate0-exit.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/unit/openapi-pilot-events.test.ts` - passed.
+65. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+66. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+67. `bash scripts/check-root-hygiene.sh` - passed.
+68. `git diff --check` - passed.
+69. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+70. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts` - passed (`41` tests).
+71. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts` - passed.
+72. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+73. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+74. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+75. `git diff --check` - passed.
+76. `bash scripts/check-root-hygiene.sh` - passed.
+77. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+78. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+79. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts` - passed (`5` tests).
+80. `node node_modules/eslint/bin/eslint.js tests/lib/pilot/storage.test.ts` - passed.
+81. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`95` tests).
+82. `node node_modules/eslint/bin/eslint.js tests/lib/pilot/storage.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/unit/openapi-pilot-events.test.ts` - passed.
+83. `node node_modules/prettier/bin/prettier.cjs --check tests/lib/pilot/storage.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md docs/api/openapi.yaml tests/unit/openapi-pilot-events.test.ts` - passed.
+84. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+85. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+86. `git diff --check` - passed.
+87. `bash scripts/check-root-hygiene.sh` - passed.
+88. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+89. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+90. `node node_modules/vitest/vitest.mjs run tests/unit/documentation-hygiene.test.ts` - passed (`14` tests).
+91. `node node_modules/eslint/bin/eslint.js tests/unit/documentation-hygiene.test.ts` - passed.
+92. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-evidence/c2-retention/README.md docs/implementation/v22-0-evidence/c2-retention/C2-20260329.md tests/unit/documentation-hygiene.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+93. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+94. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+95. `git diff --check` - passed.
+96. `bash scripts/check-root-hygiene.sh` - passed.
+97. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+98. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+99. `node node_modules/vitest/vitest.mjs run tests/unit/documentation-hygiene.test.ts` - passed (`15` tests).
+100. `node node_modules/eslint/bin/eslint.js tests/unit/documentation-hygiene.test.ts` - passed.
+101. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-phase-0-baseline-report-2026-03-09.md tests/unit/documentation-hygiene.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting the maintenance log.
+102. `git diff --check` - passed.
+103. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+104. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+105. `bash scripts/check-root-hygiene.sh` - passed.
+106. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+107. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+108. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts` - passed (`8` tests).
+109. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts` - passed.
+110. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting the maintenance log.
+111. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`40` tests).
+112. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed.
+113. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+114. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+115. `bash scripts/check-root-hygiene.sh` - passed.
+116. `git diff --check` - passed.
+117. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+118. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+119. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-integration-feasibility.test.ts` - passed (`7` tests).
+120. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-integration-feasibility.test.ts` - passed.
+121. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-integration-feasibility.test.ts tests/api/v1/pilot-referral.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`44` tests).
+122. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-integration-feasibility.test.ts tests/api/v1/pilot-referral.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed.
+123. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-integration-feasibility.test.ts tests/api/v1/pilot-referral.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+124. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+125. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+126. `git diff --check` - passed.
+127. `bash scripts/check-root-hygiene.sh` - passed.
+128. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+129. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+130. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts` - passed (`9` tests).
+131. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts` - passed.
+132. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/schemas/pilot-events.test.ts` - passed (`64` tests).
+133. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/schemas/pilot-events.test.ts` - passed.
+134. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+135. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+136. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+137. `git diff --check` - passed.
+138. `bash scripts/check-root-hygiene.sh` - passed.
+139. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+140. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+141. `node node_modules/vitest/vitest.mjs run tests/api/pilot-instrumentation-routes.test.ts` - passed (`40` tests).
+142. `node node_modules/eslint/bin/eslint.js tests/api/pilot-instrumentation-routes.test.ts` - passed.
+143. `node node_modules/vitest/vitest.mjs run tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`114` tests).
+144. `node node_modules/eslint/bin/eslint.js tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed.
+145. `node node_modules/prettier/bin/prettier.cjs --check tests/api/pilot-instrumentation-routes.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+146. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+147. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+148. `git diff --check` - passed.
+149. `bash scripts/check-root-hygiene.sh` - passed.
+150. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+151. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+152. `node node_modules/vitest/vitest.mjs run tests/api/pilot-metrics-recompute.test.ts` - passed (`7` tests).
+153. `node node_modules/vitest/vitest.mjs run tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/observability/pilot-metrics.test.ts tests/lib/schemas/pilot-events.test.ts` - passed (`71` tests).
+154. `node node_modules/eslint/bin/eslint.js tests/api/pilot-metrics-recompute.test.ts` - passed.
+155. `node node_modules/prettier/bin/prettier.cjs --check tests/api/pilot-metrics-recompute.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+156. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+157. `node --import tsx scripts/check-references.ts` - passed.
+158. `git diff --check` - passed.
+159. `bash scripts/check-root-hygiene.sh` - passed.
+160. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+161. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+162. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts` - passed (`15` tests).
+163. `node node_modules/vitest/vitest.mjs run tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/pilot/responses.test.ts` - passed (`122` tests).
+164. `node node_modules/eslint/bin/eslint.js tests/api/v1/pilot-referral.test.ts` - passed.
+165. `node node_modules/prettier/bin/prettier.cjs --check tests/api/v1/pilot-referral.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+166. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+167. `node --import tsx scripts/check-references.ts` - passed.
+168. `git diff --check` - passed.
+169. `bash scripts/check-root-hygiene.sh` - passed.
+170. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+171. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+172. `node node_modules/vitest/vitest.mjs run tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`116` tests).
+173. `node node_modules/eslint/bin/eslint.js tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed.
+174. `node node_modules/prettier/bin/prettier.cjs --check docs/api/openapi.yaml tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+175. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+176. `node --import tsx scripts/check-references.ts` - passed.
+177. `git diff --check` - passed.
+178. `bash scripts/check-root-hygiene.sh` - passed.
+179. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+180. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+181. `node node_modules/vitest/vitest.mjs run tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts tests/lib/pilot/responses.test.ts` - passed (`148` tests).
+182. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`38` tests).
+183. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+184. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+185. `node --import tsx scripts/check-references.ts` - passed.
+186. `git diff --check` - passed.
+187. `bash scripts/check-root-hygiene.sh` - passed.
+188. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+189. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+190. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`49` tests).
+191. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`170` tests).
+192. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+193. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+194. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+195. `node --import tsx scripts/check-references.ts` - passed.
+196. `git diff --check` - passed.
+197. `bash scripts/check-root-hygiene.sh` - passed.
+198. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+199. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+200. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`50` tests).
+201. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`171` tests).
+202. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+203. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+204. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+205. `node --import tsx scripts/check-references.ts` - passed.
+206. `git diff --check` - passed.
+207. `bash scripts/check-root-hygiene.sh` - passed.
+208. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+209. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+210. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`61` tests).
+211. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`182` tests).
+212. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+213. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+214. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+215. `node --import tsx scripts/check-references.ts` - passed.
+216. `git diff --check` - passed.
+217. `bash scripts/check-root-hygiene.sh` - passed.
+218. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+219. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+220. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`85` tests).
+221. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`206` tests).
+222. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+223. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+224. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+225. `node --import tsx scripts/check-references.ts` - passed.
+226. `git diff --check` - passed.
+227. `bash scripts/check-root-hygiene.sh` - passed.
+228. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+229. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+230. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`108` tests).
+231. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`229` tests).
+232. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+233. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+234. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+235. `node --import tsx scripts/check-references.ts` - passed.
+236. `git diff --check` - passed.
+237. `bash scripts/check-root-hygiene.sh` - passed.
+238. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+239. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+240. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts` - passed (`118` tests).
+241. `node node_modules/vitest/vitest.mjs run tests/unit/openapi-pilot-events.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/v1/pilot-referral.test.ts tests/api/v1/pilot-integration-feasibility.test.ts tests/api/pilot-metrics-recompute.test.ts tests/api/pilot-scorecard.test.ts tests/api/v1/pilot-scorecard.test.ts tests/lib/schemas/pilot-events.test.ts tests/lib/schemas/integration-feasibility.test.ts` - passed (`239` tests).
+242. `node node_modules/eslint/bin/eslint.js tests/unit/openapi-pilot-events.test.ts` - passed.
+243. `node node_modules/prettier/bin/prettier.cjs --check tests/unit/openapi-pilot-events.test.ts docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+244. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+245. `node --import tsx scripts/check-references.ts` - passed.
+246. `git diff --check` - passed.
+247. `bash scripts/check-root-hygiene.sh` - passed.
+248. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+249. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+250. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts` - passed (`14` tests).
+251. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`20` tests).
+252. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts` - passed.
+253. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+254. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+255. `node --import tsx scripts/check-references.ts` - passed.
+256. `git diff --check` - passed.
+257. `bash scripts/check-root-hygiene.sh` - passed.
+258. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+259. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+260. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`24` tests).
+261. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts` - passed.
+262. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+263. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+264. `node --import tsx scripts/check-references.ts` - passed.
+265. `git diff --check` - passed.
+266. `bash scripts/check-root-hygiene.sh` - passed.
+267. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+268. `bash scripts/check-v22-gate0-exit.sh` - expected blocked result: evidence intake and threat-model checks pass, then Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`.
+269. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts` - passed (`10` tests).
+270. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`25` tests).
+271. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts` - passed.
+272. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts tests/lib/offline/local-recovery-audit.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+273. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+274. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+275. `git diff --check` - passed.
+276. `bash scripts/check-root-hygiene.sh` - passed.
+277. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh` - passed.
+278. `if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: evidence intake and threat-model checks pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+279. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts` - passed (`15` tests).
+280. `node node_modules/vitest/vitest.mjs run tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/AuthProvider.test.tsx` - passed (`26` tests).
+281. `node node_modules/eslint/bin/eslint.js lib/offline/local-recovery-audit.ts lib/offline/pilot-draft-cleanup.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts` - passed.
+282. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/local-recovery-audit.ts lib/offline/pilot-draft-cleanup.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts docs/runbooks/offline-local-recovery.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/lib/offline/local-recovery-audit.test.ts`.
+283. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+284. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+285. `git diff --check` - passed.
+286. `bash scripts/check-root-hygiene.sh` - passed.
+287. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+288. `node node_modules/vitest/vitest.mjs run tests/lib/offline/feedback.test.ts` - passed (`10` tests).
+289. `node node_modules/vitest/vitest.mjs run tests/lib/offline/feedback.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/offline/OfflineSync.test.tsx tests/components/AuthProvider.test.tsx` - passed (`54` tests).
+290. `node node_modules/eslint/bin/eslint.js lib/offline/feedback.ts tests/lib/offline/feedback.test.ts` - passed.
+291. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/feedback.ts tests/lib/offline/feedback.test.ts docs/runbooks/offline-local-recovery.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `lib/offline/feedback.ts` and `docs/security/v22-0-offline-local-threat-model.md`.
+292. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+293. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+294. `git diff --check` - passed.
+295. `bash scripts/check-root-hygiene.sh` - passed.
+296. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+297. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts` - passed (`6` tests).
+298. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-contact-attempt.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/v1/pilot-referral.test.ts` - passed (`84` tests).
+299. `node node_modules/eslint/bin/eslint.js lib/pilot/storage.ts tests/lib/pilot/storage.test.ts` - passed.
+300. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/storage.ts tests/lib/pilot/storage.test.ts docs/runbooks/pilot-event-replay.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/security/v22-0-offline-local-threat-model.md`.
+301. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+302. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+303. `git diff --check` - passed.
+304. `bash scripts/check-root-hygiene.sh` - passed.
+305. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+306. `node node_modules/vitest/vitest.mjs run tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx` - passed (`24` tests).
+307. `node node_modules/vitest/vitest.mjs run tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx tests/lib/offline/feedback.test.ts tests/lib/offline/local-recovery-audit.test.ts tests/lib/offline/pilot-draft-cleanup.test.ts tests/lib/offline/snapshot.test.ts tests/components/offline/OfflineSnapshotStatus.test.tsx tests/components/ui/OfflineBanner.test.tsx tests/components/AuthProvider.test.tsx` - passed (`70` tests) after retrying an intermittent WSL transport failure.
+308. `node node_modules/eslint/bin/eslint.js lib/offline/sync.ts components/offline/OfflineSync.tsx tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx` - passed.
+309. `node node_modules/prettier/bin/prettier.cjs --check lib/offline/sync.ts components/offline/OfflineSync.tsx tests/unit/lib/offline/sync.test.ts tests/components/offline/OfflineSync.test.tsx docs/runbooks/offline-local-recovery.md docs/security/v22-0-offline-local-threat-model.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/security/v22-0-offline-local-threat-model.md` and `docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md`.
+310. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+311. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+312. `git diff --check` - passed.
+313. `bash scripts/check-root-hygiene.sh` - passed after retrying an intermittent WSL transport timeout.
+314. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+315. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`7` tests).
+316. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
+317. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+318. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+319. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`190` tests).
+320. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+321. `git diff --check` - passed.
+322. `bash scripts/check-root-hygiene.sh` - passed.
+323. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+324. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`8` tests).
+325. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`191` tests).
+326. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
+327. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/lib/pilot/readiness-audit.test.ts`.
+328. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+329. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+330. `git diff --check` - passed.
+331. `bash scripts/check-root-hygiene.sh` - passed.
+332. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+333. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`9` tests).
+334. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`192` tests).
+335. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
+336. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+337. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+338. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+339. `git diff --check` - passed.
+340. `bash scripts/check-root-hygiene.sh` - passed.
+341. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+342. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts` - passed (`11` tests).
+343. `node node_modules/eslint/bin/eslint.js lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts` - passed.
+344. `node node_modules/prettier/bin/prettier.cjs --check lib/pilot/readiness-audit.ts tests/lib/pilot/readiness-audit.test.ts docs/implementation/v22-pilot-readiness/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `lib/pilot/readiness-audit.ts`.
+345. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+346. `node node_modules/vitest/vitest.mjs run tests/lib/pilot/readiness-audit.test.ts tests/lib/pilot/storage.test.ts tests/lib/pilot/event-replay-policy.test.ts tests/lib/pilot/responses.test.ts tests/api/pilot-instrumentation-routes.test.ts tests/api/pilot-metrics-recompute.test.ts tests/unit/openapi-pilot-events.test.ts` - passed (`194` tests).
+347. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+348. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
+349. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+350. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`12` tests).
+351. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+352. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
+353. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/scripts/check-v22-evidence-intake.test.ts`.
+354. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+355. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+356. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
+357. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+358. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`14` tests).
+359. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+360. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
+361. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md`.
+362. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+363. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+364. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
+365. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+366. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`16` tests).
+367. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+368. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
+369. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `tests/scripts/check-v22-evidence-intake.test.ts`.
+370. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+371. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+372. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
+373. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+374. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`18` tests).
+375. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+376. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
+377. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+378. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+379. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+380. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
+381. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+382. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`21` tests).
+383. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+384. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts` - passed.
+385. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting `docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md`.
+386. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+387. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+388. `git diff --check && bash scripts/check-root-hygiene.sh` - passed.
+389. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+390. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`22` tests).
+391. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+392. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
+393. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+394. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+395. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+396. `git diff --check` - passed.
+397. `bash scripts/check-root-hygiene.sh` - passed.
+398. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+399. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`25` tests).
+400. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+401. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
+402. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-evidence/c1-partner-terms/ARTIFACT_INVENTORY_TEMPLATE.md docs/implementation/v22-0-evidence/c1-partner-terms/C1-20260428-artifact-inventory.md docs/implementation/v22-0-evidence/c1-partner-terms/README.md docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed after formatting the C1 prep inventory scaffold.
+403. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+404. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+405. `git diff --check` - passed.
+406. `bash scripts/check-root-hygiene.sh` - passed.
+407. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+408. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`27` tests).
+409. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+410. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
+411. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+412. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+413. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+414. `git diff --check` - passed after retrying a transient WSL transport failure.
+415. `bash scripts/check-root-hygiene.sh` - passed.
+416. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+417. `node node_modules/prettier/bin/prettier.cjs --check docs/implementation/v22-0-evidence/c1-partner-terms/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-evidence/c1-partner-terms/README.md docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-evidence/d4-partner-ops/README.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md` - passed.
+418. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+419. `git diff --check` - passed.
+420. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+421. `node node_modules/vitest/vitest.mjs run tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed (`29` tests).
+422. `bash -n scripts/check-v22-evidence-intake.sh && bash -n scripts/check-v22-gate0-exit.sh && bash -n scripts/check-v22-threat-model.sh` - passed.
+423. `node node_modules/eslint/bin/eslint.js tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts` - passed.
+424. `node node_modules/prettier/bin/prettier.cjs --check tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts docs/implementation/v22-0-evidence/d4-partner-ops/ARTIFACT_INVENTORY_TEMPLATE.md docs/implementation/v22-0-evidence/d4-partner-ops/D4-20260428-artifact-inventory.md docs/implementation/v22-0-evidence/d4-partner-ops/README.md docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md docs/implementation/v22-0-gate-0-evidence-intake-pack.md docs/implementation/v22-0-gate-0-evidence-sync-runbook.md docs/implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md docs/implementation/v22-0-worktree-checkpoint-2026-06-13.md` - passed after formatting the D4 prep inventory scaffold, sync runbook, script tests, and maintenance ledger.
+425. `node node_modules/typescript/bin/tsc --noEmit` - passed.
+426. `node --import tsx scripts/check-references.ts` - passed (`144` files checked).
+427. `git diff --check` - passed.
+428. `bash scripts/check-root-hygiene.sh` - passed.
+429. `bash scripts/check-v22-threat-model.sh && bash scripts/check-v22-evidence-intake.sh && if bash scripts/check-v22-gate0-exit.sh; then echo GATE0_EXIT_ZERO; else echo GATE0_EXIT_NONZERO; fi` - expected blocked result: consistency guards pass, Gate 0 remains `NO-GO` with blocking checks `G0-3`, `G0-8`, and the guard exits nonzero.
+
+The desktop shell did not expose `npm` on WSL `PATH`, so validation used the
+Linux Node runtime at `/home/jer/.cache/codex-node-v24.14.0-linux-x64/bin/node`
+directly with repo-local `node_modules`. WSL later became intermittently
+unavailable with `Wsl/Service/E_UNEXPECTED`, so the final path-coverage-only
+OpenAPI assertion was also checked with the bundled desktop Node runtime.
+
+## Remaining Work
+
+1. Obtain and attach real C1 partner legal/API terms before any C1 closure
+   attempt.
+2. Obtain and attach real D4 named partner, outreach owner, and dated execution
+   evidence before any D4 closure attempt.
+3. Run `npm run check:v22-evidence` and `npm run check:v22-gate0` after any
+   evidence sync.

--- a/docs/implementation/v22-0-evidence/c1-partner-terms/ARTIFACT_INVENTORY_TEMPLATE.md
+++ b/docs/implementation/v22-0-evidence/c1-partner-terms/ARTIFACT_INVENTORY_TEMPLATE.md
@@ -1,0 +1,18 @@
+Artifact Inventory
+
+Review package:
+Prepared by:
+Inventory date:
+Partner:
+
+| Artifact ID | Filename / location | Artifact type | Source / owner | Date received | Used in clause matrix | Notes |
+| ----------- | ------------------- | ------------- | -------------- | ------------- | --------------------- | ----- |
+| C1-A1       |                     |               |                |               | yes / no              |       |
+
+Minimum closure check:
+
+- [ ] Candidate partner contract terms attached or accessible in the approved evidence location
+- [ ] Candidate API terms attached, or absence explicitly documented
+- [ ] Analytics, retention, audit, and re-identification addenda attached when applicable
+- [ ] Every clause-matrix source artifact appears as an Artifact ID or Filename / location in this inventory
+- [ ] At least one inventory artifact is marked `Used in clause matrix` = `yes`

--- a/docs/implementation/v22-0-evidence/c1-partner-terms/README.md
+++ b/docs/implementation/v22-0-evidence/c1-partner-terms/README.md
@@ -13,10 +13,10 @@ Recommended dated contents:
 
 1. `C1-YYYYMMDD-submission.md` based on [SUBMISSION_TEMPLATE.md](SUBMISSION_TEMPLATE.md)
 2. `C1-YYYYMMDD-clause-matrix.md` based on [CLAUSE_MATRIX_TEMPLATE.md](CLAUSE_MATRIX_TEMPLATE.md)
-3. Candidate partner contract terms
-4. Candidate API terms
-5. Any addenda covering analytics, retention, audit, or re-identification
-6. Optional artifact inventory if the source bundle spans multiple files or screenshots
+3. `C1-YYYYMMDD-artifact-inventory.md` based on [ARTIFACT_INVENTORY_TEMPLATE.md](ARTIFACT_INVENTORY_TEMPLATE.md)
+4. Candidate partner contract terms
+5. Candidate API terms
+6. Any addenda covering analytics, retention, audit, or re-identification
 
 Prepared draft packet:
 
@@ -30,16 +30,21 @@ review evidence until real candidate terms and reviewer notes are attached.
 Minimum review contents:
 
 1. Named source artifacts used for the review
-2. Clause-by-clause outcomes for `C1-1` through `C1-4`
-3. Any blocking clause with explicit `reject` or `acceptable_with_conditions` disposition
-4. Final legal recommendation with reviewer and date
+2. Submission ID that matches the dated submission filename prefix
+3. An artifact inventory mapping clause-matrix source artifacts to an Artifact ID
+   or Filename / location
+4. Clause-by-clause outcomes for `C1-1` through `C1-4`
+5. Any blocking clause with explicit `reject` or `acceptable_with_conditions` disposition
+6. Final legal recommendation with reviewer and date
 
 Suggested workflow:
 
 1. Drop the source terms into this folder with dated filenames.
 2. Fill the submission template with reviewer metadata and the artifact list.
-3. Fill the clause matrix against the exact source sections/pages reviewed.
-4. Sync the final outcome back to the control and gate-tracker documents only after the review is complete.
+3. Fill the artifact inventory with each reviewed Artifact ID and Filename /
+   location.
+4. Fill the clause matrix against the exact source sections/pages reviewed.
+5. Sync the final outcome back to the control and gate-tracker documents only after the review is complete.
 
 This folder prepares the bundle location only. C1 remains pending until the review is complete and synced back to:
 

--- a/docs/implementation/v22-0-evidence/c1-partner-terms/SUBMISSION_TEMPLATE.md
+++ b/docs/implementation/v22-0-evidence/c1-partner-terms/SUBMISSION_TEMPLATE.md
@@ -1,4 +1,5 @@
 Submission ID: C1-YYYYMMDD
+Submission ID rule: must match the dated filename prefix, for example `C1-YYYYMMDD-submission.md`.
 Submitted by:
 Reviewer:
 Date:

--- a/docs/implementation/v22-0-evidence/c2-retention/C2-20260329.md
+++ b/docs/implementation/v22-0-evidence/c2-retention/C2-20260329.md
@@ -9,37 +9,37 @@ Field-level policy table:
   retention_window: `365 days`
   deletion_trigger: `time_based`, `decision_superseded`
   deletion_executor: `manual_governance_runbook`
-  verification_evidence: pending dated read-only query output
+  verification_evidence: C2-20260329 read-only verification query output below
 
 - field: `decision_date`
   retention_window: `365 days`
   deletion_trigger: `time_based`, `decision_superseded`
   deletion_executor: `manual_governance_runbook`
-  verification_evidence: pending dated read-only query output
+  verification_evidence: C2-20260329 read-only verification query output below
 
 - field: `redline_checklist_version`
   retention_window: `365 days`
   deletion_trigger: `time_based`, `decision_superseded`
   deletion_executor: `manual_governance_runbook`
-  verification_evidence: pending dated read-only query output
+  verification_evidence: C2-20260329 read-only verification query output below
 
 - field: `violations[]`
   retention_window: `365 days`
   deletion_trigger: `time_based`, `decision_superseded`
   deletion_executor: `manual_governance_runbook`
-  verification_evidence: pending dated read-only query output
+  verification_evidence: C2-20260329 read-only verification query output below
 
 - field: `compensating_controls[]`
   retention_window: `365 days`
   deletion_trigger: `time_based`, `decision_superseded`
   deletion_executor: `manual_governance_runbook`
-  verification_evidence: pending dated read-only query output
+  verification_evidence: C2-20260329 read-only verification query output below
 
 - field: `owners[]`
   retention_window: `365 days`
   deletion_trigger: `time_based`, `decision_superseded`
   deletion_executor: `manual_governance_runbook`
-  verification_evidence: pending dated read-only query output
+  verification_evidence: C2-20260329 read-only verification query output below
 
 Privacy sign-off:
 

--- a/docs/implementation/v22-0-evidence/c2-retention/README.md
+++ b/docs/implementation/v22-0-evidence/c2-retention/README.md
@@ -16,8 +16,9 @@ Prepared artifacts already in repo:
 3. Code-backed proposal in `lib/config/pilot-retention.ts`
 4. Approved submission bundle: [C2-20260329](C2-20260329.md)
 
-Human-supplied artifacts still required:
+Attached human-supplied artifacts:
 
-1. Dated verification evidence showing the agreed deletion path behavior
+1. Dated read-only verification evidence in [C2-20260329](C2-20260329.md)
 
-Use [SUBMISSION_TEMPLATE.md](SUBMISSION_TEMPLATE.md) for the actual evidence submission.
+Use [SUBMISSION_TEMPLATE.md](SUBMISSION_TEMPLATE.md) for any future C2 evidence
+refresh.

--- a/docs/implementation/v22-0-evidence/d4-partner-ops/ARTIFACT_INVENTORY_TEMPLATE.md
+++ b/docs/implementation/v22-0-evidence/d4-partner-ops/ARTIFACT_INVENTORY_TEMPLATE.md
@@ -1,0 +1,18 @@
+Artifact Inventory
+
+Submission ID: D4-YYYYMMDD
+Prepared by:
+Inventory date:
+Outreach owner:
+
+| Artifact ID | Filename / location | Artifact type | Source / owner | Date captured | Supports outreach-log row | Notes |
+| ----------- | ------------------- | ------------- | -------------- | ------------- | ------------------------- | ----- |
+| D4-A1       |                     |               |                |               | yes / no                  |       |
+
+Minimum closure check:
+
+- [ ] Named pilot partner list artifact recorded
+- [ ] Dated contact-attempt artifacts recorded
+- [ ] Every outreach-log `source_artifact` appears as an Artifact ID or Filename / location in this inventory
+- [ ] At least one inventory artifact is marked `Supports outreach-log row` = `yes`
+- [ ] Remaining gaps and fallback artifacts are documented when applicable

--- a/docs/implementation/v22-0-evidence/d4-partner-ops/README.md
+++ b/docs/implementation/v22-0-evidence/d4-partner-ops/README.md
@@ -14,8 +14,9 @@ Recommended dated contents:
 1. `D4-YYYYMMDD-submission.md` based on [SUBMISSION_TEMPLATE.md](SUBMISSION_TEMPLATE.md)
 2. `D4-YYYYMMDD-partner-list.md` based on [PARTNER_LIST_TEMPLATE.md](PARTNER_LIST_TEMPLATE.md)
 3. `D4-YYYYMMDD-outreach-log.csv` based on [OUTREACH_LOG_TEMPLATE.csv](OUTREACH_LOG_TEMPLATE.csv)
-4. Dated email exports, screenshots, or CRM notes that support the outreach log
-5. Optional `D4-YYYYMMDD-coverage-note.md` if targeted counts or gaps need narrative context
+4. `D4-YYYYMMDD-artifact-inventory.md` based on [ARTIFACT_INVENTORY_TEMPLATE.md](ARTIFACT_INVENTORY_TEMPLATE.md)
+5. Dated email exports, screenshots, or CRM notes that support the outreach log
+6. Optional `D4-YYYYMMDD-coverage-note.md` if targeted counts or gaps need narrative context
 
 Prepared draft packet:
 
@@ -31,15 +32,20 @@ contact attempts are attached.
 Minimum execution contents:
 
 1. Named pilot partner list that matches the D4 target range
-2. Explicit outreach owner
-3. Dated contact attempts with outcome/status detail
-4. Remaining gaps called out directly instead of inferred from silence
+2. Submission ID that matches the dated submission filename prefix
+3. Artifact inventory mapping outreach-log source artifacts to an Artifact ID or
+   Filename / location
+4. Explicit outreach owner
+5. Dated contact attempts with outcome/status detail
+6. Remaining gaps called out directly instead of inferred from silence
 
 Suggested workflow:
 
 1. Fill the partner list first so target coverage is explicit.
 2. Record each dated contact attempt in the outreach log as evidence occurs.
-3. Add supporting screenshots or exports only when they materially improve audit traceability.
-4. Sync the accepted bundle back to the approval checklist and gate tracker after the evidence is complete.
+3. Fill the artifact inventory with each supporting Artifact ID and Filename /
+   location.
+4. Add supporting screenshots or exports only when they materially improve audit traceability.
+5. Sync the accepted bundle back to the approval checklist and gate tracker after the evidence is complete.
 
 This folder does not count as execution evidence until the artifacts are attached and the tracker is synchronized.

--- a/docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md
+++ b/docs/implementation/v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md
@@ -1,4 +1,5 @@
 Submission ID: D4-YYYYMMDD
+Submission ID rule: must match the dated filename prefix, for example `D4-YYYYMMDD-submission.md`.
 Submitted by:
 Date:
 Pilot partner list artifact:
@@ -6,6 +7,7 @@ Outreach owner:
 Execution evidence bundle and filenames:
 
 - outreach log
+- artifact inventory
 - dated contact attempts
 - outcomes/status notes
 - supporting screenshots or email exports (optional)

--- a/docs/implementation/v22-0-gate-0-evidence-intake-pack.md
+++ b/docs/implementation/v22-0-gate-0-evidence-intake-pack.md
@@ -1,6 +1,6 @@
 ---
 status: draft
-last_updated: 2026-04-04
+last_updated: 2026-06-12
 owner: jer
 tags: [implementation, v22.0, gate-0, evidence, intake]
 ---
@@ -64,13 +64,21 @@ Supporting templates:
 
 1. [C1 Submission Template](v22-0-evidence/c1-partner-terms/SUBMISSION_TEMPLATE.md)
 2. [C1 Clause Matrix Template](v22-0-evidence/c1-partner-terms/CLAUSE_MATRIX_TEMPLATE.md)
+3. [C1 Artifact Inventory Template](v22-0-evidence/c1-partner-terms/ARTIFACT_INVENTORY_TEMPLATE.md)
 
 Minimum evidence checks:
 
 - [ ] Partner legal/API terms bundle is attached and accessible.
-- [ ] Clause-level outcomes are provided for C1-1 through C1-4.
-- [ ] Any failed clause includes explicit rejection rationale.
+- [ ] Submission ID matches the dated submission filename prefix.
+- [ ] Artifact inventory uses the canonical template header and maps each
+      clause-matrix source artifact to an Artifact ID or Filename / location
+      marked `Used in clause matrix` = `yes`.
+- [ ] Clause matrix uses the canonical template header and exactly one row for
+      each required clause ID (`C1-1` through `C1-4`).
+- [ ] Any non-pass clause includes explicit notes/rationale and a required
+      mitigation or fallback.
 - [ ] Final legal recommendation is present and signed.
+- [ ] Submission `Date` and `Sign-off date` use `YYYY-MM-DD`.
 
 Pass rule:
 
@@ -146,21 +154,36 @@ Suggested dated artifacts:
 1. `D4-YYYYMMDD-submission.md`
 2. `D4-YYYYMMDD-partner-list.md`
 3. `D4-YYYYMMDD-outreach-log.csv`
-4. `D4-YYYYMMDD-coverage-note.md`
-5. Any dated screenshots, email exports, or CRM notes used as supporting evidence
+4. `D4-YYYYMMDD-artifact-inventory.md`
+5. `D4-YYYYMMDD-coverage-note.md`
+6. Any dated screenshots, email exports, or CRM notes used as supporting evidence
 
 Supporting templates:
 
 1. [D4 Submission Template](v22-0-evidence/d4-partner-ops/SUBMISSION_TEMPLATE.md)
 2. [D4 Partner List Template](v22-0-evidence/d4-partner-ops/PARTNER_LIST_TEMPLATE.md)
 3. [D4 Outreach Log Template](v22-0-evidence/d4-partner-ops/OUTREACH_LOG_TEMPLATE.csv)
+4. [D4 Artifact Inventory Template](v22-0-evidence/d4-partner-ops/ARTIFACT_INVENTORY_TEMPLATE.md)
 
 Minimum evidence checks:
 
 - [ ] Named pilot partner list is attached.
+- [ ] Submission ID matches the dated submission filename prefix.
+- [ ] Artifact inventory uses the canonical template header and maps each
+      outreach-log `source_artifact` to an Artifact ID or Filename / location
+      marked `Supports outreach-log row` = `yes`.
+- [ ] Partner list uses the canonical template header, no duplicate
+      organization rows, and exact partner types of `provider` or
+      `frontline organization`.
 - [ ] Outreach owner is explicitly identified.
 - [ ] Dated execution evidence bundle is attached.
 - [ ] Coverage note includes targeted counts and any remaining gaps.
+- [ ] Outreach log uses the canonical CSV header, `YYYY-MM-DD` dates, positive
+      `attempt_number` values, and a `source_artifact` reference on each
+      execution row.
+- [ ] Target and contact-attempt counts are positive integers.
+- [ ] Submitted target and contact-attempt counts match the partner-list rows
+      and outreach-log execution rows.
 
 Pass rule:
 
@@ -175,7 +198,40 @@ After any accepted submission:
 2. Sync the corresponding control/evidence docs (C1 or C2, plus approval checklist for D4).
 3. Sync [v22.0 Gate 0 Evidence Status (2026-03-09)](v22-0-gate-0-evidence-status-2026-03-09.md).
 4. Re-evaluate [v22.0 Gate 0 Exit Checklist (Decision Control)](v22-0-gate-0-exit-checklist.md).
-5. Re-run gate check (`npm run check:v22-gate0`).
+5. Re-run evidence-intake validation (`npm run check:v22-evidence`).
+6. Re-run gate check (`npm run check:v22-gate0`).
+
+## Machine Validation
+
+Use `npm run check:v22-evidence` before any Gate 0 re-review. The guard is
+status-aware:
+
+1. It passes while `UA-1/G0-3` and `UA-3/G0-8` remain pending and only
+   `prep_only` scaffolds exist.
+2. It fails if either blocker is marked `complete` or `pass` while the
+   corresponding evidence bundle is still `prep_only`.
+3. For C1 closure, it validates the canonical artifact-inventory header,
+   non-placeholder inventory rows, at least one artifact marked used in the
+   clause matrix, and clause-matrix source references against inventory Artifact
+   IDs or Filename / location values.
+4. For C1 closure, it validates the canonical matrix header, exactly one row
+   for each required clause, source references, outcomes, and
+   rationale/mitigation fields for non-pass clause outcomes.
+5. For D4 closure, it validates the artifact-inventory canonical header,
+   non-placeholder inventory rows, at least one artifact marked as supporting
+   an outreach-log row, and outreach-log `source_artifact` values against
+   inventory Artifact IDs or Filename / location values.
+6. For D4 closure, it validates the partner-list canonical header, exact
+   partner types, duplicate organization rows, target range, and the outreach
+   log's canonical header, date format, attempt numbers, and artifact
+   traceability fields.
+7. For C1/D4 closure submissions, it validates that `Submission ID` matches
+   the dated submission filename prefix, `YYYY-MM-DD` submission dates, and
+   positive integer D4 target/contact-attempt counts.
+8. It compares D4 submitted counts against the attached partner-list and
+   outreach-log artifacts.
+9. It checks only evidence-structure and status consistency. It does not make
+   legal, partner-quality, or outreach-sufficiency judgments.
 
 Detailed operator sequence:
 

--- a/docs/implementation/v22-0-gate-0-evidence-sync-runbook.md
+++ b/docs/implementation/v22-0-gate-0-evidence-sync-runbook.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_updated: 2026-04-04
+last_updated: 2026-06-12
 owner: jer
 tags: [implementation, v22.0, gate-0, evidence, runbook]
 ---
@@ -38,18 +38,40 @@ Rules:
 Confirm all of the following:
 
 1. Candidate partner legal/API terms are attached in [v22.0 Evidence Workspace / C1](v22-0-evidence/c1-partner-terms/README.md).
-2. Clause-level outcomes exist for `C1-1` through `C1-4`.
-3. Any conflicting clause is explicitly marked `reject` or `acceptable_with_conditions`.
-4. Final legal recommendation is present with reviewer and date.
+2. Submission ID matches the dated submission filename prefix.
+3. Artifact inventory uses the canonical header, includes non-placeholder
+   source metadata, marks at least one artifact as used in the clause matrix,
+   and maps each clause-matrix source artifact to an Artifact ID or Filename /
+   location.
+4. Clause matrix uses the canonical header and has exactly one row for each
+   required clause ID (`C1-1` through `C1-4`).
+5. Any non-pass clause has explicit notes/rationale and a required mitigation
+   or fallback in the clause matrix.
+6. Final legal recommendation is present with reviewer and date.
+7. Submission `Date` and `Sign-off date` use `YYYY-MM-DD`.
 
 ### `UA-3 / G0-8 / D4`
 
 Confirm all of the following:
 
 1. Named pilot partner list is attached in [v22.0 Evidence Workspace / D4](v22-0-evidence/d4-partner-ops/README.md).
-2. Outreach owner is explicitly named.
-3. Dated contact attempts are recorded in the outreach bundle.
-4. Coverage note includes targeted counts and any remaining gaps.
+2. Submission ID matches the dated submission filename prefix.
+3. Artifact inventory uses the canonical header, includes non-placeholder
+   source metadata, marks at least one artifact as supporting an outreach-log
+   row, and maps each outreach-log `source_artifact` to an Artifact ID or
+   Filename / location.
+4. Partner list uses the canonical header, exact partner types of `provider` or
+   `frontline organization`, and no duplicate organization rows.
+5. Outreach owner is explicitly named.
+6. Dated contact attempts are recorded in the outreach bundle.
+7. Coverage note includes targeted counts and any remaining gaps.
+8. The outreach log follows the canonical CSV header and each execution row has
+   a `YYYY-MM-DD` date, positive `attempt_number`, outcome, owner, and
+   `source_artifact` reference.
+9. Target and contact-attempt counts in the D4 submission are positive
+   integers.
+10. Submitted counts match the attached artifacts: provider rows, frontline
+    organization rows, and outreach-log execution rows.
 
 ## Step 2: Update the Source Record First
 
@@ -96,19 +118,21 @@ Required sync points:
 4. checklist pass/pending state
 5. overall Gate 0 decision, if all blockers are now closed
 
-## Step 4: Re-Run the Gate Check
+## Step 4: Re-Run Evidence and Gate Checks
 
 Run:
 
 ```bash
+npm run check:v22-evidence
 npm run check:v22-gate0
 ```
 
 Interpretation:
 
-1. `BLOCKED` with `G0-3` or `G0-8` is expected if only one blocker has been closed.
-2. `OK` is valid only when the checklist decision is `GO` and every `G0-*` row is `pass`.
-3. Any mismatch between the checklist and the script output means the synced docs are inconsistent and must be corrected before further work.
+1. `npm run check:v22-evidence` must pass before a closure decision is accepted.
+2. `BLOCKED` with `G0-3` or `G0-8` is expected if only one blocker has been closed.
+3. `OK` from `npm run check:v22-gate0` is valid only when the checklist decision is `GO` and every `G0-*` row is `pass`.
+4. Any mismatch between the checklist and the script output means the synced docs are inconsistent and must be corrected before further work.
 
 ## Step 5: Preserve Evidence Discipline
 

--- a/docs/implementation/v22-0-gate-0-exit-checklist.md
+++ b/docs/implementation/v22-0-gate-0-exit-checklist.md
@@ -1,6 +1,6 @@
 ---
 status: draft
-last_updated: 2026-04-28
+last_updated: 2026-06-12
 owner: jer
 tags: [implementation, v22.0, gate-0, checklist, governance]
 ---
@@ -14,6 +14,8 @@ Rule:
 1. Gate 0 exit is `GO` only if all required checks are `pass`.
 2. Any `fail` or `pending` check keeps Gate 0 at `NO-GO`.
 3. Step 1 approval lock (`D1-D7`) is necessary but not sufficient for Gate 0 exit.
+4. When the decision is `NO-GO`, the `Blocking Checks` row must match the
+   current non-`pass` required checks.
 
 Related:
 

--- a/docs/implementation/v22-0-gate-0-user-action-tracker.md
+++ b/docs/implementation/v22-0-gate-0-user-action-tracker.md
@@ -1,6 +1,6 @@
 ---
 status: draft
-last_updated: 2026-04-28
+last_updated: 2026-06-12
 owner: jer
 tags: [implementation, v22.0, gate-0, actions, governance]
 ---
@@ -39,6 +39,7 @@ Related:
 - [x] Sync control statuses in [v22.0 Integration Feasibility Decision Record](v22-0-integration-feasibility-decision.md).
 - [x] Sync evidence matrix in [v22.0 Gate 0 Evidence Status (2026-03-09)](v22-0-gate-0-evidence-status-2026-03-09.md).
 - [x] Re-evaluate required checks and decision in [v22.0 Gate 0 Exit Checklist (Decision Control)](v22-0-gate-0-exit-checklist.md).
+- [x] Re-run evidence-intake guard: `npm run check:v22-evidence`.
 - [x] Re-run CI guard: `npm run check:v22-gate0`.
 
 ## Synchronization Order (When UA Status Changes)
@@ -50,7 +51,8 @@ Related:
    - `UA-3` -> [v22.0 Approval Checklist](../planning/v22-0-approval-checklist.md)
 3. Update [v22.0 Integration Feasibility Decision Record](v22-0-integration-feasibility-decision.md) control tracker.
 4. Update [v22.0 Gate 0 Evidence Status (2026-03-09)](v22-0-gate-0-evidence-status-2026-03-09.md).
-5. Re-evaluate [v22.0 Gate 0 Exit Checklist (Decision Control)](v22-0-gate-0-exit-checklist.md) and run `npm run check:v22-gate0`.
+5. Re-evaluate [v22.0 Gate 0 Exit Checklist (Decision Control)](v22-0-gate-0-exit-checklist.md).
+6. Run `npm run check:v22-evidence` and `npm run check:v22-gate0`.
 
 Detailed operator runbook:
 
@@ -64,3 +66,4 @@ Detailed operator runbook:
 | 2026-03-24 | Autonomous prep     | Added evidence workspace scaffolding and a draft C2 retention/deletion policy artifact     |
 | 2026-03-29 | C2 closure          | Recorded policy approval, privacy sign-off, verification evidence, and Gate 0 tracker sync |
 | 2026-04-28 | Autonomous prep     | Added prep-only C1 and D4 dated evidence packets; UA-1 and UA-3 remain pending             |
+| 2026-06-12 | Autonomous guard    | Added C1/D4 evidence-intake validation; UA-1 and UA-3 remain pending                       |

--- a/docs/implementation/v22-0-phase-0-baseline-report-2026-03-09.md
+++ b/docs/implementation/v22-0-phase-0-baseline-report-2026-03-09.md
@@ -78,4 +78,4 @@ Preflight results:
 
 - Product owner: `pending`
 - Governance owner: `pending`
-- Notes: This artifact is structurally complete and ready for value entry once database execution context is available.
+- Notes: M1/M3 execution evidence is recorded above. Product/governance sign-off fields remain pending and are not used as Gate 0 closure evidence.

--- a/docs/implementation/v22-0-worktree-checkpoint-2026-06-13.md
+++ b/docs/implementation/v22-0-worktree-checkpoint-2026-06-13.md
@@ -1,0 +1,102 @@
+---
+status: draft
+last_updated: 2026-06-13
+owner: jer
+tags: [implementation, v22.0, checkpoint, review]
+---
+
+# v22.0 Worktree Checkpoint (2026-06-13)
+
+## Purpose
+
+Checkpoint the autonomous repo-local work completed while Gate 0 remains
+blocked on user-owned C1 legal evidence and D4 partner-operations evidence.
+This document is a review inventory only. It does not close Gate 0, assert
+legal sufficiency, assert partner outreach sufficiency, or provide production
+runbook instructions.
+
+## Worktree Inventory
+
+### Gate 0 Guards and Evidence Discipline
+
+- Added status-aware C1/D4 evidence-intake validation and threat-model
+  consistency checks.
+- Hardened Gate 0 decision validation so `NO-GO` blocking checks must match
+  the required-check rows.
+- Added C1/D4 closure evidence structure checks for dated submissions,
+  canonical evidence artifacts, submission IDs, traceability inventories, and
+  submitted-count consistency.
+- Updated evidence templates, runbooks, README command references, CI static
+  validation, and targeted fixture tests.
+
+### Offline Privacy and Recovery Hardening
+
+- Added aggregate offline recovery diagnostics and non-destructive recovery
+  recommendations.
+- Added pilot draft cleanup helpers and sign-out cleanup wiring.
+- Normalized offline feedback queue payloads before storage and replay.
+- Sanitized offline sync and recovery warning/error metadata so raw payloads,
+  browser exception messages, and network details are not surfaced.
+
+### Pilot Event Idempotency and Contracts
+
+- Added optional client event IDs for pilot event create payloads.
+- Centralized no-store pilot create/idempotent-retry responses.
+- Limited duplicate retry suppression to supplied-ID primary-key conflicts.
+- Documented implemented internal pilot routes in OpenAPI and added contract
+  tests for route/method inventory, operation metadata, JSON write contracts,
+  and response envelopes.
+
+### Pilot Readiness Governance
+
+- Added fail-closed validation for pilot readiness scope inputs loaded from
+  files, Supabase, and direct report-builder calls.
+- Sanitized readiness load failures and invalid-scope diagnostics.
+- Neutralized CSV formula prefixes in generated readiness worksheets.
+- Rejected duplicate readiness scope identities instead of silently
+  deduplicating.
+
+### Documentation and Test Coverage
+
+- Added public-safe runbooks for pilot event replay and offline local recovery.
+- Updated the offline/local threat model with mitigation evidence status.
+- Added documentation hygiene coverage for C2 retention and Phase 0 baseline
+  evidence alignment.
+- Expanded route, storage, OpenAPI, and script fixture tests for the changed
+  contracts.
+
+## Recommended Commit Boundaries
+
+1. `chore: add v22 gate0 evidence and threat guards`
+   - Gate 0 guard scripts, CI/npm wiring, evidence templates, evidence
+     runbooks, and script tests.
+2. `fix: harden offline privacy and local recovery paths`
+   - Offline sync/feedback sanitization, recovery diagnostics, draft cleanup,
+     runbooks, threat-model updates, and related tests.
+3. `feat: add pilot event idempotent retry contracts`
+   - Optional event IDs, supplied-ID retry behavior, shared pilot responses,
+     storage duplicate handling, OpenAPI docs, and route tests.
+4. `test: pin internal pilot OpenAPI and route contracts`
+   - Derived route/method inventory tests, operation metadata checks, JSON
+     write `415` coverage, and documented response-envelope checks.
+5. `fix: validate pilot readiness audit inputs`
+   - Scope validation, sanitized readiness diagnostics, duplicate detection,
+     CSV formula neutralization, readiness docs, and tests.
+6. `docs: align existing v22 evidence records`
+   - C2 retention wording, Phase 0 baseline note, roadmap/runbook references,
+     and documentation hygiene tests.
+
+## Verification To Preserve
+
+- Focused Gate 0 guard tests must pass.
+- Script syntax, ESLint, Prettier check, TypeScript, reference check, root
+  hygiene, and `git diff --check` must pass before review.
+- The v22 guard chain must keep returning the expected `NO-GO` result with
+  blocking checks `G0-3` and `G0-8` until real external evidence is attached.
+
+## Remaining External Blockers
+
+1. Real C1 partner legal/API terms and reviewer outcome.
+2. Real D4 named partner list, outreach owner, dated outreach execution
+   evidence, and supporting artifact inventory.
+3. Human decision to sync accepted evidence and re-evaluate Gate 0.

--- a/docs/implementation/v22-0-worktree-checkpoint-2026-06-13.md
+++ b/docs/implementation/v22-0-worktree-checkpoint-2026-06-13.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: stable
 last_updated: 2026-06-13
 owner: jer
 tags: [implementation, v22.0, checkpoint, review]
@@ -65,26 +65,31 @@ runbook instructions.
 - Expanded route, storage, OpenAPI, and script fixture tests for the changed
   contracts.
 
-## Recommended Commit Boundaries
+## Committed Review Boundaries
 
-1. `chore: add v22 gate0 evidence and threat guards`
+1. `chore: add v22 gate0 validation guards`
    - Gate 0 guard scripts, CI/npm wiring, evidence templates, evidence
      runbooks, and script tests.
-2. `fix: harden offline privacy and local recovery paths`
+2. `fix: harden offline recovery privacy`
    - Offline sync/feedback sanitization, recovery diagnostics, draft cleanup,
      runbooks, threat-model updates, and related tests.
-3. `feat: add pilot event idempotent retry contracts`
+3. `feat: add pilot event retry contracts`
    - Optional event IDs, supplied-ID retry behavior, shared pilot responses,
      storage duplicate handling, OpenAPI docs, and route tests.
-4. `test: pin internal pilot OpenAPI and route contracts`
+4. `test: pin internal pilot openapi contracts`
    - Derived route/method inventory tests, operation metadata checks, JSON
      write `415` coverage, and documented response-envelope checks.
-5. `fix: validate pilot readiness audit inputs`
+5. `fix: validate pilot readiness inputs`
    - Scope validation, sanitized readiness diagnostics, duplicate detection,
      CSV formula neutralization, readiness docs, and tests.
-6. `docs: align existing v22 evidence records`
+6. `fix: tighten pilot privacy key guards`
+   - Pilot privacy-key schema validation and focused guard coverage.
+7. `docs: checkpoint v22 maintenance worktree`
    - C2 retention wording, Phase 0 baseline note, roadmap/runbook references,
      and documentation hygiene tests.
+8. `docs: clarify v22 remaining roadmap work`
+   - Roadmap cleanup so the remaining default path is external C1/D4 evidence,
+     not open-ended autonomous hardening.
 
 ## Verification To Preserve
 

--- a/docs/implementation/v22-pilot-readiness/README.md
+++ b/docs/implementation/v22-pilot-readiness/README.md
@@ -44,6 +44,17 @@ Optional fields per entry:
 1. `pilot_cycle_id`
 2. `org_id`
 
+Validation behavior:
+
+1. Scope input fails closed if it is not a top-level array or an object with a
+   `services` array.
+2. Each entry must contain only the supported fields listed above.
+3. `org_id`, when present, must be a UUID.
+4. Duplicate `(pilot_cycle_id, org_id, service_id)` scope identities fail
+   closed so audit counts cannot be inflated by repeated rows.
+5. Invalid file or Supabase scope entries report only field-level validation
+   paths, not raw entry values or partner notes.
+
 Allowed `sla_tier` values:
 
 1. `crisis`
@@ -78,6 +89,10 @@ The command writes:
 1. `pilot-readiness-audit.json`
 2. `pilot-readiness-summary.md`
 3. `pilot-verification-worksheet.csv`
+
+The CSV worksheet neutralizes spreadsheet formula prefixes in text cells before
+writing output. This keeps service names or reviewer-entered fields readable as
+text if the worksheet is opened in spreadsheet software.
 
 ## Step 3: Review and Prioritize
 

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_updated: 2026-06-04
+last_updated: 2026-06-13
 owner: jer
 tags: [planning, roadmap, governance, public-docs]
 ---
@@ -17,7 +17,7 @@ This directory contains planning and strategy documents for CareConnect.
 
 ## Active Planning: v22.0
 
-**Status:** GATE 0 DECISION WORK IN PROGRESS (`NO-GO` pending C1/D4 closure; C2 complete)
+**Status:** GATE 0 DECISION WORK IN PROGRESS (`NO-GO` pending C1/D4 closure; C2 complete; repo-local maintenance checkpoint review-ready)
 **Created:** 2026-02-27
 
 ### Quick Start (Read These First)
@@ -55,6 +55,10 @@ This directory contains planning and strategy documents for CareConnect.
 - [v22.0 Gate 0 Prep and Deploy Contract Alignment Archive (2026-04-28)](archive/2026-04-28-v22-0-gate-0-prep-and-deploy-contract-alignment.md)
   - Completed autonomous maintenance pass for prep-only Gate 0 evidence packets, deploy-contract alignment, and validation
   - **Reading time:** 5 minutes
+
+- [v22.0 Autonomous Gate 0 Maintenance Archive (2026-06-13)](../implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md)
+  - Completed bounded repo-local maintenance pass for evidence guards, D4 artifact-inventory validation, offline recovery/privacy, pilot event contracts, and readiness validation while leaving C1/D4 evidence externally blocked
+  - **Reading time:** 10 minutes
 
 - **[v22.0 Approval Checklist](v22-0-approval-checklist.md)**
   - Canonical sign-off record for Gate 0 decisions

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -15,8 +15,8 @@ tags: [planning, roadmap, v22.0, governance]
 ## Current State
 
 - **Services**: 196 manually curated social services (`npm run validate-data` and `npm run audit:data` on 2026-05-03)
-- **Tests**: default Vitest suite green as of 2026-05-03 (`189` files; `1361` passed; `24` skipped)
-- **DB integration lane**: `npm run db:types` and `npm run test:db` are green as of 2026-04-20 on a Docker-capable machine, and local Supabase-backed retrieval, route, export, search, and policy tests remain healthy
+- **Tests**: default Vitest suite green as of 2026-06-13 (`198` files; `1599` passed; `24` skipped)
+- **DB integration lane**: PR DB integration checks are green as of 2026-06-13, and local Supabase-backed retrieval, route, export, search, and policy tests remain healthy
 - **Coverage**: `72.13%` statements / `78.85%` branches / `83.20%` functions / `72.13%` lines from `npm run test:coverage` on 2026-04-03
 - **Repo hygiene**: `npm run check:refs`, typed service DB write paths, dashboard server actions, and dependency cleanup are complete
 - **Public repository hygiene**: public docs now follow ADR-022, with private deployment coordinates, alert routing, maintainer-only operational details, and real platform contracts excluded from public GitHub documentation
@@ -40,7 +40,7 @@ tags: [planning, roadmap, v22.0, governance]
 - **Semantic search resilience**: browser embedding-worker failures now fail closed to keyword-only search, and embedding request errors settle cleanly instead of emitting synthetic vectors
 - **Pilot metric stack**: M2/M4/M5/M6/M7 source schema, recompute path, and scorecard snapshot flow are implemented; values remain data-dependent rather than schema-blocked
 - **Pilot readiness reporting**: scoped JSON/Markdown/CSV readiness exports now exist for bounded A6/A16 follow-through without mutating curated service data
-- **v22 autonomous maintenance checkpoint**: Gate 0 evidence guards, offline privacy/recovery hardening, pilot event contracts, OpenAPI route coverage, and readiness-audit validation are packaged as a reviewable checkpoint; no additional autonomous hardening is planned before external C1/D4 evidence arrives
+- **v22 autonomous maintenance checkpoint**: Gate 0 evidence guards, offline privacy/recovery hardening, pilot event contracts, OpenAPI route coverage, and readiness-audit validation are packaged as a reviewable checkpoint with the completed maintenance record archived; no additional autonomous hardening is planned before external C1/D4 evidence arrives
 - **French service-data gaps**: runtime hardening is complete, but governed content follow-through still remains for `access_script_fr`, `hours_text_fr`, `eligibility_notes_fr`, and `synthetic_queries_fr`
 - **Offline**: PWA with IndexedDB fallback, background sync, and snapshot-age/stale-data messaging on offline surfaces
 - **Privacy-safe mapping**: service-detail pages gate third-party map previews behind explicit user action
@@ -165,7 +165,7 @@ The 90-day window is a review target rather than a guaranteed engineering schedu
 - [v22.0 Gate 0 User Action Tracker](../implementation/v22-0-gate-0-user-action-tracker.md)
 - [v22.0 Gate 0 Evidence Intake Pack](../implementation/v22-0-gate-0-evidence-intake-pack.md)
 - [v22.0 Gate 0 Exit Checklist](../implementation/v22-0-gate-0-exit-checklist.md)
-- [v22.0 Autonomous Gate 0 Maintenance Pass (2026-06-12)](../implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md)
+- [v22.0 Autonomous Gate 0 Maintenance Pass Archive (2026-06-13)](../implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md)
 - [v22.0 Worktree Checkpoint (2026-06-13)](../implementation/v22-0-worktree-checkpoint-2026-06-13.md)
 
 ## Parallel Maintenance While Gate 0 Waits
@@ -271,6 +271,7 @@ References:
 
 ### Recent Completed Milestones
 
+- **v22 Gate 0 autonomous maintenance checkpoint (2026-06-13)**: completed the bounded repo-local maintenance pass for C1/D4 evidence guards, D4 artifact-inventory validation, offline privacy/recovery hardening, pilot event contracts, OpenAPI coverage, readiness input validation, and roadmap stop-rule cleanup while leaving Gate 0 blocked on external evidence; archived in [2026-06-13 v22.0 Autonomous Gate 0 Maintenance](../implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md).
 - **Public GitHub cleanup (2026-06-05)**: established the public documentation boundary in ADR-022, sanitized public deployment/operations/planning/legal docs, replaced the real platform contract with fake-only example content plus a legacy-path tombstone, migrated durable private originals to the private/shared operations source of truth while preserving ignored local copies, updated boundary tests/scripts, and archived the completed pass in [2026-06-04 Public GitHub Cleanup](archive/2026-06-04-public-github-cleanup.md).
 - **Public and operational surface polish (2026-05-01)**: completed the bounded reference sources, suggest-service intake, route-reference cleanup, public workflow, static legal/help/trust, settings, and authenticated dashboard/admin polish wave without changing service-data, search, auth, or schema contracts; archived in [2026-05-01 v20.0 Public and Operational Surface Polish](archive/2026-05-01-v20-0-public-and-operational-surface-polish.md).
 - **About page polish (2026-04-30)**: rebuilt `/about` as a calmer trust and context page, removed duplicated homepage-style sections, restored the page-level background wash, aligned hero/source/context/CTA sections on a shared rail, and refined the primary CTA treatment without changing service data or search behavior; archived in [2026-04-30 v20.0 About Page Polish](archive/2026-04-30-v20-0-about-page-polish.md).
@@ -305,6 +306,7 @@ The project already has the technical base for a live, privacy-first, resilient 
 ### Archive and Historical Plans
 
 - [Planning Archive](archive/)
+- [v22.0 Autonomous Gate 0 Maintenance Archive](../implementation/archive/2026-06-13-v22-0-autonomous-gate0-maintenance.md)
 - [Public GitHub Cleanup Archive](archive/2026-06-04-public-github-cleanup.md)
 - [v20.0 Public and Operational Surface Polish Archive](archive/2026-05-01-v20-0-public-and-operational-surface-polish.md)
 - [v20.0 About Page Polish Archive](archive/2026-04-30-v20-0-about-page-polish.md)

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_updated: 2026-06-05
+last_updated: 2026-06-13
 owner: jer
 tags: [planning, roadmap, v22.0, governance]
 ---
@@ -9,7 +9,7 @@ tags: [planning, roadmap, v22.0, governance]
 
 > **Current Version**: v22.0 (Non-Duplicate Value Decision Plan, Phase 0)
 > **Next Milestone**: v22.0 Gate 0 Exit (C1/D4 blocker closure)
-> **Last Updated**: 2026-06-05
+> **Last Updated**: 2026-06-13
 > **Platform Status**: Strategic Repositioning - v22.0 Decision-Gated Planning
 
 ## Current State
@@ -40,6 +40,7 @@ tags: [planning, roadmap, v22.0, governance]
 - **Semantic search resilience**: browser embedding-worker failures now fail closed to keyword-only search, and embedding request errors settle cleanly instead of emitting synthetic vectors
 - **Pilot metric stack**: M2/M4/M5/M6/M7 source schema, recompute path, and scorecard snapshot flow are implemented; values remain data-dependent rather than schema-blocked
 - **Pilot readiness reporting**: scoped JSON/Markdown/CSV readiness exports now exist for bounded A6/A16 follow-through without mutating curated service data
+- **v22 autonomous maintenance checkpoint**: Gate 0 evidence guards, offline privacy/recovery hardening, pilot event contracts, OpenAPI route coverage, and readiness-audit validation are checkpointed for review; the next repo-local step is commit/review prep rather than more autonomous hardening
 - **French service-data gaps**: runtime hardening is complete, but governed content follow-through still remains for `access_script_fr`, `hours_text_fr`, `eligibility_notes_fr`, and `synthetic_queries_fr`
 - **Offline**: PWA with IndexedDB fallback, background sync, and snapshot-age/stale-data messaging on offline surfaces
 - **Privacy-safe mapping**: service-detail pages gate third-party map previews behind explicit user action
@@ -80,8 +81,9 @@ The active question is whether the project can prove non-duplicate value relativ
 
 1. Close the remaining v22.0 Gate 0 blockers in strict order: C1 legal review, then D4 partner operations evidence.
 2. Keep the repo stable while Gate 0 is blocked: maintain tests, keep docs aligned, and avoid speculative feature work.
-3. If pulling forward any external-validation backlog work, keep it limited to pilot readiness, safety, or evidence discipline.
-4. Preserve launch readiness materials, but do not resume beta or public-launch execution until v22 permits it.
+3. Review and commit the current autonomous maintenance checkpoint before starting any new hardening slice.
+4. If pulling forward any external-validation backlog work, keep it limited to pilot readiness, safety, or evidence discipline.
+5. Preserve launch readiness materials, but do not resume beta or public-launch execution until v22 permits it.
 
 ## What Not To Do Now
 
@@ -126,7 +128,8 @@ The 90-day window is a review target rather than a guaranteed engineering schedu
 2. Step 1 approval locks are complete.
 3. Gate 0 evidence scaffolding is in repo.
 4. C2 retention policy approval, privacy sign-off, and dated verification evidence are complete.
-5. Gate 0 remains `NO-GO` because C1 legal evidence and D4 partner-ops evidence are still incomplete.
+5. C1/D4 evidence-intake validation now protects against accidentally treating `prep_only` packets as closure evidence, including dated submission IDs, canonical artifact templates, C1/D4 traceability inventories, and D4 outreach-log source-artifact checks.
+6. Gate 0 remains `NO-GO` because C1 legal evidence and D4 partner-ops evidence are still incomplete.
 
 **Immediate blockers**
 
@@ -143,7 +146,7 @@ The 90-day window is a review target rather than a guaranteed engineering schedu
 
 1. Update the Gate 0 trackers and source control docs.
 2. Sync the integration decision record, approval checklist references, and evidence matrix.
-3. Re-evaluate Gate 0 and re-run `npm run check:v22-gate0`.
+3. Re-evaluate Gate 0 and re-run `npm run check:v22-evidence` plus `npm run check:v22-gate0`.
 4. Keep pilot APIs, schemas, tests, and docs aligned with any approved control changes.
 
 **Gate 1 success thresholds**
@@ -162,6 +165,8 @@ The 90-day window is a review target rather than a guaranteed engineering schedu
 - [v22.0 Gate 0 User Action Tracker](../implementation/v22-0-gate-0-user-action-tracker.md)
 - [v22.0 Gate 0 Evidence Intake Pack](../implementation/v22-0-gate-0-evidence-intake-pack.md)
 - [v22.0 Gate 0 Exit Checklist](../implementation/v22-0-gate-0-exit-checklist.md)
+- [v22.0 Autonomous Gate 0 Maintenance Pass (2026-06-12)](../implementation/v22-0-autonomous-gate0-maintenance-2026-06-12.md)
+- [v22.0 Worktree Checkpoint (2026-06-13)](../implementation/v22-0-worktree-checkpoint-2026-06-13.md)
 
 ## Parallel Maintenance While Gate 0 Waits
 

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -40,7 +40,7 @@ tags: [planning, roadmap, v22.0, governance]
 - **Semantic search resilience**: browser embedding-worker failures now fail closed to keyword-only search, and embedding request errors settle cleanly instead of emitting synthetic vectors
 - **Pilot metric stack**: M2/M4/M5/M6/M7 source schema, recompute path, and scorecard snapshot flow are implemented; values remain data-dependent rather than schema-blocked
 - **Pilot readiness reporting**: scoped JSON/Markdown/CSV readiness exports now exist for bounded A6/A16 follow-through without mutating curated service data
-- **v22 autonomous maintenance checkpoint**: Gate 0 evidence guards, offline privacy/recovery hardening, pilot event contracts, OpenAPI route coverage, and readiness-audit validation are checkpointed for review; the next repo-local step is commit/review prep rather than more autonomous hardening
+- **v22 autonomous maintenance checkpoint**: Gate 0 evidence guards, offline privacy/recovery hardening, pilot event contracts, OpenAPI route coverage, and readiness-audit validation are packaged as a reviewable checkpoint; no additional autonomous hardening is planned before external C1/D4 evidence arrives
 - **French service-data gaps**: runtime hardening is complete, but governed content follow-through still remains for `access_script_fr`, `hours_text_fr`, `eligibility_notes_fr`, and `synthetic_queries_fr`
 - **Offline**: PWA with IndexedDB fallback, background sync, and snapshot-age/stale-data messaging on offline surfaces
 - **Privacy-safe mapping**: service-detail pages gate third-party map previews behind explicit user action
@@ -79,10 +79,10 @@ The active question is whether the project can prove non-duplicate value relativ
 
 ## What To Do Now
 
-1. Close the remaining v22.0 Gate 0 blockers in strict order: C1 legal review, then D4 partner operations evidence.
-2. Keep the repo stable while Gate 0 is blocked: maintain tests, keep docs aligned, and avoid speculative feature work.
-3. Review and commit the current autonomous maintenance checkpoint before starting any new hardening slice.
-4. If pulling forward any external-validation backlog work, keep it limited to pilot readiness, safety, or evidence discipline.
+1. Complete `UA-1 / G0-3`: attach candidate partner legal/API terms and finish C1 clause-level review.
+2. Complete `UA-3 / G0-8`: attach the named pilot partner list, outreach owner assignment, and dated D4 execution evidence.
+3. Review and merge the current autonomous maintenance checkpoint after CI/review confirms it, without broadening its scope.
+4. Keep the repo stable while Gate 0 is blocked: maintain tests, keep docs aligned, and avoid speculative feature work.
 5. Preserve launch readiness materials, but do not resume beta or public-launch execution until v22 permits it.
 
 ## What Not To Do Now
@@ -170,7 +170,7 @@ The 90-day window is a review target rather than a guaranteed engineering schedu
 
 ## Parallel Maintenance While Gate 0 Waits
 
-These items are worth doing only if they do not distract from Gate 0 closure:
+These items are backlog candidates, not default next steps. Start one only as an explicitly named bounded task and only if it does not distract from Gate 0 closure:
 
 1. Keep the default E2E suite skip-free and keep the opt-in production/server suites healthy.
 2. Verify and document the remaining v22 threat-model mitigation items before pilot activation.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,6 +1,6 @@
 # Public Runbooks Overview
 
-**Last Updated:** 2026-06-05
+**Last Updated:** 2026-06-12
 
 This directory contains public troubleshooting summaries for CareConnect. Detailed incident response steps, alert routing, dashboard locations, host access, and recovery commands are intentionally excluded from public GitHub documentation.
 
@@ -15,6 +15,8 @@ This repository contains public project documentation and reproducible developme
 - [Slow Queries](slow-queries.md)
 - [SLO Violation](slo-violation.md)
 - [PWA Testing](pwa-testing.md)
+- [Pilot Event Replay](pilot-event-replay.md)
+- [Offline Local Data Recovery](offline-local-recovery.md)
 - [Remote Migration Repair](remote-migration-repair.md)
 
 ## Shared Principles

--- a/docs/runbooks/offline-local-recovery.md
+++ b/docs/runbooks/offline-local-recovery.md
@@ -1,0 +1,158 @@
+# Runbook Summary: Offline Local Data Recovery
+
+**Last Updated:** 2026-06-12
+
+This public summary describes safe recovery principles for browser-local
+CareConnect data when IndexedDB, cache storage, or offline queues appear stale
+or corrupted. It intentionally excludes private incident notes, live host
+access, dashboard links, and environment-specific production commands.
+
+## Scope
+
+In scope:
+
+1. Browser IndexedDB database `careconnect-offline-v1`.
+2. Service directory and embedding caches.
+3. Local metadata such as `lastSync` and export `version`.
+4. Public feedback queue store `pendingFeedback`.
+5. Any future pilot event draft queue if one is introduced.
+
+Out of scope:
+
+1. Production database repair.
+2. Private partner operations records.
+3. Manual changes to verified service data.
+4. Recovery steps that require exporting raw user text or personal contact
+   fields.
+
+## Recovery Principles
+
+1. Preserve queued write intent before clearing local data.
+2. Count queued items without copying raw free-text payloads into public issues.
+3. Prefer a forced re-sync of service cache data before deleting IndexedDB.
+4. Treat pilot event drafts as sensitive if a future queue is introduced.
+5. Document only aggregate recovery evidence in public git.
+
+## Pilot Draft Cleanup Policy
+
+Pilot event draft storage is reserved for keys prefixed with
+`careconnect-pilot-draft-`. These drafts are treated as sensitive local data.
+
+Current code-level policy:
+
+1. Draft envelopes expire after `8` hours.
+2. Malformed draft envelopes are treated as unsafe to keep.
+3. Unknown draft schema versions are treated as unsafe to keep.
+4. Sign-out clears reserved pilot draft keys from `localStorage` and
+   `sessionStorage`.
+5. Service caches, embeddings, user preferences, and public feedback queues are
+   not cleared by the pilot draft sign-out cleanup helper.
+
+This policy is implemented in `lib/offline/pilot-draft-cleanup.ts` and wired
+into `components/layout/AuthProvider.tsx`.
+
+## Aggregate Audit Helper
+
+`lib/offline/local-recovery-audit.ts` provides a privacy-preserving recovery
+snapshot for local troubleshooting. It reports:
+
+1. Service cache count.
+2. Embedding cache count.
+3. Pending feedback queue count.
+4. Pilot draft key counts in `localStorage` and `sessionStorage`.
+5. Whether `lastSync` and export `version` metadata exist.
+6. The `lastSync` freshness status using the same `fresh`, `stale`, or
+   `unknown` policy as the offline UI.
+
+The helper does not read queued feedback payloads, service records, embeddings,
+draft payloads, raw search text, or personal contact fields.
+
+If browser draft storage cannot be inspected, the affected draft count is
+reported as `null` instead of `0`. This avoids treating blocked storage access
+as evidence that no local draft data exists.
+
+Recovery warnings log only sanitized error type metadata and storage class
+labels. They must not log raw queue payloads, raw draft values, raw search text,
+or raw browser exception messages.
+
+Offline service-export sync failures return sanitized error summaries such as
+`errorType` and, for HTTP failures, `httpStatus`. Background sync components
+also log sanitized error types for service-worker registration, data sync,
+feedback sync, and offline fallback prewarm failures.
+
+The offline feedback queue validates queued payloads against the public feedback
+API schema before local storage and again before replay. Empty optional strings
+are removed before storage/replay so offline thumbs-up/down feedback does not
+create invalid `category_searched` values. Invalid queued items are not sent to
+the API; they follow the existing retry-count policy without logging raw
+feedback text.
+
+`buildOfflineLocalRecoveryPlan()` converts the aggregate snapshot into
+non-destructive recommendation IDs for dry-run recovery notes:
+
+1. `preserve_queued_writes` - queued feedback or pilot draft counts are present.
+2. `retry_offline_sync` - the service cache is empty, export metadata is
+   missing, or `lastSync` is stale/unknown.
+3. `inspect_browser_storage` - IndexedDB could not be opened from the browser,
+   or draft storage counts could not be inspected.
+4. `run_in_browser` - diagnostics were attempted outside a browser context.
+5. `no_immediate_recovery_action` - aggregate counts and freshness metadata do
+   not indicate a local recovery action.
+
+These recommendations are intentionally non-destructive. They do not authorize
+clearing queues, exporting raw payloads, or modifying verified service data.
+
+## Public Recovery Workflow
+
+1. Confirm the user-visible symptom:
+   - Offline search returns no services.
+   - Service details are stale after returning online.
+   - Feedback remains queued after connectivity returns.
+   - Browser storage errors appear in the console.
+2. Inspect local storage classes in browser DevTools:
+   - IndexedDB: `careconnect-offline-v1`
+   - Object stores: `services`, `embeddings`, `meta`, `pendingFeedback`
+   - Cache Storage entries used by service export or PWA fallback routes
+3. Record only aggregate counts:
+   - Number of cached services
+   - Number of cached embeddings
+   - `lastSync` timestamp presence
+   - `lastSync` freshness status
+   - `pendingFeedback` item count
+   - Pilot draft queue item count, if such a queue exists
+4. Attempt non-destructive recovery first:
+   - Return the browser to online mode.
+   - Reload the app.
+   - Trigger or wait for offline sync.
+   - Confirm `/api/v1/services/export` can be fetched.
+5. If cache data remains stale but queues are empty:
+   - Clear `services`, `embeddings`, and stale `meta` entries.
+   - Leave queue stores untouched.
+   - Reload online and confirm service export rehydrates IndexedDB.
+6. If queued items exist:
+   - Do not delete the queue as a first step.
+   - Reconnect and retry sync.
+   - If sync still fails, capture aggregate failure evidence only and escalate
+     through private/shared operations material.
+7. If IndexedDB cannot be opened:
+   - Confirm whether any queue contents are recoverable through browser tools.
+   - Escalate before destructive clearing when queued writes may exist.
+   - Clear the affected local database only after queue preservation is either
+     complete or explicitly waived by the appropriate owner.
+
+## Verification Checklist
+
+- [ ] User-visible offline/search symptom is reproduced.
+- [ ] Local store counts are recorded without raw payload contents.
+- [ ] Non-destructive online re-sync is attempted.
+- [ ] Queued write stores are audited before any destructive clearing.
+- [ ] Service cache rehydrates from `/api/v1/services/export`.
+- [ ] Public notes exclude raw queries, free-text feedback, names, phone
+      numbers, email addresses, street addresses, private dashboard links, and
+      live environment details.
+
+## Current Limitation
+
+This repo currently documents the recovery workflow, but F5 is not fully
+verified until a dry run records evidence that the queue audit and re-sync steps
+work as expected.

--- a/docs/runbooks/pilot-event-replay.md
+++ b/docs/runbooks/pilot-event-replay.md
@@ -1,0 +1,72 @@
+# Runbook Summary: Pilot Event Replay and Duplicate Suppression
+
+**Last Updated:** 2026-06-12
+
+This public summary defines replay criteria for v22 pilot event submissions.
+It intentionally excludes production database access steps, private dashboard
+links, and environment-specific recovery commands.
+
+## Meaning
+
+A replay occurs when the same pilot event submission is sent more than once,
+typically because an offline queue retries after a network interruption. Replay
+handling must prevent duplicate metric inputs without storing raw user text,
+personal contact fields, or private operational notes.
+
+## Public Response Principles
+
+1. Treat exact repeated submissions as idempotent retries, not new facts.
+2. Build replay checks from privacy-safe structured fields only.
+3. Never use raw search text, free-text notes, names, phone numbers, email
+   addresses, or street addresses in replay keys.
+4. Prefer database-backed unique constraints or equivalent atomic writes before
+   marking duplicate suppression fully verified.
+5. Store detailed incident notes and live remediation commands outside public
+   git.
+
+## Replay Criteria
+
+The canonical code-level replay criteria live in
+`lib/pilot/event-replay-policy.ts`.
+
+| Event Type       | Duplicate When These Fields Match                                                                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Contact attempt  | `pilot_cycle_id`, `service_id`, `recorded_by_org_id`, `entity_key_hash`, `attempt_channel`, `attempt_outcome`, `attempted_at`, `resolved_at`, `outcome_notes_code` |
+| Referral         | `pilot_cycle_id`, `source_org_id`, `target_service_id`, `referral_state`, `created_at`, `updated_at`, `terminal_at`, `failure_reason_code`                         |
+| Connection       | `pilot_cycle_id`, `org_id`, `service_id`, `connected_at`, `contact_attempt_event_id`, `referral_event_id`                                                          |
+| Service status   | `pilot_cycle_id`, `org_id`, `service_id`, `checked_at`, `status_code`                                                                                              |
+| Data decay audit | `pilot_cycle_id`, `org_id`, `service_id`, `audited_at`, `is_fatal`, `fatal_error_category`, `verification_mode`                                                    |
+| Preference fit   | `pilot_cycle_id`, `org_id`, `cohort_label`, `recorded_at`, `preferred_via_careconnect`                                                                             |
+
+## Client Event Idempotency
+
+Pilot event create endpoints accept an optional client-generated UUID `id`.
+Offline queues should generate this ID once when the local draft is created and
+reuse the same ID for every retry of the same event.
+
+When a retry reaches storage after the original event has already been written,
+the existing table primary key raises a duplicate-key conflict. The API treats
+that conflict as an idempotent retry only when the client supplied an `id` and
+the duplicate conflict is on the primary key or `id` key. It then returns a
+no-store success response with `duplicate: true`.
+
+Duplicate conflicts on any other unique constraint are not suppressed as
+idempotent retries. They remain storage errors until the future replay
+constraint and live-schema evidence are explicitly reviewed.
+
+Requests without a supplied `id` use database-generated IDs and are not treated
+as idempotent duplicate retries.
+
+## Verification Standard
+
+F3 remains unverified until both conditions are true:
+
+1. Unit/API/storage tests confirm deterministic, privacy-safe replay
+   fingerprints and supplied-ID duplicate handling.
+2. Integration evidence confirms repeated submissions are atomically suppressed
+   by storage, such as through a database unique constraint, conflict-handling
+   write path, or an equivalent trusted persistence mechanism.
+
+The current repo-local policy satisfies the first condition only. Live repeated
+submission evidence against a real backing store is still required before F3 can
+be marked verified.

--- a/docs/security/v22-0-offline-local-threat-model.md
+++ b/docs/security/v22-0-offline-local-threat-model.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_updated: 2026-04-04
+last_updated: 2026-06-12
 owner: jer
 tags: [security, v22.0, threat-model, offline, privacy]
 ---
@@ -62,6 +62,20 @@ Out of scope:
 | F4         | medium   | Ensure stale data timestamp surfacing in pilot UI/operations process                           | Product + Engineering | 2026-03-21 | Focused component tests + offline UI walkthrough evidence | yes      |
 | F5         | medium   | Define local corruption recovery steps in runbook (resync + queued item audit)                 | Engineering           | 2026-03-21 | Documented runbook step + dry-run execution               | no       |
 
+## 2026-06-12 Mitigation Evidence Audit
+
+This audit covered repo-local implementation evidence only. It did not inspect
+private/shared operations material and does not close any partner, legal, or
+production-readiness evidence gates.
+
+| Finding ID | Evidence Inspected                                                                                                                                                                                                                                                                                                                                                            | Current Result                                                                                                                                                                                                                                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| F1         | `lib/schemas/privacy-guards.ts`, `lib/schemas/pilot-events.ts`, `tests/lib/schemas/privacy-guards.test.ts`, `tests/lib/schemas/pilot-events.test.ts`                                                                                                                                                                                                                          | Partially mitigated at the pilot event contract boundary: schemas reject raw query/message/notes fields, personal contact fields, and free-text fields. The local queue-specific behavior remains unverified, so `Verified` stays `no`.                                                                                                          |
+| F2         | `lib/offline/pilot-draft-cleanup.ts`, `components/layout/AuthProvider.tsx`, `tests/lib/offline/pilot-draft-cleanup.test.ts`, `tests/components/AuthProvider.test.tsx`                                                                                                                                                                                                         | Pilot draft TTL, malformed-envelope pruning, and sign-out cleanup for reserved pilot draft keys are implemented and covered by unit/component tests. No actual pilot draft queue was identified, and manual QA evidence is still missing, so `Verified` stays `no`.                                                                              |
+| F3         | `lib/pilot/event-replay-policy.ts`, `lib/pilot/storage.ts`, pilot event routes, `tests/lib/pilot/event-replay-policy.test.ts`, `tests/lib/pilot/storage.test.ts`, route tests                                                                                                                                                                                                 | Replay criteria, deterministic privacy-safe fingerprints, and supplied-ID primary-key retry handling are unit/API/storage covered. Non-primary duplicate constraints are not suppressed as idempotent retries. Live repeated-submission integration evidence remains missing, so `Verified` stays `no`.                                          |
+| F4         | Existing threat-model record                                                                                                                                                                                                                                                                                                                                                  | Previously verified stale-state surfacing remains recorded as `yes`; this pass did not re-open it.                                                                                                                                                                                                                                               |
+| F5         | `docs/runbooks/offline-local-recovery.md`, `lib/offline/local-recovery-audit.ts`, `tests/lib/offline/local-recovery-audit.test.ts`, `lib/offline/feedback.ts`, `tests/lib/offline/feedback.test.ts`, `lib/offline/db.ts`, `lib/offline/sync.ts`, `tests/unit/lib/offline/sync.test.ts`, `components/offline/OfflineSync.tsx`, `tests/components/offline/OfflineSync.test.tsx` | A public-safe recovery workflow and aggregate audit helper now cover queue counts, cache counts, sync metadata, non-destructive re-sync, destructive-clearing safeguards, API-schema validation before feedback queue storage/replay, and sanitized sync failure metadata. Dry-run execution evidence remains missing, so `Verified` stays `no`. |
+
 ## Validation Checklist
 
 - [x] Device-loss scenario assessed for all local data classes
@@ -82,3 +96,10 @@ Out of scope:
 | Critical findings resolved                       | GO     |
 | High findings have owners and mitigation plans   | GO     |
 | Threat model signed by security/governance owner | GO     |
+
+## Automated Consistency Check
+
+Run `npm run check:v22-threat-model` after editing this file. The guard checks
+the mitigation matrix and Gate 0 security outcome for internal consistency; it
+does not judge whether a mitigation is strategically sufficient or close any
+finding that still lacks its stated verification evidence.

--- a/lib/offline/feedback.ts
+++ b/lib/offline/feedback.ts
@@ -1,17 +1,81 @@
 import { getOfflineDB, PendingFeedback } from "./db"
 import { logger } from "@/lib/logger"
+import { FeedbackSubmitSchema, type FeedbackSubmitPayload } from "@/types/feedback"
+
+export type OfflineFeedbackQueueInput = Pick<
+  PendingFeedback,
+  "category_searched" | "feedback_type" | "message" | "service_id"
+>
+
+type OfflineFeedbackDB = Awaited<ReturnType<typeof getOfflineDB>>
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function getFeedbackSyncErrorType(error: unknown): string {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name || "DOMException"
+  }
+
+  if (error instanceof Error) {
+    return "Error"
+  }
+
+  return typeof error
+}
+
+export function normalizeOfflineFeedbackPayload(feedback: OfflineFeedbackQueueInput): FeedbackSubmitPayload {
+  const candidate: Record<string, unknown> = {
+    feedback_type: feedback.feedback_type,
+  }
+  const serviceId = normalizeOptionalString(feedback.service_id)
+  const message = normalizeOptionalString(feedback.message)
+  const categorySearched = normalizeOptionalString(feedback.category_searched)
+
+  if (serviceId !== undefined) candidate.service_id = serviceId
+  if (message !== undefined) candidate.message = message
+  if (categorySearched !== undefined) candidate.category_searched = categorySearched
+
+  const result = FeedbackSubmitSchema.safeParse(candidate)
+  if (!result.success) {
+    throw new Error("Invalid offline feedback payload")
+  }
+
+  return result.data
+}
+
+async function recordFeedbackSyncFailure(
+  db: OfflineFeedbackDB,
+  item: PendingFeedback
+): Promise<"deleted" | "retained" | "skipped"> {
+  if (item.id === undefined) return "skipped"
+
+  const updated = { ...item, syncAttempts: (item.syncAttempts || 0) + 1 }
+  if (updated.syncAttempts > 5) {
+    await db.delete("pendingFeedback", item.id)
+    return "deleted"
+  }
+
+  await db.put("pendingFeedback", updated)
+  return "retained"
+}
 
 /**
  * Queue a feedback submission to IndexedDB
  */
-export async function queueFeedback(feedback: Omit<PendingFeedback, "createdAt" | "syncAttempts" | "id">) {
+export async function queueFeedback(feedback: OfflineFeedbackQueueInput) {
+  const payload = normalizeOfflineFeedbackPayload(feedback)
   const db = await getOfflineDB()
   await db.put("pendingFeedback", {
-    ...feedback,
+    ...payload,
     createdAt: new Date().toISOString(),
     syncAttempts: 0,
   })
-  logger.info("[Offline] Feedback queued for sync")
+  logger.info("[Offline] Feedback queued for sync", { feedbackType: payload.feedback_type })
 }
 
 /**
@@ -34,9 +98,7 @@ export async function syncPendingFeedback() {
     for (const item of pending) {
       try {
         // Attempt submission to API
-        // Payload is now exactly what the API expects
-
-        const { id: _, syncAttempts: __, createdAt: ___, ...payload } = item
+        const payload = normalizeOfflineFeedbackPayload(item)
 
         const response = await fetch("/api/v1/feedback", {
           method: "POST",
@@ -48,22 +110,27 @@ export async function syncPendingFeedback() {
           // Cleanup on success
           if (item.id !== undefined) await db.delete("pendingFeedback", item.id)
         } else {
-          // Increment attempts if retryable
-          if (item.id !== undefined) {
-            const updated = { ...item, syncAttempts: (item.syncAttempts || 0) + 1 }
-            if (updated.syncAttempts > 5) {
-              // Give up after 5 tries
-              await db.delete("pendingFeedback", item.id)
-            } else {
-              await db.put("pendingFeedback", updated)
-            }
-          }
+          const action = await recordFeedbackSyncFailure(db, item)
+          logger.warn("[Sync] Feedback API rejected pending item", {
+            action,
+            feedbackType: item.feedback_type,
+            id: item.id,
+            status: response.status,
+          })
         }
       } catch (err) {
-        logger.error("[Sync] Failed to sync feedback item", { err })
+        const action = await recordFeedbackSyncFailure(db, item)
+        logger.warn("[Sync] Failed to sync feedback item", {
+          action,
+          errorType: getFeedbackSyncErrorType(err),
+          feedbackType: item.feedback_type,
+          id: item.id,
+        })
       }
     }
   } catch (error) {
-    logger.error("[Sync] Error accessing offline DB for feedback", { error })
+    logger.warn("[Sync] Error accessing offline DB for feedback", {
+      errorType: getFeedbackSyncErrorType(error),
+    })
   }
 }

--- a/lib/offline/local-recovery-audit.ts
+++ b/lib/offline/local-recovery-audit.ts
@@ -1,0 +1,224 @@
+import { getOfflineDB } from "@/lib/offline/db"
+import { isPilotDraftStorageKey } from "@/lib/offline/pilot-draft-cleanup"
+import { getOfflineSnapshotStatus, type OfflineSnapshotStatus } from "@/lib/offline/snapshot"
+import { logger } from "@/lib/logger"
+
+export type OfflineLocalRecoverySnapshot = {
+  available: boolean
+  counts: {
+    embeddings: number | null
+    pendingFeedback: number | null
+    pilotDraftLocalStorage: number | null
+    pilotDraftSessionStorage: number | null
+    services: number | null
+  }
+  inspectedAt: string
+  metadata: {
+    hasExportVersion: boolean
+    hasLastSync: boolean
+    lastSync: string | null
+    lastSyncStatus: OfflineSnapshotStatus
+  }
+  reason?: "offline_db_unavailable" | "server"
+}
+
+export type OfflineLocalRecoveryRecommendationId =
+  | "inspect_browser_storage"
+  | "no_immediate_recovery_action"
+  | "preserve_queued_writes"
+  | "run_in_browser"
+  | "retry_offline_sync"
+
+export type OfflineLocalRecoveryRecommendation = {
+  destructive: false
+  id: OfflineLocalRecoveryRecommendationId
+  priority: "high" | "medium" | "low"
+}
+
+export type OfflineLocalRecoveryPlan = {
+  hasQueuedLocalWrites: boolean
+  recommendations: OfflineLocalRecoveryRecommendation[]
+}
+
+function countPilotDraftKeys(storage: Storage): number {
+  let count = 0
+
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index)
+    if (key && isPilotDraftStorageKey(key)) {
+      count += 1
+    }
+  }
+
+  return count
+}
+
+function getStorageDraftCounts(): Pick<
+  OfflineLocalRecoverySnapshot["counts"],
+  "pilotDraftLocalStorage" | "pilotDraftSessionStorage"
+> {
+  if (typeof window === "undefined") {
+    return {
+      pilotDraftLocalStorage: null,
+      pilotDraftSessionStorage: null,
+    }
+  }
+
+  return {
+    pilotDraftLocalStorage: countPilotDraftKeysSafely("localStorage", () => window.localStorage),
+    pilotDraftSessionStorage: countPilotDraftKeysSafely("sessionStorage", () => window.sessionStorage),
+  }
+}
+
+function countPilotDraftKeysSafely(label: "localStorage" | "sessionStorage", getStorage: () => Storage): number | null {
+  try {
+    return countPilotDraftKeys(getStorage())
+  } catch (error) {
+    logger.warn("Unable to count pilot draft storage keys for recovery snapshot", {
+      errorType: getRecoveryErrorType(error),
+      storage: label,
+    })
+
+    return null
+  }
+}
+
+function getRecoveryErrorType(error: unknown): string {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name || "DOMException"
+  }
+
+  if (error instanceof Error) {
+    return "Error"
+  }
+
+  return typeof error
+}
+
+function hasPositiveCount(value: number | null): boolean {
+  return typeof value === "number" && value > 0
+}
+
+function addRecommendation(
+  recommendations: OfflineLocalRecoveryRecommendation[],
+  id: OfflineLocalRecoveryRecommendationId,
+  priority: OfflineLocalRecoveryRecommendation["priority"]
+): void {
+  if (recommendations.some((recommendation) => recommendation.id === id)) return
+
+  recommendations.push({
+    destructive: false,
+    id,
+    priority,
+  })
+}
+
+export function buildOfflineLocalRecoveryPlan(snapshot: OfflineLocalRecoverySnapshot): OfflineLocalRecoveryPlan {
+  const hasQueuedLocalWrites =
+    hasPositiveCount(snapshot.counts.pendingFeedback) ||
+    hasPositiveCount(snapshot.counts.pilotDraftLocalStorage) ||
+    hasPositiveCount(snapshot.counts.pilotDraftSessionStorage)
+  const hasUnknownDraftStorage =
+    snapshot.counts.pilotDraftLocalStorage === null || snapshot.counts.pilotDraftSessionStorage === null
+  const recommendations: OfflineLocalRecoveryRecommendation[] = []
+
+  if (hasQueuedLocalWrites) {
+    addRecommendation(recommendations, "preserve_queued_writes", "high")
+  }
+
+  if (snapshot.reason === "server") {
+    addRecommendation(recommendations, "run_in_browser", "high")
+  } else if (!snapshot.available || hasUnknownDraftStorage) {
+    addRecommendation(recommendations, "inspect_browser_storage", "high")
+  }
+
+  if (
+    snapshot.available &&
+    (snapshot.metadata.lastSyncStatus !== "fresh" ||
+      !snapshot.metadata.hasExportVersion ||
+      snapshot.counts.services === 0 ||
+      snapshot.counts.embeddings === 0)
+  ) {
+    addRecommendation(recommendations, "retry_offline_sync", hasQueuedLocalWrites ? "high" : "medium")
+  }
+
+  if (recommendations.length === 0) {
+    addRecommendation(recommendations, "no_immediate_recovery_action", "low")
+  }
+
+  return {
+    hasQueuedLocalWrites,
+    recommendations,
+  }
+}
+
+export async function buildOfflineLocalRecoverySnapshot(
+  inspectedAt = new Date()
+): Promise<OfflineLocalRecoverySnapshot> {
+  const draftCounts = getStorageDraftCounts()
+  const baseSnapshot = {
+    counts: {
+      embeddings: null,
+      pendingFeedback: null,
+      services: null,
+      ...draftCounts,
+    },
+    inspectedAt: inspectedAt.toISOString(),
+    metadata: {
+      hasExportVersion: false,
+      hasLastSync: false,
+      lastSync: null,
+      lastSyncStatus: "unknown" as const,
+    },
+  }
+
+  if (typeof window === "undefined") {
+    return {
+      ...baseSnapshot,
+      available: false,
+      reason: "server",
+    }
+  }
+
+  try {
+    const db = await getOfflineDB()
+    const [services, embeddings, pendingFeedback, lastSync, version] = await Promise.all([
+      db.count("services"),
+      db.count("embeddings"),
+      db.count("pendingFeedback"),
+      db.get("meta", "lastSync"),
+      db.get("meta", "version"),
+    ])
+
+    const lastSyncValue = typeof lastSync?.value === "string" ? lastSync.value : null
+    const lastSyncStatus = getOfflineSnapshotStatus(lastSyncValue, inspectedAt.getTime())
+
+    return {
+      ...baseSnapshot,
+      available: true,
+      counts: {
+        ...baseSnapshot.counts,
+        embeddings,
+        pendingFeedback,
+        services,
+      },
+      metadata: {
+        hasExportVersion: Boolean(version?.value),
+        hasLastSync: Boolean(lastSyncValue),
+        lastSync: lastSyncValue,
+        lastSyncStatus,
+      },
+    }
+  } catch (error) {
+    logger.warn("Unable to build offline local recovery snapshot", {
+      errorType: getRecoveryErrorType(error),
+      reason: "offline_db_unavailable",
+    })
+
+    return {
+      ...baseSnapshot,
+      available: false,
+      reason: "offline_db_unavailable",
+    }
+  }
+}

--- a/lib/offline/pilot-draft-cleanup.ts
+++ b/lib/offline/pilot-draft-cleanup.ts
@@ -1,0 +1,107 @@
+import { logger } from "@/lib/logger"
+
+export const PILOT_DRAFT_STORAGE_PREFIX = "careconnect-pilot-draft-"
+export const PILOT_DRAFT_MAX_AGE_MS = 8 * 60 * 60 * 1000
+export const PILOT_DRAFT_SCHEMA_VERSION = 1
+
+export type PilotDraftEnvelope<T = unknown> = {
+  createdAt: string
+  payload: T
+  schemaVersion: typeof PILOT_DRAFT_SCHEMA_VERSION
+}
+
+type StorageLike = Pick<Storage, "getItem" | "key" | "length" | "removeItem">
+
+export function isPilotDraftExpired(createdAt: string, nowMs = Date.now(), maxAgeMs = PILOT_DRAFT_MAX_AGE_MS): boolean {
+  const createdAtMs = Date.parse(createdAt)
+  return Number.isNaN(createdAtMs) || nowMs - createdAtMs > maxAgeMs
+}
+
+export function isPilotDraftStorageKey(key: string): boolean {
+  return key.startsWith(PILOT_DRAFT_STORAGE_PREFIX)
+}
+
+export function clearPilotDraftStorage(storage: StorageLike): string[] {
+  const removedKeys: string[] = []
+
+  for (let index = storage.length - 1; index >= 0; index -= 1) {
+    const key = storage.key(index)
+    if (!key || !isPilotDraftStorageKey(key)) continue
+
+    storage.removeItem(key)
+    removedKeys.push(key)
+  }
+
+  return removedKeys
+}
+
+export function pruneExpiredPilotDraftStorage(storage: StorageLike, nowMs = Date.now()): string[] {
+  const removedKeys: string[] = []
+
+  for (let index = storage.length - 1; index >= 0; index -= 1) {
+    const key = storage.key(index)
+    if (!key || !isPilotDraftStorageKey(key)) continue
+
+    const rawValue = storage.getItem(key)
+    if (!rawValue) {
+      storage.removeItem(key)
+      removedKeys.push(key)
+      continue
+    }
+
+    try {
+      const envelope = JSON.parse(rawValue) as Partial<PilotDraftEnvelope>
+      if (envelope.schemaVersion !== PILOT_DRAFT_SCHEMA_VERSION || !envelope.createdAt) {
+        storage.removeItem(key)
+        removedKeys.push(key)
+        continue
+      }
+
+      if (isPilotDraftExpired(envelope.createdAt, nowMs)) {
+        storage.removeItem(key)
+        removedKeys.push(key)
+      }
+    } catch {
+      storage.removeItem(key)
+      removedKeys.push(key)
+    }
+  }
+
+  return removedKeys
+}
+
+function getDraftCleanupErrorType(error: unknown): string {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name || "DOMException"
+  }
+
+  if (error instanceof Error) {
+    return "Error"
+  }
+
+  return typeof error
+}
+
+export async function clearPilotDraftStorageOnSignOut(): Promise<string[]> {
+  if (typeof window === "undefined") {
+    return []
+  }
+
+  const removedKeys: string[] = []
+
+  for (const [label, getStorage] of [
+    ["localStorage", () => window.localStorage],
+    ["sessionStorage", () => window.sessionStorage],
+  ] as const) {
+    try {
+      removedKeys.push(...clearPilotDraftStorage(getStorage()))
+    } catch (error) {
+      logger.warn("Unable to clear pilot draft storage during sign-out", {
+        errorType: getDraftCleanupErrorType(error),
+        storage: label,
+      })
+    }
+  }
+
+  return removedKeys
+}

--- a/lib/offline/sync.ts
+++ b/lib/offline/sync.ts
@@ -3,19 +3,63 @@ import { logger } from "@/lib/logger"
 import { Service } from "@/types/service"
 import { resetServiceDataCache } from "@/lib/search/data"
 
-interface SyncResult {
+export type SyncErrorSummary = {
+  errorType: string
+  httpStatus?: number
+}
+
+export interface SyncResult {
   status: "synced" | "up-to-date" | "error"
   count?: number
-  error?: unknown
+  error?: SyncErrorSummary
 }
 
 const SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+class OfflineSyncHttpError extends Error {
+  constructor(readonly status: number) {
+    super("Offline sync HTTP request failed")
+    this.name = "OfflineSyncHttpError"
+  }
+}
+
+function summarizeSyncError(error: unknown): SyncErrorSummary {
+  if (error instanceof OfflineSyncHttpError) {
+    return {
+      errorType: "HttpError",
+      httpStatus: error.status,
+    }
+  }
+
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return {
+      errorType: error.name || "DOMException",
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      errorType: "Error",
+    }
+  }
+
+  return {
+    errorType: typeof error,
+  }
+}
 
 /**
  * Syncs offline data from the API
  */
 export async function syncOfflineData(force = false, retryCount = 0): Promise<SyncResult> {
-  if (typeof window === "undefined") return { status: "error", error: "Server-side sync not supported" }
+  if (typeof window === "undefined") {
+    return {
+      status: "error",
+      error: {
+        errorType: "ServerContext",
+      },
+    }
+  }
 
   try {
     const lastSync = await getMeta<string>("lastSync")
@@ -48,7 +92,7 @@ export async function syncOfflineData(force = false, retryCount = 0): Promise<Sy
     }
 
     if (!response.ok) {
-      throw new Error(`Sync failed: ${response.status} ${response.statusText}`)
+      throw new OfflineSyncHttpError(response.status)
     }
 
     const data = (await response.json()) as {
@@ -70,7 +114,8 @@ export async function syncOfflineData(force = false, retryCount = 0): Promise<Sy
 
     return { status: "synced", count: data.count }
   } catch (error) {
-    logger.error("Offline sync error", { error })
+    const errorSummary = summarizeSyncError(error)
+    logger.warn("Offline sync error", { ...errorSummary, attempt: retryCount + 1 })
 
     // 3. Simple Retry Logic (Max 2 retries)
     if (retryCount < 2) {
@@ -80,7 +125,7 @@ export async function syncOfflineData(force = false, retryCount = 0): Promise<Sy
       return syncOfflineData(force, retryCount + 1)
     }
 
-    return { status: "error", error }
+    return { status: "error", error: errorSummary }
   }
 }
 

--- a/lib/pilot/event-replay-policy.ts
+++ b/lib/pilot/event-replay-policy.ts
@@ -1,0 +1,121 @@
+import { createHash } from "crypto"
+import type { PilotContactAttemptEvent } from "@/types/pilot-contact-attempt"
+import type { PilotReferralEvent } from "@/types/pilot-referral"
+import type {
+  PilotConnectionEvent,
+  PilotDataDecayAudit,
+  PilotPreferenceFitEvent,
+  ServiceOperationalStatusEvent,
+} from "@/types/pilot-instrumentation"
+
+export type PilotReplayPayloads = {
+  connection: Omit<PilotConnectionEvent, "id">
+  contact_attempt: Omit<PilotContactAttemptEvent, "id">
+  data_decay_audit: Omit<PilotDataDecayAudit, "id">
+  preference_fit: Omit<PilotPreferenceFitEvent, "id">
+  referral: Omit<PilotReferralEvent, "id">
+  service_status: Omit<ServiceOperationalStatusEvent, "id">
+}
+
+export type PilotReplayEventKind = keyof PilotReplayPayloads
+
+export const PILOT_EVENT_REPLAY_CRITERIA = {
+  connection: [
+    "pilot_cycle_id",
+    "org_id",
+    "service_id",
+    "connected_at",
+    "contact_attempt_event_id",
+    "referral_event_id",
+  ],
+  contact_attempt: [
+    "pilot_cycle_id",
+    "service_id",
+    "recorded_by_org_id",
+    "entity_key_hash",
+    "attempt_channel",
+    "attempt_outcome",
+    "attempted_at",
+    "resolved_at",
+    "outcome_notes_code",
+  ],
+  data_decay_audit: [
+    "pilot_cycle_id",
+    "org_id",
+    "service_id",
+    "audited_at",
+    "is_fatal",
+    "fatal_error_category",
+    "verification_mode",
+  ],
+  preference_fit: ["pilot_cycle_id", "org_id", "cohort_label", "recorded_at", "preferred_via_careconnect"],
+  referral: [
+    "pilot_cycle_id",
+    "source_org_id",
+    "target_service_id",
+    "referral_state",
+    "created_at",
+    "updated_at",
+    "terminal_at",
+    "failure_reason_code",
+  ],
+  service_status: ["pilot_cycle_id", "org_id", "service_id", "checked_at", "status_code"],
+} satisfies {
+  [Kind in PilotReplayEventKind]: readonly (keyof PilotReplayPayloads[Kind])[]
+}
+
+type JsonCompatible = boolean | number | string | null | JsonCompatible[] | { [key: string]: JsonCompatible }
+
+export type PilotEventReplayMaterial<Kind extends PilotReplayEventKind = PilotReplayEventKind> = {
+  criteria: Record<string, unknown>
+  kind: Kind
+}
+
+function normalizeForHash(value: unknown): JsonCompatible {
+  if (value === undefined || value === null) {
+    return null
+  }
+
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForHash(item))
+  }
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>
+    const normalized: Record<string, JsonCompatible> = {}
+    for (const key of Object.keys(record).sort()) {
+      normalized[key] = normalizeForHash(record[key])
+    }
+    return normalized
+  }
+
+  return String(value)
+}
+
+export function buildPilotEventReplayMaterial<Kind extends PilotReplayEventKind>(
+  kind: Kind,
+  payload: PilotReplayPayloads[Kind]
+): PilotEventReplayMaterial<Kind> {
+  const criteria: Record<string, unknown> = {}
+  const record = payload as Record<string, unknown>
+
+  for (const key of PILOT_EVENT_REPLAY_CRITERIA[kind]) {
+    criteria[String(key)] = record[String(key)] ?? null
+  }
+
+  return { kind, criteria }
+}
+
+export function buildPilotEventReplayFingerprint<Kind extends PilotReplayEventKind>(
+  kind: Kind,
+  payload: PilotReplayPayloads[Kind]
+): string {
+  const material = buildPilotEventReplayMaterial(kind, payload)
+  const canonicalMaterial = JSON.stringify(normalizeForHash(material))
+
+  return createHash("sha256").update(canonicalMaterial).digest("hex")
+}

--- a/lib/pilot/readiness-audit.ts
+++ b/lib/pilot/readiness-audit.ts
@@ -1,7 +1,8 @@
 import { createClient } from "@supabase/supabase-js"
 import fs from "fs/promises"
+import { z } from "zod"
 import type { Service } from "@/types/service"
-import type { PilotScopeSlaTier } from "@/types/pilot-instrumentation"
+import { PILOT_SCOPE_SLA_TIERS, type PilotScopeSlaTier } from "@/types/pilot-instrumentation"
 import type { Database } from "@/types/supabase"
 
 export interface PilotScopeEntry {
@@ -56,11 +57,65 @@ interface ScopeFilePayload {
   services?: PilotScopeEntry[]
 }
 
+const PilotScopeEntrySchema = z
+  .object({
+    service_id: z.string().min(1).max(100),
+    sla_tier: z.enum(PILOT_SCOPE_SLA_TIERS),
+    org_id: z.string().uuid().optional(),
+    pilot_cycle_id: z.string().min(1).max(100).optional(),
+  })
+  .strict()
+
 const STALENESS_THRESHOLDS = {
   crisis: 30,
   general: 90,
   stale: 180,
 } as const
+
+function formatScopeIssuePath(path: (string | number)[]): string {
+  const [entryIndex, ...fieldPath] = path
+  const entryLabel = typeof entryIndex === "number" ? `entry ${entryIndex + 1}` : "entry"
+  const fieldLabel = fieldPath.length > 0 ? fieldPath.join(".") : "value"
+  return `${entryLabel} ${fieldLabel}`
+}
+
+function parsePilotScopeEntries(entries: unknown[], source: "file" | "Supabase" | "report"): PilotScopeEntry[] {
+  const result = z.array(PilotScopeEntrySchema).safeParse(entries)
+
+  if (!result.success) {
+    const issuePaths = [...new Set(result.error.issues.map((issue) => formatScopeIssuePath(issue.path)))]
+    throw new Error(`Invalid pilot scope ${source} entries: ${issuePaths.join(", ")}`)
+  }
+
+  const seenEntries = new Map<string, number>()
+  for (const [index, entry] of result.data.entries()) {
+    const identityKey = [entry.pilot_cycle_id ?? "", entry.org_id ?? "", entry.service_id].join("\u001f")
+    const existingIndex = seenEntries.get(identityKey)
+
+    if (existingIndex !== undefined) {
+      throw new Error(`Invalid pilot scope ${source} entries: entry ${index + 1} duplicates entry ${existingIndex + 1}`)
+    }
+
+    seenEntries.set(identityKey, index)
+  }
+
+  return result.data
+}
+
+function extractScopeEntriesFromFilePayload(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  if (payload && typeof payload === "object") {
+    const services = (payload as ScopeFilePayload).services
+    if (Array.isArray(services)) {
+      return services
+    }
+  }
+
+  throw new Error("Invalid pilot scope file: expected an array or an object with a services array")
+}
 
 function isActive(service: Service): boolean {
   if (service.deleted_at) return false
@@ -102,13 +157,15 @@ function getVerificationStatus(service: Service): "missing" | "fresh" | "due" | 
 
 export async function loadPilotScopeEntriesFromFile(filePath: string): Promise<PilotScopeEntry[]> {
   const raw = await fs.readFile(filePath, "utf-8")
-  const parsed = JSON.parse(raw) as PilotScopeEntry[] | ScopeFilePayload
+  let parsed: unknown
 
-  if (Array.isArray(parsed)) {
-    return parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new Error("Invalid pilot scope file: JSON parse failed")
   }
 
-  return parsed.services ?? []
+  return parsePilotScopeEntries(extractScopeEntriesFromFilePayload(parsed), "file")
 }
 
 export async function loadPilotScopeEntriesFromSupabase(options: {
@@ -135,14 +192,15 @@ export async function loadPilotScopeEntriesFromSupabase(options: {
 
   const { data, error } = await query.order("service_id", { ascending: true })
   if (error) {
-    throw new Error(`Failed to load pilot scope: ${error.message}`)
+    throw new Error(`Failed to load pilot scope from Supabase (${error.code ?? "unknown"})`)
   }
 
-  return (data ?? []) as PilotScopeEntry[]
+  return parsePilotScopeEntries(data ?? [], "Supabase")
 }
 
 export function buildPilotReadinessReport(services: Service[], scopeEntries: PilotScopeEntry[]): PilotReadinessReport {
   const serviceMap = new Map(services.map((service) => [service.id, service]))
+  const validScopeEntries = parsePilotScopeEntries(scopeEntries, "report")
   const matchedRows: PilotReadinessServiceRow[] = []
   const missingServiceRecords: string[] = []
 
@@ -165,7 +223,7 @@ export function buildPilotReadinessReport(services: Service[], scopeEntries: Pil
     verification_stale: 0,
   }
 
-  for (const entry of scopeEntries) {
+  for (const entry of validScopeEntries) {
     slaTierDistribution[entry.sla_tier] += 1
     const service = serviceMap.get(entry.service_id)
     if (!service) {
@@ -214,7 +272,7 @@ export function buildPilotReadinessReport(services: Service[], scopeEntries: Pil
 
   return {
     generated_at: new Date().toISOString(),
-    total_scoped_services: scopeEntries.length,
+    total_scoped_services: validScopeEntries.length,
     matched_services: matchedRows.length,
     missing_service_records: missingServiceRecords,
     verification_level_distribution: verificationLevelDistribution,
@@ -261,7 +319,8 @@ export function renderPilotReadinessMarkdown(report: PilotReadinessReport): stri
 
 function csvEscape(value: string | boolean | null): string {
   if (value === null) return ""
-  const text = String(value)
+  const rawText = String(value)
+  const text = /^[=+\-@\t\r]|^\s+[=+\-@]/.test(rawText) ? `'${rawText}` : rawText
   if (text.includes(",") || text.includes('"') || text.includes("\n")) {
     return `"${text.replaceAll('"', '""')}"`
   }

--- a/lib/pilot/responses.ts
+++ b/lib/pilot/responses.ts
@@ -1,0 +1,11 @@
+import { createApiResponse } from "@/lib/api-utils"
+
+const PILOT_NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const
+
+export function createPilotWriteSuccessResponse(status = 201) {
+  return createApiResponse({ success: true }, { status, headers: PILOT_NO_STORE_HEADERS })
+}
+
+export function createPilotIdempotentRetryResponse() {
+  return createApiResponse({ success: true, duplicate: true }, { status: 200, headers: PILOT_NO_STORE_HEADERS })
+}

--- a/lib/pilot/storage.ts
+++ b/lib/pilot/storage.ts
@@ -16,16 +16,20 @@ import type { Database } from "@/types/supabase"
 
 type DatabaseError = {
   code?: string
+  constraint?: string
+  details?: string
   message?: string
 }
 
 export type PilotStorageResult<T> = {
   data: T | null
+  duplicate?: boolean
   error: DatabaseError | null
   missingTable: boolean
 }
 
 type PilotSupabaseClient = SupabaseClient<Database>
+type PilotEventInsert<T extends { id: string }> = Omit<T, "id"> & Partial<Pick<T, "id">>
 type ContactAttemptRow = Database["public"]["Tables"]["pilot_contact_attempt_events"]["Row"]
 type ReferralRow = Database["public"]["Tables"]["pilot_referral_events"]["Row"]
 type ConnectionRow = Database["public"]["Tables"]["pilot_connection_events"]["Row"]
@@ -44,34 +48,61 @@ function isMissingTableError(error: DatabaseError | null): boolean {
   return error.code === "42P01" || /does not exist|relation/i.test(error.message || "")
 }
 
+function isDuplicatePrimaryKeyError(error: DatabaseError | null): boolean {
+  if (!error) return false
+  const isDuplicate = error.code === "23505" || /duplicate key/i.test(error.message || "")
+  if (!isDuplicate) return false
+
+  return (
+    /(^|_)pkey$/i.test(error.constraint || "") ||
+    /unique constraint "[^"]*_pkey"/i.test(error.message || "") ||
+    /Key \(id\)=/i.test(error.details || "")
+  )
+}
+
+function toPilotStorageResult<T, Payload extends { id?: string }>(
+  data: T | null | undefined,
+  error: DatabaseError | null,
+  payload: Payload
+): PilotStorageResult<T> {
+  const duplicate = Boolean(payload.id && isDuplicatePrimaryKeyError(error))
+
+  return {
+    data: data ?? null,
+    duplicate,
+    error: duplicate ? null : error,
+    missingTable: duplicate ? false : isMissingTableError(error),
+  }
+}
+
 export async function insertContactAttempt(
   supabase: PilotSupabaseClient,
-  payload: Omit<PilotContactAttemptEvent, "id">
+  payload: PilotEventInsert<PilotContactAttemptEvent>
 ): Promise<PilotStorageResult<ContactAttemptRow>> {
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("pilot_contact_attempt_events").insert(payload).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return toPilotStorageResult(data, error, payload)
 }
 
 export async function insertReferralEvent(
   supabase: PilotSupabaseClient,
-  payload: Omit<PilotReferralEvent, "id">
+  payload: PilotEventInsert<PilotReferralEvent>
 ): Promise<PilotStorageResult<ReferralRow>> {
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("pilot_referral_events").insert(payload).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return toPilotStorageResult(data, error, payload)
 }
 
 export async function insertConnectionEvent(
   supabase: PilotSupabaseClient,
-  payload: Omit<PilotConnectionEvent, "id">
+  payload: PilotEventInsert<PilotConnectionEvent>
 ): Promise<PilotStorageResult<ConnectionRow>> {
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("pilot_connection_events").insert(payload).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return toPilotStorageResult(data, error, payload)
 }
 
 export async function upsertPilotScopeService(
@@ -85,37 +116,37 @@ export async function upsertPilotScopeService(
       .select()
       .single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return { data: data ?? null, duplicate: false, error, missingTable: isMissingTableError(error) }
 }
 
 export async function insertServiceOperationalStatusEvent(
   supabase: PilotSupabaseClient,
-  payload: Omit<ServiceOperationalStatusEvent, "id">
+  payload: PilotEventInsert<ServiceOperationalStatusEvent>
 ): Promise<PilotStorageResult<ServiceStatusRow>> {
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("service_operational_status_events").insert(payload).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return toPilotStorageResult(data, error, payload)
 }
 
 export async function insertPilotDataDecayAudit(
   supabase: PilotSupabaseClient,
-  payload: Omit<PilotDataDecayAudit, "id">
+  payload: PilotEventInsert<PilotDataDecayAudit>
 ): Promise<PilotStorageResult<DataDecayAuditRow>> {
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("pilot_data_decay_audits").insert(payload).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return toPilotStorageResult(data, error, payload)
 }
 
 export async function insertPilotPreferenceFitEvent(
   supabase: PilotSupabaseClient,
-  payload: Omit<PilotPreferenceFitEvent, "id">
+  payload: PilotEventInsert<PilotPreferenceFitEvent>
 ): Promise<PilotStorageResult<PreferenceFitRow>> {
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("pilot_preference_fit_events").insert(payload).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return toPilotStorageResult(data, error, payload)
 }
 
 export async function updateReferralEvent(
@@ -126,7 +157,7 @@ export async function updateReferralEvent(
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("pilot_referral_events").update(payload).eq("id", id).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return { data: data ?? null, duplicate: false, error, missingTable: isMissingTableError(error) }
 }
 
 export async function insertIntegrationDecision(
@@ -136,7 +167,7 @@ export async function insertIntegrationDecision(
   const { data, error } = await withCircuitBreaker(async () =>
     supabase.from("pilot_integration_feasibility_decisions").insert(payload).select().single()
   )
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return { data: data ?? null, duplicate: false, error, missingTable: isMissingTableError(error) }
 }
 
 export async function insertPilotMetricSnapshots(
@@ -163,7 +194,7 @@ export async function insertPilotMetricSnapshots(
       .select("metric_id, metric_value, numerator, denominator, calculated_at")
   )
 
-  return { data: data ?? null, error, missingTable: isMissingTableError(error) }
+  return { data: data ?? null, duplicate: false, error, missingTable: isMissingTableError(error) }
 }
 
 export async function getScorecardByCycle(
@@ -181,11 +212,11 @@ export async function getScorecardByCycle(
   )
 
   if (isMissingTableError(error)) {
-    return { data: null, error, missingTable: true }
+    return { data: null, duplicate: false, error, missingTable: true }
   }
 
   if (error || !data) {
-    return { data: null, error, missingTable: false }
+    return { data: null, duplicate: false, error, missingTable: false }
   }
 
   const byMetric = new Map<SnapshotRow["metric_id"], number | null>()
@@ -226,5 +257,5 @@ export async function getScorecardByCycle(
   scorecard.m6_data_decay_fatal_error_rate = byMetric.get("M6") ?? null
   scorecard.m7_preference_fit_indicator = byMetric.get("M7") ?? null
 
-  return { data: scorecard, error: null, missingTable: false }
+  return { data: scorecard, duplicate: false, error: null, missingTable: false }
 }

--- a/lib/schemas/pilot-events.ts
+++ b/lib/schemas/pilot-events.ts
@@ -20,6 +20,7 @@ const ServiceOperationalStatusCodeEnum = z.enum(SERVICE_OPERATIONAL_STATUS_CODES
 const DataDecayFatalErrorCategoryEnum = z.enum(PILOT_DATA_DECAY_FATAL_ERROR_CATEGORIES)
 const DataDecayVerificationModeEnum = z.enum(PILOT_DATA_DECAY_VERIFICATION_MODES)
 const Sha256HexSchema = z.string().regex(/^[0-9a-fA-F]{64}$/, "entity_key_hash must be a SHA-256 hex digest")
+const ClientEventIdSchema = z.string().uuid()
 
 function addPrivacyFieldIssues(value: unknown, context: z.RefinementCtx) {
   const disallowedPaths = findDisallowedPrivacyKeyPaths(value)
@@ -33,6 +34,7 @@ function addPrivacyFieldIssues(value: unknown, context: z.RefinementCtx) {
 
 export const PilotContactAttemptCreateSchema = z
   .object({
+    id: ClientEventIdSchema.optional(),
     pilot_cycle_id: z.string().min(1).max(100),
     service_id: z.string().min(1).max(100),
     recorded_by_org_id: z.string().uuid(),
@@ -48,6 +50,7 @@ export const PilotContactAttemptCreateSchema = z
 
 export const PilotReferralCreateSchema = z
   .object({
+    id: ClientEventIdSchema.optional(),
     pilot_cycle_id: z.string().min(1).max(100),
     source_org_id: z.string().uuid(),
     target_service_id: z.string().min(1).max(100),
@@ -62,6 +65,7 @@ export const PilotReferralCreateSchema = z
 
 export const PilotConnectionCreateSchema = z
   .object({
+    id: ClientEventIdSchema.optional(),
     pilot_cycle_id: z.string().min(1).max(100),
     org_id: z.string().uuid(),
     service_id: z.string().min(1).max(100),
@@ -94,6 +98,7 @@ export const PilotServiceScopeCreateSchema = z
 
 export const ServiceOperationalStatusEventCreateSchema = z
   .object({
+    id: ClientEventIdSchema.optional(),
     pilot_cycle_id: z.string().min(1).max(100),
     org_id: z.string().uuid(),
     service_id: z.string().min(1).max(100),
@@ -105,6 +110,7 @@ export const ServiceOperationalStatusEventCreateSchema = z
 
 export const PilotDataDecayAuditCreateSchema = z
   .object({
+    id: ClientEventIdSchema.optional(),
     pilot_cycle_id: z.string().min(1).max(100),
     org_id: z.string().uuid(),
     service_id: z.string().min(1).max(100),
@@ -136,6 +142,7 @@ export const PilotDataDecayAuditCreateSchema = z
 
 export const PilotPreferenceFitEventCreateSchema = z
   .object({
+    id: ClientEventIdSchema.optional(),
     pilot_cycle_id: z.string().min(1).max(100),
     org_id: z.string().uuid(),
     cohort_label: z.string().min(1).max(100),

--- a/lib/schemas/privacy-guards.ts
+++ b/lib/schemas/privacy-guards.ts
@@ -1,4 +1,29 @@
-const DISALLOWED_PRIVACY_KEYS = new Set(["query", "query_text", "message", "user_text", "notes"])
+const DISALLOWED_PRIVACY_KEYS = new Set([
+  "client_address",
+  "client_name",
+  "comment",
+  "comments",
+  "contact_email",
+  "contact_name",
+  "contact_phone",
+  "email",
+  "email_address",
+  "first_name",
+  "free_text",
+  "full_name",
+  "home_address",
+  "last_name",
+  "message",
+  "note",
+  "notes",
+  "person_name",
+  "phone",
+  "phone_number",
+  "query",
+  "query_text",
+  "street_address",
+  "user_text",
+])
 
 function walk(value: unknown, path: string[] = [], found: string[] = []): string[] {
   if (!value || typeof value !== "object") {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "format:check": "prettier --check .",
     "ci:check": "bash scripts/validate-ci.sh",
     "check:v22-gate0": "bash scripts/check-v22-gate0-exit.sh",
+    "check:v22-evidence": "bash scripts/check-v22-evidence-intake.sh",
+    "check:v22-threat-model": "bash scripts/check-v22-threat-model.sh",
     "check:refs": "node --import tsx scripts/check-references.ts",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/scripts/check-v22-evidence-intake.sh
+++ b/scripts/check-v22-evidence-intake.sh
@@ -1,0 +1,792 @@
+#!/bin/bash
+# Validate v22.0 Gate 0 C1/D4 evidence-intake consistency.
+# This guard does not judge legal sufficiency or partner quality. It only
+# prevents docs from claiming C1/D4 closure while canonical evidence remains
+# prep-only or placeholder-only.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+CHECKLIST_PATH="${GATE0_CHECKLIST_PATH:-$PROJECT_ROOT/docs/implementation/v22-0-gate-0-exit-checklist.md}"
+TRACKER_PATH="${GATE0_TRACKER_PATH:-$PROJECT_ROOT/docs/implementation/v22-0-gate-0-user-action-tracker.md}"
+C1_CONTROL_PATH="${GATE0_C1_CONTROL_PATH:-$PROJECT_ROOT/docs/implementation/v22-0-control-c1-legal-review.md}"
+C1_EVIDENCE_DIR="${GATE0_C1_EVIDENCE_DIR:-$PROJECT_ROOT/docs/implementation/v22-0-evidence/c1-partner-terms}"
+D4_EVIDENCE_DIR="${GATE0_D4_EVIDENCE_DIR:-$PROJECT_ROOT/docs/implementation/v22-0-evidence/d4-partner-ops}"
+
+errors=()
+D4_PROVIDER_TARGET_COUNT=0
+D4_FRONTLINE_ORG_TARGET_COUNT=0
+D4_OUTREACH_EXECUTION_ROW_COUNT=0
+D4_ARTIFACT_REFERENCES=$'\n'
+D4_HAS_OUTREACH_ARTIFACT_REFERENCE=0
+C1_INVENTORY_MATRIX_REFERENCES=$'\n'
+C1_INVENTORY_HAS_MATRIX_REFERENCE=0
+
+add_error() {
+  errors+=("$1")
+}
+
+require_file() {
+  local path="$1"
+  local label="$2"
+
+  if [[ ! -f "$path" ]]; then
+    add_error "$label not found at: $path"
+  fi
+}
+
+normalize_status() {
+  echo "$1" | tr -d '[:space:]*`' | tr '[:lower:]' '[:upper:]'
+}
+
+trim_value() {
+  sed 's/^ *//;s/ *$//' <<<"$1"
+}
+
+normalize_markdown_row() {
+  awk -F'|' '
+    {
+      output = "|"
+      for (i = 2; i < NF; i++) {
+        cell = $i
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", cell)
+        output = output " " cell " |"
+      }
+      print output
+    }
+  ' <<<"$1"
+}
+
+markdown_cell() {
+  local file="$1"
+  local row_id="$2"
+  local cell_number="$3"
+  local row
+
+  row="$(grep -E "^\|[[:space:]]*$row_id[[:space:]]*\|" "$file" | head -n 1 || true)"
+
+  if [[ -z "$row" ]]; then
+    echo ""
+    return
+  fi
+
+  awk -F'|' -v cell="$cell_number" '{print $cell}' <<<"$row" | sed 's/^ *//;s/ *$//'
+}
+
+gate_status() {
+  normalize_status "$(markdown_cell "$CHECKLIST_PATH" "$1" 4)"
+}
+
+action_status() {
+  normalize_status "$(markdown_cell "$TRACKER_PATH" "$1" 6)"
+}
+
+frontmatter_field() {
+  local file="$1"
+  local field="$2"
+
+  awk -v field="$field" '
+    NR == 1 && $0 == "---" { in_frontmatter = 1; next }
+    in_frontmatter && $0 == "---" { exit }
+    in_frontmatter && $0 ~ "^" field ":" {
+      sub("^" field ":[[:space:]]*", "", $0)
+      print $0
+      exit
+    }
+  ' "$file"
+}
+
+is_prep_only() {
+  local file="$1"
+  local value
+
+  value="$(frontmatter_field "$file" "evidence_status" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  [[ "$value" == "prep_only" ]]
+}
+
+line_value() {
+  local file="$1"
+  local label="$2"
+  local line
+
+  line="$(grep -E "^(-[[:space:]]*)?$label(:|\\?)" "$file" | head -n 1 || true)"
+
+  if [[ -z "$line" ]]; then
+    echo ""
+    return
+  fi
+
+  sed -E "s/^(-[[:space:]]*)?$label(:|\\?)[[:space:]]*//" <<<"$line" | sed 's/^ *//;s/ *$//'
+}
+
+is_blank_or_pending() {
+  local value
+
+  value="$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/^ *//;s/ *$//')"
+
+  [[ -z "$value" || "$value" == "pending" || "$value" == "n/a" || "$value" == "not attached" ]]
+}
+
+require_filled_line() {
+  local file="$1"
+  local label="$2"
+  local value
+
+  value="$(line_value "$file" "$label")"
+  if is_blank_or_pending "$value"; then
+    add_error "$file must include a non-placeholder '$label' value."
+  fi
+}
+
+require_date_line() {
+  local file="$1"
+  local label="$2"
+  local value
+
+  value="$(line_value "$file" "$label")"
+  if is_blank_or_pending "$value"; then
+    add_error "$file must include a non-placeholder '$label' value."
+  elif [[ ! "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    add_error "$file must include a '$label' value in YYYY-MM-DD format."
+  fi
+}
+
+require_positive_integer_line() {
+  local file="$1"
+  local label="$2"
+  local value
+
+  value="$(line_value "$file" "$label")"
+  if is_blank_or_pending "$value"; then
+    add_error "$file must include a non-placeholder '$label' value."
+  elif [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    add_error "$file must include a positive integer '$label' value."
+  fi
+}
+
+require_submission_id_matches_file() {
+  local file="$1"
+  local expected_id="$2"
+  local actual_id
+
+  actual_id="$(line_value "$file" "Submission ID")"
+  if is_blank_or_pending "$actual_id"; then
+    add_error "$file must include a non-placeholder 'Submission ID' value."
+  elif [[ "$actual_id" != "$expected_id" ]]; then
+    add_error "$file Submission ID '$actual_id' must match filename-derived ID '$expected_id'."
+  fi
+}
+
+latest_non_prep_submission() {
+  local dir="$1"
+  local prefix="$2"
+  local candidate
+
+  while IFS= read -r candidate; do
+    if ! is_prep_only "$candidate"; then
+      echo "$candidate"
+    fi
+  done < <(find "$dir" -maxdepth 1 -type f -name "$prefix-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-submission.md" | sort)
+}
+
+submission_id_from_file() {
+  basename "$1" "-submission.md"
+}
+
+requires_c1_closure_evidence() {
+  local g0_status="$1"
+  local ua_status="$2"
+
+  [[ "$g0_status" == "PASS" || "$ua_status" == "COMPLETE" ]]
+}
+
+requires_d4_closure_evidence() {
+  local g0_status="$1"
+  local ua_status="$2"
+
+  [[ "$g0_status" == "PASS" || "$ua_status" == "COMPLETE" ]]
+}
+
+validate_status_pair() {
+  local gate_id="$1"
+  local gate_value="$2"
+  local action_id="$3"
+  local action_value="$4"
+
+  case "$gate_value" in
+    PASS|PENDING|FAIL) ;;
+    *) add_error "$gate_id has unknown status '$gate_value' in $CHECKLIST_PATH." ;;
+  esac
+
+  case "$action_value" in
+    COMPLETE|IN_PROGRESS|PENDING) ;;
+    *) add_error "$action_id has unknown status '$action_value' in $TRACKER_PATH." ;;
+  esac
+
+  if [[ "$gate_value" == "PASS" && "$action_value" != "COMPLETE" ]]; then
+    add_error "$gate_id is pass but $action_id is not complete."
+  fi
+
+  if [[ "$action_value" == "COMPLETE" && "$gate_value" != "PASS" ]]; then
+    add_error "$action_id is complete but $gate_id is not pass."
+  fi
+}
+
+validate_c1_matrix() {
+  local matrix_path="$1"
+  local inventory_path="$2"
+  local expected_header="| Clause ID | Source artifact | Source section / page | Requirement under review | Outcome | Notes / rationale | Required mitigation or fallback |"
+  local header_line
+  local clause_id
+  local row
+  local row_count
+  local source_artifact
+  local source_section
+  local outcome
+  local notes_rationale
+  local mitigation
+
+  if [[ ! -f "$matrix_path" ]]; then
+    add_error "C1 clause matrix not found at: $matrix_path"
+    return
+  fi
+
+  if is_prep_only "$matrix_path"; then
+    add_error "C1 clause matrix is still marked evidence_status: prep_only: $matrix_path"
+  fi
+
+  header_line="$(grep -E '^\|[[:space:]]*Clause ID[[:space:]]*\|' "$matrix_path" | head -n 1 || true)"
+  if [[ "$(normalize_markdown_row "$header_line")" != "$expected_header" ]]; then
+    add_error "$matrix_path must use the canonical C1 clause matrix header."
+  fi
+
+  for clause_id in C1-1 C1-2 C1-3 C1-4; do
+    row_count="$(grep -Ec "^\|[[:space:]]*$clause_id[[:space:]]*\|" "$matrix_path" || true)"
+    row="$(grep -E "^\|[[:space:]]*$clause_id[[:space:]]*\|" "$matrix_path" | head -n 1 || true)"
+
+    if [[ "$row_count" -eq 0 ]]; then
+      add_error "C1 clause matrix is missing row $clause_id."
+      continue
+    fi
+
+    if [[ "$row_count" -gt 1 ]]; then
+      add_error "$matrix_path must include exactly one row for $clause_id; found $row_count."
+      continue
+    fi
+
+    source_artifact="$(awk -F'|' '{print $3}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    source_section="$(awk -F'|' '{print $4}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    outcome="$(normalize_status "$(awk -F'|' '{print $6}' <<<"$row")")"
+    notes_rationale="$(awk -F'|' '{print $7}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    mitigation="$(awk -F'|' '{print $8}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+
+    if is_blank_or_pending "$source_artifact"; then
+      add_error "$matrix_path row $clause_id must reference a source artifact."
+    elif [[ "$C1_INVENTORY_HAS_MATRIX_REFERENCE" -eq 1 ]] &&
+      ! grep -Fqx -- "$source_artifact" <<<"$C1_INVENTORY_MATRIX_REFERENCES"; then
+      add_error "$matrix_path row $clause_id source artifact '$source_artifact' must appear as an Artifact ID or Filename / location in $inventory_path with Used in clause matrix = yes."
+    fi
+
+    if is_blank_or_pending "$source_section"; then
+      add_error "$matrix_path row $clause_id must reference a source section or page."
+    fi
+
+    case "$outcome" in
+      PASS|FAIL|NEEDSCLARIFICATION|ACCEPTABLE|ACCEPTABLE_WITH_CONDITIONS|NOT_ACCEPTABLE) ;;
+      *) add_error "$matrix_path row $clause_id has placeholder or unknown outcome '$outcome'." ;;
+    esac
+
+    case "$outcome" in
+      FAIL|NEEDSCLARIFICATION|ACCEPTABLE_WITH_CONDITIONS|NOT_ACCEPTABLE)
+        if is_blank_or_pending "$notes_rationale"; then
+          add_error "$matrix_path row $clause_id must include notes / rationale for non-pass outcomes."
+        fi
+
+        if is_blank_or_pending "$mitigation"; then
+          add_error "$matrix_path row $clause_id must include required mitigation or fallback for non-pass outcomes."
+        fi
+        ;;
+    esac
+  done
+}
+
+validate_c1_artifact_inventory() {
+  local inventory_path="$1"
+  local expected_header="| Artifact ID | Filename / location | Artifact type | Source / owner | Date received | Used in clause matrix | Notes |"
+  local header_line
+  local row
+  local artifact_id
+  local filename_location
+  local artifact_type
+  local source_owner
+  local date_received
+  local used_in_clause_matrix
+  local row_count=0
+  local matrix_reference_count=0
+
+  C1_INVENTORY_MATRIX_REFERENCES=$'\n'
+  C1_INVENTORY_HAS_MATRIX_REFERENCE=0
+
+  if [[ ! -f "$inventory_path" ]]; then
+    add_error "C1 artifact inventory not found at: $inventory_path"
+    return
+  fi
+
+  if is_prep_only "$inventory_path"; then
+    add_error "C1 artifact inventory is still marked evidence_status: prep_only: $inventory_path"
+  fi
+
+  header_line="$(grep -E '^\|[[:space:]]*Artifact ID[[:space:]]*\|' "$inventory_path" | head -n 1 || true)"
+  if [[ "$(normalize_markdown_row "$header_line")" != "$expected_header" ]]; then
+    add_error "$inventory_path must use the canonical C1 artifact inventory header."
+  fi
+
+  while IFS= read -r row; do
+    artifact_id="$(awk -F'|' '{print $2}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    filename_location="$(awk -F'|' '{print $3}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    artifact_type="$(awk -F'|' '{print $4}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    source_owner="$(awk -F'|' '{print $5}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    date_received="$(awk -F'|' '{print $6}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    used_in_clause_matrix="$(normalize_status "$(awk -F'|' '{print $7}' <<<"$row")")"
+
+    if [[ "$artifact_id" == "Artifact ID" || "$artifact_id" =~ ^-+$ ]]; then
+      continue
+    fi
+
+    row_count=$((row_count + 1))
+
+    if is_blank_or_pending "$artifact_id"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Artifact ID."
+    fi
+
+    if is_blank_or_pending "$filename_location"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Filename / location."
+    fi
+
+    if is_blank_or_pending "$artifact_type"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Artifact type."
+    fi
+
+    if is_blank_or_pending "$source_owner"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Source / owner."
+    fi
+
+    if is_blank_or_pending "$date_received"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Date received."
+    elif [[ ! "$date_received" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      add_error "$inventory_path row $row_count must include Date received in YYYY-MM-DD format."
+    fi
+
+    case "$used_in_clause_matrix" in
+      YES|NO) ;;
+      *) add_error "$inventory_path row $row_count must mark Used in clause matrix as yes or no." ;;
+    esac
+
+    if [[ "$used_in_clause_matrix" == "YES" ]]; then
+      matrix_reference_count=$((matrix_reference_count + 1))
+      C1_INVENTORY_MATRIX_REFERENCES+="$artifact_id"$'\n'
+      C1_INVENTORY_MATRIX_REFERENCES+="$filename_location"$'\n'
+    fi
+  done < <(grep -E '^\|' "$inventory_path" || true)
+
+  if [[ "$row_count" -eq 0 ]]; then
+    add_error "$inventory_path must include at least one artifact row."
+  fi
+
+  if [[ "$matrix_reference_count" -eq 0 ]]; then
+    add_error "$inventory_path must include at least one artifact marked Used in clause matrix = yes."
+  else
+    C1_INVENTORY_HAS_MATRIX_REFERENCE=1
+  fi
+}
+
+validate_c1_closure_evidence() {
+  local submission
+  local latest_submission=""
+  local submission_id
+  local matrix_path
+  local inventory_path
+  local recommendation
+
+  while IFS= read -r submission; do
+    latest_submission="$submission"
+  done < <(latest_non_prep_submission "$C1_EVIDENCE_DIR" "C1")
+
+  if [[ -z "$latest_submission" ]]; then
+    add_error "C1 is marked for closure but no non-prep C1 submission exists in $C1_EVIDENCE_DIR."
+    return
+  fi
+
+  submission_id="$(submission_id_from_file "$latest_submission")"
+  require_submission_id_matches_file "$latest_submission" "$submission_id"
+  require_filled_line "$latest_submission" "Submitted by"
+  require_filled_line "$latest_submission" "Reviewer"
+  require_date_line "$latest_submission" "Date"
+  require_filled_line "$latest_submission" "Partner"
+  require_filled_line "$latest_submission" "Partner artifact bundle location"
+  require_filled_line "$latest_submission" "Decision owner"
+  require_date_line "$latest_submission" "Sign-off date"
+
+  recommendation="$(line_value "$latest_submission" "Final legal recommendation" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case "$recommendation" in
+    acceptable|acceptable_with_conditions|not_acceptable) ;;
+    *) add_error "$latest_submission must include a final legal recommendation of acceptable, acceptable_with_conditions, or not_acceptable." ;;
+  esac
+
+  matrix_path="$C1_EVIDENCE_DIR/$submission_id-clause-matrix.md"
+  inventory_path="$C1_EVIDENCE_DIR/$submission_id-artifact-inventory.md"
+  validate_c1_artifact_inventory "$inventory_path"
+  validate_c1_matrix "$matrix_path" "$inventory_path"
+
+  if grep -E '^- Result:[[:space:]]*`?pending`?[[:space:]]*$' "$C1_CONTROL_PATH" >/dev/null; then
+    add_error "C1 closure evidence exists, but $C1_CONTROL_PATH still has Result: pending."
+  fi
+}
+
+validate_d4_partner_list() {
+  local partner_list_path="$1"
+  local expected_header="| Organization / Partner | Partner type | Primary contact | Contact channel | Priority | Status | Notes |"
+  local header_line
+  local provider_count=0
+  local frontline_count=0
+  local invalid_type_rows=0
+  local duplicate_rows=0
+  local row
+  local organization
+  local partner_type
+  local organization_key
+  local seen_organizations=$'\n'
+
+  D4_PROVIDER_TARGET_COUNT=0
+  D4_FRONTLINE_ORG_TARGET_COUNT=0
+
+  if [[ ! -f "$partner_list_path" ]]; then
+    add_error "D4 partner list not found at: $partner_list_path"
+    return
+  fi
+
+  if is_prep_only "$partner_list_path"; then
+    add_error "D4 partner list is still marked evidence_status: prep_only: $partner_list_path"
+  fi
+
+  header_line="$(grep -E '^\|[[:space:]]*Organization / Partner[[:space:]]*\|' "$partner_list_path" | head -n 1 || true)"
+  if [[ "$(normalize_markdown_row "$header_line")" != "$expected_header" ]]; then
+    add_error "$partner_list_path must use the canonical D4 partner-list header."
+  fi
+
+  while IFS= read -r row || [[ -n "$row" ]]; do
+    [[ "$row" =~ ^\| ]] || continue
+    [[ "$row" == *"---"* ]] && continue
+    [[ "$row" == *"Organization / Partner"* ]] && continue
+
+    organization="$(awk -F'|' '{print $2}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    partner_type="$(awk -F'|' '{print $3}' <<<"$row" | tr '[:upper:]' '[:lower:]' | sed 's/^ *//;s/ *$//')"
+
+    if is_blank_or_pending "$organization"; then
+      continue
+    fi
+
+    organization_key="$(echo "$organization" | tr '[:upper:]' '[:lower:]')"
+    if [[ "$seen_organizations" == *$'\n'"$organization_key"$'\n'* ]]; then
+      duplicate_rows=$((duplicate_rows + 1))
+    else
+      seen_organizations+="$organization_key"$'\n'
+    fi
+
+    if [[ "$partner_type" == "provider" ]]; then
+      provider_count=$((provider_count + 1))
+    elif [[ "$partner_type" == "frontline organization" ]]; then
+      frontline_count=$((frontline_count + 1))
+    else
+      invalid_type_rows=$((invalid_type_rows + 1))
+    fi
+  done < "$partner_list_path"
+
+  if (( invalid_type_rows > 0 )); then
+    add_error "$partner_list_path has $invalid_type_rows row(s) with a partner type other than provider or frontline organization."
+  fi
+
+  if (( duplicate_rows > 0 )); then
+    add_error "$partner_list_path has $duplicate_rows duplicate organization / partner row(s)."
+  fi
+
+  if (( provider_count < 5 || provider_count > 10 )); then
+    add_error "$partner_list_path must identify 5-10 provider targets; found $provider_count."
+  fi
+
+  if (( frontline_count < 2 || frontline_count > 3 )); then
+    add_error "$partner_list_path must identify 2-3 frontline organization targets; found $frontline_count."
+  fi
+
+  D4_PROVIDER_TARGET_COUNT="$provider_count"
+  D4_FRONTLINE_ORG_TARGET_COUNT="$frontline_count"
+}
+
+validate_d4_artifact_inventory() {
+  local inventory_path="$1"
+  local expected_header="| Artifact ID | Filename / location | Artifact type | Source / owner | Date captured | Supports outreach-log row | Notes |"
+  local header_line
+  local row
+  local artifact_id
+  local filename_location
+  local artifact_type
+  local source_owner
+  local date_captured
+  local supports_outreach_log
+  local row_count=0
+  local outreach_reference_count=0
+
+  D4_ARTIFACT_REFERENCES=$'\n'
+  D4_HAS_OUTREACH_ARTIFACT_REFERENCE=0
+
+  if [[ ! -f "$inventory_path" ]]; then
+    add_error "D4 artifact inventory not found at: $inventory_path"
+    return
+  fi
+
+  if is_prep_only "$inventory_path"; then
+    add_error "D4 artifact inventory is still marked evidence_status: prep_only: $inventory_path"
+  fi
+
+  header_line="$(grep -E '^\|[[:space:]]*Artifact ID[[:space:]]*\|' "$inventory_path" | head -n 1 || true)"
+  if [[ "$(normalize_markdown_row "$header_line")" != "$expected_header" ]]; then
+    add_error "$inventory_path must use the canonical D4 artifact inventory header."
+  fi
+
+  while IFS= read -r row; do
+    artifact_id="$(awk -F'|' '{print $2}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    filename_location="$(awk -F'|' '{print $3}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    artifact_type="$(awk -F'|' '{print $4}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    source_owner="$(awk -F'|' '{print $5}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    date_captured="$(awk -F'|' '{print $6}' <<<"$row" | sed 's/^ *//;s/ *$//')"
+    supports_outreach_log="$(normalize_status "$(awk -F'|' '{print $7}' <<<"$row")")"
+
+    if [[ "$artifact_id" == "Artifact ID" || "$artifact_id" =~ ^-+$ ]]; then
+      continue
+    fi
+
+    row_count=$((row_count + 1))
+
+    if is_blank_or_pending "$artifact_id"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Artifact ID."
+    fi
+
+    if is_blank_or_pending "$filename_location"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Filename / location."
+    fi
+
+    if is_blank_or_pending "$artifact_type"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Artifact type."
+    fi
+
+    if is_blank_or_pending "$source_owner"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Source / owner."
+    fi
+
+    if is_blank_or_pending "$date_captured"; then
+      add_error "$inventory_path row $row_count must include a non-placeholder Date captured."
+    elif [[ ! "$date_captured" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      add_error "$inventory_path row $row_count must include Date captured in YYYY-MM-DD format."
+    fi
+
+    case "$supports_outreach_log" in
+      YES|NO) ;;
+      *) add_error "$inventory_path row $row_count must mark Supports outreach-log row as yes or no." ;;
+    esac
+
+    if [[ "$supports_outreach_log" == "YES" ]]; then
+      outreach_reference_count=$((outreach_reference_count + 1))
+      D4_ARTIFACT_REFERENCES+="$artifact_id"$'\n'
+      D4_ARTIFACT_REFERENCES+="$filename_location"$'\n'
+    fi
+  done < <(grep -E '^\|' "$inventory_path" || true)
+
+  if [[ "$row_count" -eq 0 ]]; then
+    add_error "$inventory_path must include at least one artifact row."
+  fi
+
+  if [[ "$outreach_reference_count" -eq 0 ]]; then
+    add_error "$inventory_path must include at least one artifact marked Supports outreach-log row = yes."
+  else
+    D4_HAS_OUTREACH_ARTIFACT_REFERENCE=1
+  fi
+}
+
+validate_d4_outreach_log() {
+  local outreach_log_path="$1"
+  local inventory_path="$2"
+  local expected_header="date,organization_or_partner,contact_name,contact_role,channel,owner,attempt_number,outcome,next_step,source_artifact"
+  local header_seen=0
+  local data_rows=0
+  local invalid_rows=0
+  local invalid_date_rows=0
+  local invalid_attempt_rows=0
+  local missing_artifact_rows=0
+  local raw_row
+  local row
+
+  D4_OUTREACH_EXECUTION_ROW_COUNT=0
+
+  if [[ ! -f "$outreach_log_path" ]]; then
+    add_error "D4 outreach log not found at: $outreach_log_path"
+    return
+  fi
+
+  while IFS= read -r raw_row || [[ -n "$raw_row" ]]; do
+    row="${raw_row%$'\r'}"
+    if [[ -z "$(trim_value "$row")" ]]; then
+      continue
+    fi
+
+    if [[ "$header_seen" -eq 0 ]]; then
+      header_seen=1
+      if [[ "$row" != "$expected_header" ]]; then
+        add_error "$outreach_log_path must use the canonical D4 outreach CSV header."
+      fi
+      continue
+    fi
+
+    IFS=, read -r date organization contact_name contact_role channel owner attempt_number outcome next_step source_artifact <<<"$row"
+
+    [[ -n "$date$organization$owner$outcome" ]] || continue
+    data_rows=$((data_rows + 1))
+
+    if is_blank_or_pending "$date" || is_blank_or_pending "$organization" || is_blank_or_pending "$owner" || is_blank_or_pending "$outcome"; then
+      invalid_rows=$((invalid_rows + 1))
+    fi
+
+    if [[ ! "$date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      invalid_date_rows=$((invalid_date_rows + 1))
+    fi
+
+    if [[ ! "$attempt_number" =~ ^[1-9][0-9]*$ ]]; then
+      invalid_attempt_rows=$((invalid_attempt_rows + 1))
+    fi
+
+    if is_blank_or_pending "$source_artifact"; then
+      missing_artifact_rows=$((missing_artifact_rows + 1))
+    elif [[ "$D4_HAS_OUTREACH_ARTIFACT_REFERENCE" -eq 1 ]] &&
+      ! grep -Fqx -- "$source_artifact" <<<"$D4_ARTIFACT_REFERENCES"; then
+      add_error "$outreach_log_path source_artifact '$source_artifact' must appear as an Artifact ID or Filename / location in $inventory_path with Supports outreach-log row = yes."
+    fi
+  done < "$outreach_log_path"
+
+  if [[ "$header_seen" -eq 0 ]]; then
+    add_error "$outreach_log_path must include the canonical D4 outreach CSV header."
+  fi
+
+  if (( data_rows == 0 )); then
+    add_error "$outreach_log_path must include at least one dated outreach execution row."
+  fi
+
+  if (( invalid_rows > 0 )); then
+    add_error "$outreach_log_path has $invalid_rows row(s) missing date, organization, owner, or outcome."
+  fi
+
+  if (( invalid_date_rows > 0 )); then
+    add_error "$outreach_log_path has $invalid_date_rows row(s) with a non-YYYY-MM-DD date."
+  fi
+
+  if (( invalid_attempt_rows > 0 )); then
+    add_error "$outreach_log_path has $invalid_attempt_rows row(s) with a missing or non-positive attempt_number."
+  fi
+
+  if (( missing_artifact_rows > 0 )); then
+    add_error "$outreach_log_path has $missing_artifact_rows row(s) missing source_artifact traceability."
+  fi
+
+  D4_OUTREACH_EXECUTION_ROW_COUNT="$data_rows"
+}
+
+validate_d4_closure_evidence() {
+  local submission
+  local latest_submission=""
+  local submission_id
+  local partner_list_path
+  local outreach_log_path
+  local inventory_path
+  local readiness
+  local submitted_attempt_count
+  local submitted_partner_count
+  local submitted_org_count
+
+  while IFS= read -r submission; do
+    latest_submission="$submission"
+  done < <(latest_non_prep_submission "$D4_EVIDENCE_DIR" "D4")
+
+  if [[ -z "$latest_submission" ]]; then
+    add_error "D4 is marked for closure but no non-prep D4 submission exists in $D4_EVIDENCE_DIR."
+    return
+  fi
+
+  submission_id="$(submission_id_from_file "$latest_submission")"
+  require_submission_id_matches_file "$latest_submission" "$submission_id"
+  require_filled_line "$latest_submission" "Submitted by"
+  require_date_line "$latest_submission" "Date"
+  require_filled_line "$latest_submission" "Outreach owner"
+  require_positive_integer_line "$latest_submission" "Number of dated contact attempts recorded"
+  require_positive_integer_line "$latest_submission" "Number of partners targeted"
+  require_positive_integer_line "$latest_submission" "Number of organizations targeted"
+
+  submitted_attempt_count="$(line_value "$latest_submission" "Number of dated contact attempts recorded")"
+  submitted_partner_count="$(line_value "$latest_submission" "Number of partners targeted")"
+  submitted_org_count="$(line_value "$latest_submission" "Number of organizations targeted")"
+
+  readiness="$(line_value "$latest_submission" "Is D4 auditable from the attached artifacts" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  if [[ "$readiness" != "yes" ]]; then
+    add_error "$latest_submission must mark D4 as auditable from attached artifacts."
+  fi
+
+  partner_list_path="$D4_EVIDENCE_DIR/$submission_id-partner-list.md"
+  outreach_log_path="$D4_EVIDENCE_DIR/$submission_id-outreach-log.csv"
+  inventory_path="$D4_EVIDENCE_DIR/$submission_id-artifact-inventory.md"
+
+  validate_d4_partner_list "$partner_list_path"
+  validate_d4_artifact_inventory "$inventory_path"
+  validate_d4_outreach_log "$outreach_log_path" "$inventory_path"
+
+  if [[ "$submitted_attempt_count" =~ ^[1-9][0-9]*$ && "$submitted_attempt_count" -ne "$D4_OUTREACH_EXECUTION_ROW_COUNT" ]]; then
+    add_error "$latest_submission Number of dated contact attempts recorded ($submitted_attempt_count) must match outreach log execution rows ($D4_OUTREACH_EXECUTION_ROW_COUNT)."
+  fi
+
+  if [[ "$submitted_partner_count" =~ ^[1-9][0-9]*$ && "$submitted_partner_count" -ne "$D4_PROVIDER_TARGET_COUNT" ]]; then
+    add_error "$latest_submission Number of partners targeted ($submitted_partner_count) must match provider rows in the partner list ($D4_PROVIDER_TARGET_COUNT)."
+  fi
+
+  if [[ "$submitted_org_count" =~ ^[1-9][0-9]*$ && "$submitted_org_count" -ne "$D4_FRONTLINE_ORG_TARGET_COUNT" ]]; then
+    add_error "$latest_submission Number of organizations targeted ($submitted_org_count) must match frontline organization rows in the partner list ($D4_FRONTLINE_ORG_TARGET_COUNT)."
+  fi
+}
+
+require_file "$CHECKLIST_PATH" "Gate 0 checklist"
+require_file "$TRACKER_PATH" "Gate 0 user action tracker"
+require_file "$C1_CONTROL_PATH" "C1 control document"
+
+if [[ ${#errors[@]} -eq 0 ]]; then
+  c1_gate_status="$(gate_status "G0-3")"
+  c1_action_status="$(action_status "UA-1")"
+  d4_gate_status="$(gate_status "G0-8")"
+  d4_action_status="$(action_status "UA-3")"
+
+  validate_status_pair "G0-3" "$c1_gate_status" "UA-1" "$c1_action_status"
+  validate_status_pair "G0-8" "$d4_gate_status" "UA-3" "$d4_action_status"
+
+  if requires_c1_closure_evidence "$c1_gate_status" "$c1_action_status"; then
+    validate_c1_closure_evidence
+  fi
+
+  if requires_d4_closure_evidence "$d4_gate_status" "$d4_action_status"; then
+    validate_d4_closure_evidence
+  fi
+fi
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo "BLOCKED: v22.0 Gate 0 evidence intake is inconsistent."
+  for error in "${errors[@]}"; do
+    echo "- $error"
+  done
+  exit 1
+fi
+
+echo "OK: v22.0 Gate 0 C1/D4 evidence intake is internally consistent."

--- a/scripts/check-v22-gate0-exit.sh
+++ b/scripts/check-v22-gate0-exit.sh
@@ -6,10 +6,20 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CHECKLIST_PATH="${GATE0_CHECKLIST_PATH:-$PROJECT_ROOT/docs/implementation/v22-0-gate-0-exit-checklist.md}"
+EVIDENCE_INTAKE_SCRIPT="$PROJECT_ROOT/scripts/check-v22-evidence-intake.sh"
+THREAT_MODEL_SCRIPT="$PROJECT_ROOT/scripts/check-v22-threat-model.sh"
 
 if [[ ! -f "$CHECKLIST_PATH" ]]; then
   echo "ERROR: Gate 0 checklist not found at: $CHECKLIST_PATH"
   exit 1
+fi
+
+if [[ -f "$EVIDENCE_INTAKE_SCRIPT" ]]; then
+  bash "$EVIDENCE_INTAKE_SCRIPT"
+fi
+
+if [[ -f "$THREAT_MODEL_SCRIPT" ]]; then
+  bash "$THREAT_MODEL_SCRIPT"
 fi
 
 decision_line="$(grep -E '^\|[[:space:]]*Gate 0 Exit Decision[[:space:]]*\|' "$CHECKLIST_PATH" | head -n 1 || true)"
@@ -23,6 +33,7 @@ decision_raw="$(echo "$decision_line" | awk -F'|' '{print $3}')"
 decision="$(echo "$decision_raw" | tr -d '[:space:]*`' | tr '[:lower:]' '[:upper:]')"
 
 non_pass_checks=()
+non_pass_check_ids=()
 while IFS= read -r line; do
   check_id="$(echo "$line" | awk -F'|' '{gsub(/[[:space:]]/, "", $2); print $2}')"
   status_raw="$(echo "$line" | awk -F'|' '{print $4}')"
@@ -30,21 +41,56 @@ while IFS= read -r line; do
 
   if [[ "$status" != "PASS" ]]; then
     non_pass_checks+=("${check_id}:${status}")
+    non_pass_check_ids+=("$check_id")
   fi
 done < <(grep -E '^\|[[:space:]]*G0-[0-9]+[[:space:]]*\|' "$CHECKLIST_PATH" || true)
+
+join_sorted_checks() {
+  if [[ $# -eq 0 ]]; then
+    echo ""
+    return
+  fi
+
+  printf '%s\n' "$@" | sort -V | paste -sd ',' -
+}
+
+extract_blocking_check_ids() {
+  local raw="$1"
+  local ids
+
+  ids="$(grep -oE 'G0-[0-9]+' <<<"$raw" || true)"
+
+  if [[ -z "$ids" ]]; then
+    echo ""
+    return
+  fi
+
+  printf '%s\n' "$ids" | sort -V | paste -sd ',' -
+}
 
 if [[ "$decision" != "GO" ]]; then
   blocking_line="$(grep -E '^\|[[:space:]]*Blocking Checks[[:space:]]*\|' "$CHECKLIST_PATH" | head -n 1 || true)"
   blocking_checks="see checklist"
+  blocking_check_ids=""
 
   if [[ -n "$blocking_line" ]]; then
     blocking_raw="$(echo "$blocking_line" | awk -F'|' '{print $3}')"
     blocking_checks="$(echo "$blocking_raw" | sed 's/^ *//;s/ *$//')"
+    blocking_check_ids="$(extract_blocking_check_ids "$blocking_checks")"
   fi
+
+  expected_blocking_check_ids="$(join_sorted_checks "${non_pass_check_ids[@]}")"
 
   echo "BLOCKED: v22.0 Gate 0 decision is '$decision' (must be GO)."
   echo "Checklist: $CHECKLIST_PATH"
   echo "Blocking checks: $blocking_checks"
+
+  if [[ "$blocking_check_ids" != "$expected_blocking_check_ids" ]]; then
+    echo "ERROR: Gate 0 Blocking Checks row does not match required-check statuses."
+    echo "Expected blocking checks: ${expected_blocking_check_ids:-none}"
+    echo "Actual blocking checks: ${blocking_check_ids:-none}"
+  fi
+
   exit 1
 fi
 

--- a/scripts/check-v22-threat-model.sh
+++ b/scripts/check-v22-threat-model.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Validate v22.0 offline/local threat-model consistency for Gate 0 security.
+# This guard checks the public threat-model record against its own rule:
+# no unresolved critical findings, and high findings must have owners, due dates,
+# and mitigation plans. It does not judge mitigation sufficiency.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+THREAT_MODEL_PATH="${V22_THREAT_MODEL_PATH:-$PROJECT_ROOT/docs/security/v22-0-offline-local-threat-model.md}"
+
+errors=()
+unresolved_critical_ids=()
+high_incomplete_ids=()
+
+add_error() {
+  errors+=("$1")
+}
+
+trim_value() {
+  sed 's/^ *//;s/ *$//' <<<"$1"
+}
+
+normalize_token() {
+  echo "$1" | tr -d '[:space:]*`' | tr '[:upper:]' '[:lower:]'
+}
+
+is_blank_or_placeholder() {
+  local normalized
+
+  normalized="$(normalize_token "$1")"
+  [[ -z "$normalized" || "$normalized" == "pending" || "$normalized" == "tbd" || "$normalized" == "n/a" || "$normalized" == "-" ]]
+}
+
+markdown_cell() {
+  local row="$1"
+  local cell_number="$2"
+
+  awk -F'|' -v cell="$cell_number" '{print $cell}' <<<"$row" | sed 's/^ *//;s/ *$//'
+}
+
+outcome_status() {
+  local criterion="$1"
+  local row
+
+  row="$(grep -E "^\|[[:space:]]*$criterion[[:space:]]*\|" "$THREAT_MODEL_PATH" | head -n 1 || true)"
+  if [[ -z "$row" ]]; then
+    echo ""
+    return
+  fi
+
+  normalize_token "$(markdown_cell "$row" 3)"
+}
+
+require_go_outcome() {
+  local criterion="$1"
+  local reason="$2"
+  local status
+
+  status="$(outcome_status "$criterion")"
+  if [[ -z "$status" ]]; then
+    add_error "Gate 0 Security Outcome is missing criterion: $criterion"
+    return
+  fi
+
+  if [[ "$status" != "go" ]]; then
+    add_error "$criterion must be GO because $reason."
+  fi
+}
+
+if [[ ! -f "$THREAT_MODEL_PATH" ]]; then
+  echo "ERROR: v22.0 threat model not found at: $THREAT_MODEL_PATH"
+  exit 1
+fi
+
+mitigation_rows=0
+in_mitigation_tracking=0
+while IFS= read -r row; do
+  if [[ "$row" =~ ^##[[:space:]]+Mitigation[[:space:]]+Tracking[[:space:]]*$ ]]; then
+    in_mitigation_tracking=1
+    continue
+  fi
+
+  if [[ "$in_mitigation_tracking" -eq 1 && "$row" =~ ^##[[:space:]]+ ]]; then
+    break
+  fi
+
+  [[ "$in_mitigation_tracking" -eq 1 ]] || continue
+  [[ "$row" =~ ^\|[[:space:]]*F[0-9]+[[:space:]]*\| ]] || continue
+
+  mitigation_rows=$((mitigation_rows + 1))
+  finding_id="$(markdown_cell "$row" 2)"
+  severity="$(normalize_token "$(markdown_cell "$row" 3)")"
+  mitigation_plan="$(markdown_cell "$row" 4)"
+  owner="$(markdown_cell "$row" 5)"
+  due_date="$(markdown_cell "$row" 6)"
+  verification_method="$(markdown_cell "$row" 7)"
+  verified="$(normalize_token "$(markdown_cell "$row" 8)")"
+
+  case "$severity" in
+    critical|high|medium|low) ;;
+    *) add_error "$finding_id has unknown severity '$severity' in $THREAT_MODEL_PATH." ;;
+  esac
+
+  case "$verified" in
+    yes|no) ;;
+    *) add_error "$finding_id has unknown Verified value '$verified' in $THREAT_MODEL_PATH." ;;
+  esac
+
+  if is_blank_or_placeholder "$mitigation_plan"; then
+    add_error "$finding_id must include a mitigation plan."
+  fi
+
+  if is_blank_or_placeholder "$owner"; then
+    add_error "$finding_id must include an owner."
+  fi
+
+  if is_blank_or_placeholder "$due_date"; then
+    add_error "$finding_id must include a due date."
+  elif [[ ! "$due_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    add_error "$finding_id due date must use YYYY-MM-DD format."
+  fi
+
+  if is_blank_or_placeholder "$verification_method"; then
+    add_error "$finding_id must include a verification method."
+  fi
+
+  if [[ "$severity" == "critical" && "$verified" != "yes" ]]; then
+    unresolved_critical_ids+=("$finding_id")
+  fi
+
+  if [[ "$severity" == "high" ]]; then
+    if is_blank_or_placeholder "$mitigation_plan" || is_blank_or_placeholder "$owner" || is_blank_or_placeholder "$due_date"; then
+      high_incomplete_ids+=("$finding_id")
+    fi
+  fi
+done < "$THREAT_MODEL_PATH"
+
+if [[ "$mitigation_rows" -eq 0 ]]; then
+  add_error "No mitigation tracking rows were found in $THREAT_MODEL_PATH."
+fi
+
+if [[ "${#unresolved_critical_ids[@]}" -gt 0 ]]; then
+  add_error "Unresolved critical findings block Gate 0 security outcome: ${unresolved_critical_ids[*]}."
+else
+  require_go_outcome "Critical findings resolved" "there are no unresolved critical findings"
+fi
+
+if [[ "${#high_incomplete_ids[@]}" -gt 0 ]]; then
+  add_error "High findings are missing owner, due date, or mitigation plan: ${high_incomplete_ids[*]}."
+else
+  require_go_outcome "High findings have owners and mitigation plans" "all high findings have owners, due dates, and mitigation plans"
+fi
+
+signoff_status="$(outcome_status "Threat model signed by security/governance owner")"
+if [[ -z "$signoff_status" ]]; then
+  add_error "Gate 0 Security Outcome is missing criterion: Threat model signed by security/governance owner"
+elif [[ "$signoff_status" == "go" ]]; then
+  signoff_line="$(grep -E '^- Security/governance owner review:[[:space:]]*`?[^`[:space:]]+' "$THREAT_MODEL_PATH" | head -n 1 || true)"
+  if [[ -z "$signoff_line" ]] || grep -Eiq 'pending|tbd|not signed|n/a' <<<"$signoff_line"; then
+    add_error "Threat model signed outcome is GO but sign-off line is missing or placeholder."
+  fi
+else
+  add_error "Threat model signed by security/governance owner must be GO for Gate 0 security outcome."
+fi
+
+if [[ "${#errors[@]}" -gt 0 ]]; then
+  echo "ERROR: v22.0 threat-model Gate 0 security outcome is inconsistent."
+  printf -- '- %s\n' "${errors[@]}"
+  exit 1
+fi
+
+echo "OK: v22.0 threat-model Gate 0 security outcome is internally consistent."

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -54,6 +54,16 @@ npm run check:refs
 echo "✅ Reference check passed"
 echo ""
 
+echo "🧾 Checking v22 Gate 0 evidence intake..."
+npm run check:v22-evidence
+echo "✅ v22 Gate 0 evidence intake check passed"
+echo ""
+
+echo "🧾 Checking v22 threat model..."
+npm run check:v22-threat-model
+echo "✅ v22 threat model check passed"
+echo ""
+
 echo "🛡️ Validating security headers..."
 npm run validate:security-headers
 echo "✅ Security header validation passed"

--- a/tests/api/pilot-contact-attempt.test.ts
+++ b/tests/api/pilot-contact-attempt.test.ts
@@ -168,6 +168,27 @@ describe("POST /api/v1/pilot/events/contact-attempt", () => {
     expect(json.error.details).toBe("database unavailable")
   })
 
+  it("returns 200 for idempotent retries with a client event id", async () => {
+    const idempotentPayload = {
+      ...validPayload,
+      id: "11111111-1111-4111-8111-111111111111",
+    }
+    vi.mocked(insertContactAttempt).mockResolvedValue({
+      data: null,
+      duplicate: true,
+      error: null,
+      missingTable: false,
+    })
+
+    const response = await POST(createRequest(idempotentPayload))
+    const json = (await response.json()) as any
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(json.data).toEqual({ success: true, duplicate: true })
+    expect(insertContactAttempt).toHaveBeenCalledWith(mockSupabaseAuth, idempotentPayload)
+  })
+
   it("returns 201 with success payload and no-store header on success", async () => {
     const response = await POST(createRequest())
     const json = (await response.json()) as any

--- a/tests/api/pilot-instrumentation-routes.test.ts
+++ b/tests/api/pilot-instrumentation-routes.test.ts
@@ -7,6 +7,7 @@ import { POST as postPilotScopeService } from "@/app/api/v1/pilot/scope/services
 import { POST as postServiceStatus } from "@/app/api/v1/pilot/events/service-status/route"
 import { POST as postDataDecayAudit } from "@/app/api/v1/pilot/events/data-decay-audit/route"
 import { POST as postPreferenceFit } from "@/app/api/v1/pilot/events/preference-fit/route"
+import { checkRateLimit } from "@/lib/rate-limit"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { assertPermission } from "@/lib/auth/authorization"
 import {
@@ -57,6 +58,14 @@ function createRequest(url: string, body: unknown) {
   })
 }
 
+function createNonJsonRequest(url: string, body: string = "not-json") {
+  return createMockRequest(url, {
+    method: "POST",
+    headers: { "content-type": "text/plain" },
+    body,
+  })
+}
+
 describe("pilot instrumentation write routes", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -88,6 +97,7 @@ describe("pilot instrumentation write routes", () => {
       },
       storageMock: insertConnectionEvent,
       missingTableMessage: "Pilot storage not ready: missing pilot_connection_events table",
+      supportsClientEventId: true,
     },
     {
       name: "scope service",
@@ -107,6 +117,7 @@ describe("pilot instrumentation write routes", () => {
       },
       storageMock: upsertPilotScopeService,
       missingTableMessage: "Pilot storage not ready: missing pilot_service_scope table",
+      supportsClientEventId: false,
     },
     {
       name: "service status",
@@ -128,6 +139,7 @@ describe("pilot instrumentation write routes", () => {
       },
       storageMock: insertServiceOperationalStatusEvent,
       missingTableMessage: "Pilot storage not ready: missing service_operational_status_events table",
+      supportsClientEventId: true,
     },
     {
       name: "data decay audit",
@@ -153,6 +165,7 @@ describe("pilot instrumentation write routes", () => {
       },
       storageMock: insertPilotDataDecayAudit,
       missingTableMessage: "Pilot storage not ready: missing pilot_data_decay_audits table",
+      supportsClientEventId: true,
     },
     {
       name: "preference fit",
@@ -174,6 +187,7 @@ describe("pilot instrumentation write routes", () => {
       },
       storageMock: insertPilotPreferenceFitEvent,
       missingTableMessage: "Pilot storage not ready: missing pilot_preference_fit_events table",
+      supportsClientEventId: true,
     },
   ] as const
 
@@ -184,6 +198,18 @@ describe("pilot instrumentation write routes", () => {
         error: null,
         missingTable: false,
       })
+    })
+
+    it("returns 429 when rate limited", async () => {
+      vi.mocked(checkRateLimit).mockResolvedValueOnce({ success: false } as never)
+
+      const response = await testCase.route(createRequest(testCase.url, testCase.payload))
+      const json = (await response.json()) as { error: { message: string } }
+
+      expect(response.status).toBe(429)
+      expect(json.error.message).toBe("Rate limit exceeded")
+      expect(requireAuthenticatedUser).not.toHaveBeenCalled()
+      expect(testCase.storageMock).not.toHaveBeenCalled()
     })
 
     it("returns 401 when auth is missing", async () => {
@@ -212,6 +238,15 @@ describe("pilot instrumentation write routes", () => {
       expect(response.status).toBe(400)
     })
 
+    it("returns 415 when content type is not json", async () => {
+      const response = await testCase.route(createNonJsonRequest(testCase.url))
+      const json = (await response.json()) as { error: { message: string } }
+
+      expect(response.status).toBe(415)
+      expect(json.error.message).toBe("Content-Type must be application/json")
+      expect(testCase.storageMock).not.toHaveBeenCalled()
+    })
+
     it("returns 400 when disallowed privacy fields are present", async () => {
       const response = await testCase.route(
         createRequest(testCase.url, {
@@ -237,6 +272,32 @@ describe("pilot instrumentation write routes", () => {
 
       expect(response.status).toBe(501)
       expect(json.error.message).toBe(testCase.missingTableMessage)
+    })
+
+    it("returns 200 for idempotent retries with a client event id", async () => {
+      if (!testCase.supportsClientEventId) {
+        expect(testCase.name).toBe("scope service")
+        return
+      }
+
+      vi.mocked(testCase.storageMock).mockResolvedValue({
+        data: null,
+        duplicate: true,
+        error: null,
+        missingTable: false,
+      })
+      const payload = {
+        ...testCase.payload,
+        id: "11111111-1111-4111-8111-111111111111",
+      }
+
+      const response = await testCase.route(createRequest(testCase.url, payload))
+      const json = (await response.json()) as any
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get("cache-control")).toBe("no-store")
+      expect(json.data).toEqual({ success: true, duplicate: true })
+      expect(testCase.storageMock).toHaveBeenCalledWith(expect.anything(), payload)
     })
 
     it("returns 201 with no-store header on success", async () => {

--- a/tests/api/pilot-metrics-recompute.test.ts
+++ b/tests/api/pilot-metrics-recompute.test.ts
@@ -6,6 +6,7 @@ import { POST } from "@/app/api/v1/pilot/metrics/recompute/route"
 import { requireAuthenticatedUser } from "@/lib/pilot/auth"
 import { assertPermission } from "@/lib/auth/authorization"
 import { recomputePilotMetrics } from "@/lib/pilot/recompute"
+import { checkRateLimit } from "@/lib/rate-limit"
 
 vi.mock("@/lib/logger", () => ({
   logger: {
@@ -47,8 +48,17 @@ describe("POST /api/v1/pilot/metrics/recompute", () => {
     })
   }
 
+  function createNonJsonRequest() {
+    return createMockRequest("http://localhost/api/v1/pilot/metrics/recompute", {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: "not-json",
+    })
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: true } as never)
     vi.mocked(requireAuthenticatedUser).mockResolvedValue({
       error: null,
       supabaseAuth: {} as never,
@@ -78,6 +88,15 @@ describe("POST /api/v1/pilot/metrics/recompute", () => {
     })
   })
 
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(checkRateLimit).mockResolvedValueOnce({ success: false } as never)
+
+    const response = await POST(createRequest())
+
+    expect(response.status).toBe(429)
+    expect(requireAuthenticatedUser).not.toHaveBeenCalled()
+  })
+
   it("returns 401 when auth is missing", async () => {
     vi.mocked(requireAuthenticatedUser).mockResolvedValue({
       error: null,
@@ -92,6 +111,15 @@ describe("POST /api/v1/pilot/metrics/recompute", () => {
   it("returns 400 for invalid payloads", async () => {
     const response = await POST(createRequest({ pilot_cycle_id: "" }))
     expect(response.status).toBe(400)
+  })
+
+  it("returns 415 when content type is not json", async () => {
+    const response = await POST(createNonJsonRequest())
+    const json = (await response.json()) as { error: { message: string } }
+
+    expect(response.status).toBe(415)
+    expect(json.error.message).toBe("Content-Type must be application/json")
+    expect(recomputePilotMetrics).not.toHaveBeenCalled()
   })
 
   it("returns 403 when permission assertion fails", async () => {

--- a/tests/api/v1/pilot-integration-feasibility.test.ts
+++ b/tests/api/v1/pilot-integration-feasibility.test.ts
@@ -21,11 +21,38 @@ vi.mock("@/lib/pilot/storage", () => ({
 }))
 
 describe("POST /api/v1/pilot/integration-feasibility", () => {
+  const validPayload = {
+    decision: "conditional",
+    decision_date: "2026-03-08",
+    redline_checklist_version: "v1",
+    violations: ["retention_policy_conflict"],
+    compensating_controls: ["limit retention to aggregate-only snapshots"],
+    owners: ["jer"],
+  }
+
+  function createRequest(body: unknown = validPayload) {
+    return createMockRequest("http://localhost/api/v1/pilot/integration-feasibility", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  }
+
+  function createNonJsonRequest() {
+    return createMockRequest("http://localhost/api/v1/pilot/integration-feasibility", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "not-json",
+    })
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks()
+    const { checkRateLimit } = await import("@/lib/rate-limit")
     const { requireAuthenticatedUser } = await import("@/lib/pilot/auth")
     const { isUserAdmin } = await import("@/lib/auth/authorization")
     const { insertIntegrationDecision } = await import("@/lib/pilot/storage")
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: true, reset: 0 } as never)
     vi.mocked(requireAuthenticatedUser).mockResolvedValue({
       error: null,
       supabaseAuth: {} as any,
@@ -49,60 +76,115 @@ describe("POST /api/v1/pilot/integration-feasibility", () => {
     })
   })
 
+  it("returns 429 when rate limited", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit")
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: false, reset: 0 } as never)
+
+    const res = await POST(createRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(429)
+    expect(json.error.message).toBe("Rate limit exceeded")
+  })
+
+  it("returns 401 when auth is missing", async () => {
+    const { requireAuthenticatedUser } = await import("@/lib/pilot/auth")
+    vi.mocked(requireAuthenticatedUser).mockResolvedValue({
+      error: null,
+      supabaseAuth: null,
+      user: null,
+    } as never)
+
+    const res = await POST(createRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(401)
+    expect(json.error.message).toBe("Unauthorized")
+  })
+
   it("returns 403 for non-admin user", async () => {
     const { isUserAdmin } = await import("@/lib/auth/authorization")
     vi.mocked(isUserAdmin).mockResolvedValue(false)
 
-    const req = createMockRequest("http://localhost/api/v1/pilot/integration-feasibility", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+    const res = await POST(
+      createRequest({
         decision: "blocked",
         decision_date: "2026-03-08",
         redline_checklist_version: "v1",
         violations: ["forced_user_identifying_telemetry"],
         compensating_controls: [],
         owners: ["jer"],
-      }),
-    })
-
-    const res = await POST(req)
+      })
+    )
     expect(res.status).toBe(403)
   })
 
   it("returns 400 for invalid payload", async () => {
-    const req = createMockRequest("http://localhost/api/v1/pilot/integration-feasibility", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+    const res = await POST(
+      createRequest({
         decision: "go",
         decision_date: "2026-03-08",
         redline_checklist_version: "v1",
         violations: ["raw_query_text_required"],
         compensating_controls: [],
         owners: ["jer"],
-      }),
-    })
+      })
+    )
 
-    const res = await POST(req)
     expect(res.status).toBe(400)
   })
 
-  it("returns 201 for valid payload", async () => {
-    const req = createMockRequest("http://localhost/api/v1/pilot/integration-feasibility", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        decision: "conditional",
-        decision_date: "2026-03-08",
-        redline_checklist_version: "v1",
-        violations: ["retention_policy_conflict"],
-        compensating_controls: ["limit retention to aggregate-only snapshots"],
-        owners: ["jer"],
-      }),
+  it("returns 415 when content type is not json", async () => {
+    const { insertIntegrationDecision } = await import("@/lib/pilot/storage")
+
+    const res = await POST(createNonJsonRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(415)
+    expect(json.error.message).toBe("Content-Type must be application/json")
+    expect(insertIntegrationDecision).not.toHaveBeenCalled()
+  })
+
+  it("returns 501 when pilot decision storage is not ready", async () => {
+    const { insertIntegrationDecision } = await import("@/lib/pilot/storage")
+    vi.mocked(insertIntegrationDecision).mockResolvedValue({
+      data: null,
+      error: { code: "42P01", message: "relation does not exist" },
+      missingTable: true,
     })
 
-    const res = await POST(req)
+    const res = await POST(createRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(501)
+    expect(json.error.message).toBe("Pilot storage not ready: missing pilot_integration_feasibility_decisions table")
+  })
+
+  it("returns 500 when pilot decision storage fails", async () => {
+    const { insertIntegrationDecision } = await import("@/lib/pilot/storage")
+    vi.mocked(insertIntegrationDecision).mockResolvedValue({
+      data: null,
+      error: { message: "database unavailable" },
+      missingTable: false,
+    })
+
+    const res = await POST(createRequest())
+    const json = (await res.json()) as { error: { message: string; details: string } }
+
+    expect(res.status).toBe(500)
+    expect(json.error.message).toBe("Failed to store integration feasibility decision")
+    expect(json.error.details).toBe("database unavailable")
+  })
+
+  it("returns 201 for valid payload", async () => {
+    const { insertIntegrationDecision } = await import("@/lib/pilot/storage")
+
+    const res = await POST(createRequest())
+    const json = (await res.json()) as { data: { success: boolean } }
+
     expect(res.status).toBe(201)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(json.data).toEqual({ success: true })
+    expect(insertIntegrationDecision).toHaveBeenCalledWith(expect.anything(), validPayload)
   })
 })

--- a/tests/api/v1/pilot-referral.test.ts
+++ b/tests/api/v1/pilot-referral.test.ts
@@ -1,5 +1,6 @@
 import "../../setup/next-mocks"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { AuthorizationError } from "@/lib/api-utils"
 import { createMockRequest } from "@/tests/utils/api-test-utils"
 import { POST } from "@/app/api/v1/pilot/events/referral/route"
 import { PATCH } from "@/app/api/v1/pilot/events/referral/[id]/route"
@@ -23,15 +24,68 @@ vi.mock("@/lib/pilot/storage", () => ({
 }))
 
 describe("pilot referral routes", () => {
+  const terminalUpdatePayload = {
+    source_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+    referral_state: "failed",
+    updated_at: "2026-03-08T15:10:00.000Z",
+    terminal_at: "2026-03-08T15:20:00.000Z",
+    failure_reason_code: "unknown_failure",
+  }
+
+  const createPayload = {
+    pilot_cycle_id: "v22-cycle-1",
+    source_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+    target_service_id: "svc-2",
+    referral_state: "initiated",
+    created_at: "2026-03-08T15:00:00.000Z",
+    updated_at: "2026-03-08T15:00:00.000Z",
+  }
+
+  function createPostRequest(body: unknown = createPayload) {
+    return createMockRequest("http://localhost/api/v1/pilot/events/referral", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  }
+
+  function createNonJsonPostRequest() {
+    return createMockRequest("http://localhost/api/v1/pilot/events/referral", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "not-json",
+    })
+  }
+
+  function createPatchRequest(body: unknown = terminalUpdatePayload) {
+    return createMockRequest("http://localhost/api/v1/pilot/events/referral/ref-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  }
+
+  function createNonJsonPatchRequest() {
+    return createMockRequest("http://localhost/api/v1/pilot/events/referral/ref-1", {
+      method: "PATCH",
+      headers: { "Content-Type": "text/plain" },
+      body: "not-json",
+    })
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks()
+    const { checkRateLimit } = await import("@/lib/rate-limit")
     const { requireAuthenticatedUser } = await import("@/lib/pilot/auth")
+    const { assertPermission } = await import("@/lib/auth/authorization")
     const { insertReferralEvent, updateReferralEvent } = await import("@/lib/pilot/storage")
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: true, reset: 0 } as never)
     vi.mocked(requireAuthenticatedUser).mockResolvedValue({
       error: null,
       supabaseAuth: {} as any,
       user: { id: "user-1" } as any,
     })
+    vi.mocked(assertPermission).mockResolvedValue("editor" as never)
     vi.mocked(insertReferralEvent).mockResolvedValue({
       data: {
         id: "ref-1",
@@ -65,36 +119,195 @@ describe("pilot referral routes", () => {
   })
 
   it("POST returns 201 for valid payload", async () => {
+    const { insertReferralEvent } = await import("@/lib/pilot/storage")
+
+    const res = await POST(createPostRequest())
+    const json = (await res.json()) as { data: { success: boolean } }
+
+    expect(res.status).toBe(201)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(json.data).toEqual({ success: true })
+    expect(insertReferralEvent).toHaveBeenCalledWith(expect.anything(), createPayload)
+  })
+
+  it("POST returns 200 for idempotent retries with a client event id", async () => {
+    const { insertReferralEvent } = await import("@/lib/pilot/storage")
+    vi.mocked(insertReferralEvent).mockResolvedValue({
+      data: null,
+      duplicate: true,
+      error: null,
+      missingTable: false,
+    })
+
+    const payload = {
+      id: "11111111-1111-4111-8111-111111111111",
+      pilot_cycle_id: "v22-cycle-1",
+      source_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+      target_service_id: "svc-2",
+      referral_state: "initiated",
+      created_at: "2026-03-08T15:00:00.000Z",
+      updated_at: "2026-03-08T15:00:00.000Z",
+    }
     const req = createMockRequest("http://localhost/api/v1/pilot/events/referral", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        pilot_cycle_id: "v22-cycle-1",
-        source_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
-        target_service_id: "svc-2",
-        referral_state: "initiated",
-        created_at: "2026-03-08T15:00:00.000Z",
-        updated_at: "2026-03-08T15:00:00.000Z",
-      }),
+      body: JSON.stringify(payload),
     })
 
     const res = await POST(req)
-    expect(res.status).toBe(201)
+    const json = (await res.json()) as any
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(json.data).toEqual({ success: true, duplicate: true })
+    expect(insertReferralEvent).toHaveBeenCalledWith(expect.anything(), payload)
+  })
+
+  it("POST returns 429 when rate limited", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit")
+    const { requireAuthenticatedUser } = await import("@/lib/pilot/auth")
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: false, reset: 0 } as never)
+
+    const res = await POST(createPostRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(429)
+    expect(json.error.message).toBe("Rate limit exceeded")
+    expect(requireAuthenticatedUser).not.toHaveBeenCalled()
+  })
+
+  it("POST returns 401 when auth is missing", async () => {
+    const { requireAuthenticatedUser } = await import("@/lib/pilot/auth")
+    vi.mocked(requireAuthenticatedUser).mockResolvedValue({
+      error: null,
+      supabaseAuth: null,
+      user: null,
+    } as never)
+
+    const res = await POST(createPostRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(401)
+    expect(json.error.message).toBe("Unauthorized")
+  })
+
+  it("POST returns 403 when permission assertion fails", async () => {
+    const { assertPermission } = await import("@/lib/auth/authorization")
+    vi.mocked(assertPermission).mockRejectedValue(new AuthorizationError("Access denied"))
+
+    const res = await POST(createPostRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(403)
+    expect(json.error.message).toBe("Access denied")
+  })
+
+  it("POST returns 400 for invalid payloads", async () => {
+    const { insertReferralEvent } = await import("@/lib/pilot/storage")
+
+    const res = await POST(createPostRequest({ pilot_cycle_id: "" }))
+
+    expect(res.status).toBe(400)
+    expect(insertReferralEvent).not.toHaveBeenCalled()
+  })
+
+  it("POST returns 415 when content type is not json", async () => {
+    const { insertReferralEvent } = await import("@/lib/pilot/storage")
+
+    const res = await POST(createNonJsonPostRequest())
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(415)
+    expect(json.error.message).toBe("Content-Type must be application/json")
+    expect(insertReferralEvent).not.toHaveBeenCalled()
+  })
+
+  it("POST returns 501 when pilot table is missing", async () => {
+    const { insertReferralEvent } = await import("@/lib/pilot/storage")
+    vi.mocked(insertReferralEvent).mockResolvedValue({
+      data: null,
+      error: { code: "42P01", message: "relation does not exist" },
+      missingTable: true,
+    })
+
+    const res = await POST(createPostRequest())
+    expect(res.status).toBe(501)
+  })
+
+  it("POST returns 500 when pilot referral storage fails", async () => {
+    const { insertReferralEvent } = await import("@/lib/pilot/storage")
+    vi.mocked(insertReferralEvent).mockResolvedValue({
+      data: null,
+      error: { message: "database unavailable" },
+      missingTable: false,
+    })
+
+    const res = await POST(createPostRequest())
+    const json = (await res.json()) as { error: { message: string; details: string } }
+
+    expect(res.status).toBe(500)
+    expect(json.error.message).toBe("Failed to store referral event")
+    expect(json.error.details).toBe("database unavailable")
+  })
+
+  it("PATCH returns 429 when rate limited", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit")
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: false, reset: 0 } as never)
+
+    const res = await PATCH(createPatchRequest(), { params: Promise.resolve({ id: "ref-1" }) })
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(429)
+    expect(json.error.message).toBe("Rate limit exceeded")
+  })
+
+  it("PATCH returns 401 when auth is missing", async () => {
+    const { requireAuthenticatedUser } = await import("@/lib/pilot/auth")
+    vi.mocked(requireAuthenticatedUser).mockResolvedValue({
+      error: null,
+      supabaseAuth: null,
+      user: null,
+    } as never)
+
+    const res = await PATCH(createPatchRequest(), { params: Promise.resolve({ id: "ref-1" }) })
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(401)
+    expect(json.error.message).toBe("Unauthorized")
+  })
+
+  it("PATCH returns 403 when permission assertion fails", async () => {
+    const { assertPermission } = await import("@/lib/auth/authorization")
+    vi.mocked(assertPermission).mockRejectedValue(new AuthorizationError("Access denied"))
+
+    const res = await PATCH(createPatchRequest(), { params: Promise.resolve({ id: "ref-1" }) })
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(403)
+    expect(json.error.message).toBe("Access denied")
   })
 
   it("PATCH returns 400 for invalid terminal state update", async () => {
-    const req = createMockRequest("http://localhost/api/v1/pilot/events/referral/ref-1", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+    const res = await PATCH(
+      createPatchRequest({
         source_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
         referral_state: "failed",
         updated_at: "2026-03-08T15:10:00.000Z",
       }),
-    })
-
-    const res = await PATCH(req, { params: Promise.resolve({ id: "ref-1" }) })
+      { params: Promise.resolve({ id: "ref-1" }) }
+    )
     expect(res.status).toBe(400)
+  })
+
+  it("PATCH returns 415 when content type is not json", async () => {
+    const { updateReferralEvent } = await import("@/lib/pilot/storage")
+
+    const res = await PATCH(createNonJsonPatchRequest(), { params: Promise.resolve({ id: "ref-1" }) })
+    const json = (await res.json()) as { error: { message: string } }
+
+    expect(res.status).toBe(415)
+    expect(json.error.message).toBe("Content-Type must be application/json")
+    expect(updateReferralEvent).not.toHaveBeenCalled()
   })
 
   it("PATCH returns 501 when pilot table is missing", async () => {
@@ -105,18 +318,40 @@ describe("pilot referral routes", () => {
       missingTable: true,
     })
 
-    const req = createMockRequest("http://localhost/api/v1/pilot/events/referral/ref-1", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        source_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
-        referral_state: "failed",
-        updated_at: "2026-03-08T15:10:00.000Z",
-        terminal_at: "2026-03-08T15:20:00.000Z",
-      }),
+    const res = await PATCH(createPatchRequest(), { params: Promise.resolve({ id: "ref-1" }) })
+    expect(res.status).toBe(501)
+  })
+
+  it("PATCH returns 500 when pilot referral storage fails", async () => {
+    const { updateReferralEvent } = await import("@/lib/pilot/storage")
+    vi.mocked(updateReferralEvent).mockResolvedValue({
+      data: null,
+      error: { message: "database unavailable" },
+      missingTable: false,
     })
 
-    const res = await PATCH(req, { params: Promise.resolve({ id: "ref-1" }) })
-    expect(res.status).toBe(501)
+    const res = await PATCH(createPatchRequest(), { params: Promise.resolve({ id: "ref-1" }) })
+    const json = (await res.json()) as { error: { message: string; details: string } }
+
+    expect(res.status).toBe(500)
+    expect(json.error.message).toBe("Failed to update referral event")
+    expect(json.error.details).toBe("database unavailable")
+  })
+
+  it("PATCH returns a no-store success envelope for valid terminal updates", async () => {
+    const { updateReferralEvent } = await import("@/lib/pilot/storage")
+
+    const res = await PATCH(createPatchRequest(), { params: Promise.resolve({ id: "ref-1" }) })
+    const json = (await res.json()) as { data: { success: boolean } }
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(json.data).toEqual({ success: true })
+    expect(updateReferralEvent).toHaveBeenCalledWith(expect.anything(), "ref-1", {
+      referral_state: terminalUpdatePayload.referral_state,
+      updated_at: terminalUpdatePayload.updated_at,
+      terminal_at: terminalUpdatePayload.terminal_at,
+      failure_reason_code: terminalUpdatePayload.failure_reason_code,
+    })
   })
 })

--- a/tests/components/AuthProvider.test.tsx
+++ b/tests/components/AuthProvider.test.tsx
@@ -1,12 +1,14 @@
-import { render, screen, waitFor } from "@testing-library/react"
-import { AuthProvider } from "@/components/layout/AuthProvider"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { AuthProvider, useAuth } from "@/components/layout/AuthProvider"
+import { PILOT_DRAFT_STORAGE_PREFIX } from "@/lib/offline/pilot-draft-cleanup"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 // Hoist mocks to avoid reference error
-const { mockGetSession, mockHasSupabaseCredentials, mockSubscribe } = vi.hoisted(() => {
+const { mockGetSession, mockHasSupabaseCredentials, mockSignOut, mockSubscribe } = vi.hoisted(() => {
   return {
     mockGetSession: vi.fn(),
     mockSubscribe: vi.fn(),
+    mockSignOut: vi.fn(),
     mockHasSupabaseCredentials: vi.fn(),
   }
 })
@@ -14,6 +16,7 @@ const { mockGetSession, mockHasSupabaseCredentials, mockSubscribe } = vi.hoisted
 // Setup returns
 mockGetSession.mockResolvedValue({ data: { session: null }, error: null })
 mockSubscribe.mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } })
+mockSignOut.mockResolvedValue({ error: null })
 mockHasSupabaseCredentials.mockReturnValue(true)
 
 vi.mock("@/lib/supabase", () => ({
@@ -22,7 +25,7 @@ vi.mock("@/lib/supabase", () => ({
     auth: {
       getSession: mockGetSession,
       onAuthStateChange: mockSubscribe,
-      signOut: vi.fn(),
+      signOut: mockSignOut,
     },
   },
 }))
@@ -35,11 +38,19 @@ vi.mock("next/navigation", () => ({
   }),
 }))
 
+function SignOutButton() {
+  const { signOut } = useAuth()
+  return <button onClick={() => void signOut()}>Sign out</button>
+}
+
 describe("AuthProvider Component", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
     mockGetSession.mockResolvedValue({ data: { session: null }, error: null })
     mockSubscribe.mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } })
+    mockSignOut.mockResolvedValue({ error: null })
     mockHasSupabaseCredentials.mockReturnValue(true)
   })
 
@@ -74,5 +85,23 @@ describe("AuthProvider Component", () => {
     await waitFor(() => expect(screen.getByText("Child Content")).toBeInTheDocument())
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockSubscribe).not.toHaveBeenCalled()
+  })
+
+  it("clears reserved pilot draft storage during sign out", async () => {
+    const draftKey = `${PILOT_DRAFT_STORAGE_PREFIX}contact-attempt`
+    localStorage.setItem(draftKey, "{}")
+    localStorage.setItem("careconnect-high-contrast", "true")
+
+    render(
+      <AuthProvider>
+        <SignOutButton />
+      </AuthProvider>
+    )
+
+    fireEvent.click(screen.getByText("Sign out"))
+
+    await waitFor(() => expect(mockSignOut).toHaveBeenCalled())
+    expect(localStorage.getItem(draftKey)).toBeNull()
+    expect(localStorage.getItem("careconnect-high-contrast")).toBe("true")
   })
 })

--- a/tests/components/offline/OfflineSync.test.tsx
+++ b/tests/components/offline/OfflineSync.test.tsx
@@ -125,10 +125,12 @@ describe("OfflineSync", () => {
       render(<OfflineSync />)
 
       await waitFor(() => {
-        expect(mockLogger.error).toHaveBeenCalledWith("Offline sync failed", error, {
+        expect(mockLogger.warn).toHaveBeenCalledWith("Offline sync failed", {
           component: "OfflineSync",
+          errorType: "Error",
         })
       })
+      expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain("Sync failed")
     })
 
     it("should log error when feedback sync fails", async () => {
@@ -138,10 +140,12 @@ describe("OfflineSync", () => {
       render(<OfflineSync />)
 
       await waitFor(() => {
-        expect(mockLogger.error).toHaveBeenCalledWith("Pending feedback sync failed", error, {
+        expect(mockLogger.warn).toHaveBeenCalledWith("Pending feedback sync failed", {
           component: "OfflineSync",
+          errorType: "Error",
         })
       })
+      expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain("Feedback sync failed")
     })
   })
 
@@ -201,7 +205,7 @@ describe("OfflineSync", () => {
       vi.stubEnv("NODE_ENV", "production")
 
       const getRegistrations = vi.fn().mockResolvedValue([])
-      const error = new Error("registration failed")
+      const error = new Error("raw registration failure detail")
       const register = vi.fn().mockRejectedValue(error)
 
       Object.defineProperty(window.navigator, "serviceWorker", {
@@ -217,9 +221,10 @@ describe("OfflineSync", () => {
       await waitFor(() => {
         expect(mockLogger.warn).toHaveBeenCalledWith("Service worker registration failed", {
           component: "OfflineSync",
-          error: "registration failed",
+          errorType: "Error",
         })
       })
+      expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain("raw registration failure detail")
     })
   })
 
@@ -320,10 +325,11 @@ describe("OfflineSync", () => {
 
       await waitFor(() => {
         expect(mockLogger.warn).toHaveBeenCalledWith("Offline fallback prewarm failed", {
-          err: error,
+          errorType: "Error",
           locale: "en",
         })
       })
+      expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain("Fetch failed")
 
       fetchSpy.mockRestore()
     })

--- a/tests/lib/offline/feedback.test.ts
+++ b/tests/lib/offline/feedback.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { queueFeedback, syncPendingFeedback } from "@/lib/offline/feedback"
+import { normalizeOfflineFeedbackPayload, queueFeedback, syncPendingFeedback } from "@/lib/offline/feedback"
 import { getOfflineDB } from "@/lib/offline/db"
+import { logger } from "@/lib/logger"
 
 // Mock the DB module
 vi.mock("@/lib/offline/db", () => ({
   getOfflineDB: vi.fn(),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
 }))
 
 describe("Offline Feedback", () => {
@@ -16,7 +24,7 @@ describe("Offline Feedback", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(getOfflineDB as any).mockResolvedValue(mockDb)
+    vi.mocked(getOfflineDB).mockResolvedValue(mockDb as never)
 
     // Mock navigator.onLine
     Object.defineProperty(global.navigator, "onLine", {
@@ -28,6 +36,32 @@ describe("Offline Feedback", () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ success: true }),
+    })
+  })
+
+  describe("normalizeOfflineFeedbackPayload", () => {
+    it("removes empty optional fields before local queue storage or replay", () => {
+      expect(
+        normalizeOfflineFeedbackPayload({
+          category_searched: "",
+          feedback_type: "helpful_yes",
+          message: " ",
+          service_id: " service-1 ",
+        })
+      ).toEqual({
+        feedback_type: "helpful_yes",
+        service_id: "service-1",
+      })
+    })
+
+    it("rejects payloads that would fail the public feedback API schema", () => {
+      expect(() =>
+        normalizeOfflineFeedbackPayload({
+          category_searched: "Unsupported",
+          feedback_type: "not_found",
+          message: "x".repeat(1001),
+        })
+      ).toThrow("Invalid offline feedback payload")
     })
   })
 
@@ -52,6 +86,17 @@ describe("Offline Feedback", () => {
         })
       )
     })
+
+    it("does not store locally queued feedback that fails API-schema validation", async () => {
+      await expect(
+        queueFeedback({
+          category_searched: "Unsupported",
+          feedback_type: "not_found",
+        })
+      ).rejects.toThrow("Invalid offline feedback payload")
+
+      expect(mockDb.put).not.toHaveBeenCalled()
+    })
   })
 
   describe("syncPendingFeedback", () => {
@@ -75,11 +120,37 @@ describe("Offline Feedback", () => {
       expect(mockDb.delete).toHaveBeenCalledWith("pendingFeedback", 2)
     })
 
+    it("normalizes legacy empty optional fields before replaying pending feedback", async () => {
+      const pendingItems = [
+        {
+          category_searched: "",
+          id: 1,
+          feedback_type: "helpful_yes",
+          message: "",
+          service_id: "s1",
+          syncAttempts: 0,
+        },
+      ]
+      mockDb.getAll.mockResolvedValue(pendingItems)
+
+      await syncPendingFeedback()
+
+      const fetchCall = vi.mocked(global.fetch).mock.calls[0]
+      const requestBody = fetchCall?.[1] && "body" in fetchCall[1] ? fetchCall[1].body : undefined
+
+      expect(fetchCall?.[0]).toBe("/api/v1/feedback")
+      expect(JSON.parse(String(requestBody))).toEqual({
+        feedback_type: "helpful_yes",
+        service_id: "s1",
+      })
+      expect(mockDb.delete).toHaveBeenCalledWith("pendingFeedback", 1)
+    })
+
     it("increments sync attempts on API failure", async () => {
       const item = { id: 1, feedback_type: "helpful_yes", syncAttempts: 0 }
       mockDb.getAll.mockResolvedValue([item])
 
-      global.fetch = vi.fn().mockResolvedValue({ ok: false })
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 })
 
       await syncPendingFeedback()
 
@@ -91,6 +162,12 @@ describe("Offline Feedback", () => {
         })
       )
       expect(mockDb.delete).not.toHaveBeenCalled()
+      expect(logger.warn).toHaveBeenCalledWith("[Sync] Feedback API rejected pending item", {
+        action: "retained",
+        feedbackType: "helpful_yes",
+        id: 1,
+        status: 503,
+      })
     })
 
     it("gives up and deletes after 5 failed attempts", async () => {
@@ -103,6 +180,35 @@ describe("Offline Feedback", () => {
 
       expect(mockDb.delete).toHaveBeenCalledWith("pendingFeedback", 1)
       expect(mockDb.put).not.toHaveBeenCalled()
+    })
+
+    it("does not replay invalid pending feedback payloads", async () => {
+      const item = {
+        category_searched: "Unsupported",
+        id: 1,
+        feedback_type: "not_found",
+        message: "raw sensitive queued details",
+        syncAttempts: 0,
+      }
+      mockDb.getAll.mockResolvedValue([item])
+
+      await syncPendingFeedback()
+
+      expect(global.fetch).not.toHaveBeenCalled()
+      expect(mockDb.put).toHaveBeenCalledWith(
+        "pendingFeedback",
+        expect.objectContaining({
+          id: 1,
+          syncAttempts: 1,
+        })
+      )
+      expect(logger.warn).toHaveBeenCalledWith("[Sync] Failed to sync feedback item", {
+        action: "retained",
+        errorType: "Error",
+        feedbackType: "not_found",
+        id: 1,
+      })
+      expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain("raw sensitive queued details")
     })
   })
 })

--- a/tests/lib/offline/local-recovery-audit.test.ts
+++ b/tests/lib/offline/local-recovery-audit.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { buildOfflineLocalRecoveryPlan, buildOfflineLocalRecoverySnapshot } from "@/lib/offline/local-recovery-audit"
+import { PILOT_DRAFT_STORAGE_PREFIX } from "@/lib/offline/pilot-draft-cleanup"
+import { getOfflineDB } from "@/lib/offline/db"
+import { logger } from "@/lib/logger"
+
+vi.mock("@/lib/offline/db", () => ({
+  getOfflineDB: vi.fn(),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}))
+
+const mockDb = {
+  count: vi.fn(),
+  get: vi.fn(),
+}
+
+describe("offline local recovery audit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+
+    mockDb.count.mockImplementation(async (storeName: string) => {
+      if (storeName === "services") return 196
+      if (storeName === "embeddings") return 196
+      if (storeName === "pendingFeedback") return 2
+      return 0
+    })
+    mockDb.get.mockImplementation(async (_storeName: string, key: string) => {
+      if (key === "lastSync") return { id: "lastSync", value: "2026-03-08T15:00:00.000Z" }
+      if (key === "version") return { id: "version", value: "export-v1" }
+      return undefined
+    })
+    vi.mocked(getOfflineDB).mockResolvedValue(mockDb as never)
+  })
+
+  it("returns aggregate local recovery counts and metadata", async () => {
+    localStorage.setItem(`${PILOT_DRAFT_STORAGE_PREFIX}contact`, "{}")
+    localStorage.setItem("careconnect-high-contrast", "true")
+    sessionStorage.setItem(`${PILOT_DRAFT_STORAGE_PREFIX}referral`, "{}")
+
+    const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+
+    expect(snapshot).toEqual({
+      available: true,
+      counts: {
+        embeddings: 196,
+        pendingFeedback: 2,
+        pilotDraftLocalStorage: 1,
+        pilotDraftSessionStorage: 1,
+        services: 196,
+      },
+      inspectedAt: "2026-03-08T16:00:00.000Z",
+      metadata: {
+        hasExportVersion: true,
+        hasLastSync: true,
+        lastSync: "2026-03-08T15:00:00.000Z",
+        lastSyncStatus: "fresh",
+      },
+    })
+  })
+
+  it("marks old recovery metadata as stale", async () => {
+    mockDb.get.mockImplementation(async (_storeName: string, key: string) => {
+      if (key === "lastSync") return { id: "lastSync", value: "2026-03-07T15:00:00.000Z" }
+      if (key === "version") return { id: "version", value: "export-v1" }
+      return undefined
+    })
+
+    const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+
+    expect(snapshot.metadata.lastSyncStatus).toBe("stale")
+  })
+
+  it("marks invalid recovery metadata timestamps as unknown", async () => {
+    mockDb.get.mockImplementation(async (_storeName: string, key: string) => {
+      if (key === "lastSync") return { id: "lastSync", value: "not-a-date" }
+      if (key === "version") return { id: "version", value: "export-v1" }
+      return undefined
+    })
+
+    const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+
+    expect(snapshot.metadata).toMatchObject({
+      hasLastSync: true,
+      lastSync: "not-a-date",
+      lastSyncStatus: "unknown",
+    })
+  })
+
+  it("does not read queued payload contents", async () => {
+    await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+
+    expect(mockDb.count).toHaveBeenCalledWith("services")
+    expect(mockDb.count).toHaveBeenCalledWith("embeddings")
+    expect(mockDb.count).toHaveBeenCalledWith("pendingFeedback")
+    expect(mockDb.get).toHaveBeenCalledWith("meta", "lastSync")
+    expect(mockDb.get).toHaveBeenCalledWith("meta", "version")
+    expect(mockDb.get).not.toHaveBeenCalledWith("pendingFeedback")
+  })
+
+  it("returns a non-payload failure snapshot when IndexedDB is unavailable", async () => {
+    vi.mocked(getOfflineDB).mockRejectedValue(new Error("contains internal details"))
+    localStorage.setItem(`${PILOT_DRAFT_STORAGE_PREFIX}contact`, "{}")
+
+    const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+
+    expect(snapshot.available).toBe(false)
+    expect(snapshot.reason).toBe("offline_db_unavailable")
+    expect(snapshot.counts).toEqual({
+      embeddings: null,
+      pendingFeedback: null,
+      pilotDraftLocalStorage: 1,
+      pilotDraftSessionStorage: 0,
+      services: null,
+    })
+    expect(snapshot.metadata.lastSyncStatus).toBe("unknown")
+    expect(JSON.stringify(snapshot)).not.toContain("contains internal details")
+    expect(logger.warn).toHaveBeenCalledWith("Unable to build offline local recovery snapshot", {
+      errorType: "Error",
+      reason: "offline_db_unavailable",
+    })
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain("contains internal details")
+  })
+
+  it("keeps recovery snapshots aggregate-only when draft storage cannot be inspected", async () => {
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(window, "localStorage")
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("blocked local storage details")
+      },
+    })
+
+    try {
+      const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+      const plan = buildOfflineLocalRecoveryPlan(snapshot)
+
+      expect(snapshot.available).toBe(true)
+      expect(snapshot.counts.pilotDraftLocalStorage).toBeNull()
+      expect(snapshot.counts.pilotDraftSessionStorage).toBe(0)
+      expect(JSON.stringify(snapshot)).not.toContain("blocked local storage details")
+      expect(plan.recommendations).toContainEqual({
+        destructive: false,
+        id: "inspect_browser_storage",
+        priority: "high",
+      })
+      expect(logger.warn).toHaveBeenCalledWith("Unable to count pilot draft storage keys for recovery snapshot", {
+        errorType: "Error",
+        storage: "localStorage",
+      })
+      expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain("blocked local storage details")
+    } finally {
+      if (originalLocalStorage) {
+        Object.defineProperty(window, "localStorage", originalLocalStorage)
+      }
+    }
+  })
+
+  it("recommends preserving queued writes before recovery actions", async () => {
+    localStorage.setItem(`${PILOT_DRAFT_STORAGE_PREFIX}contact`, "{}")
+
+    const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+    const plan = buildOfflineLocalRecoveryPlan(snapshot)
+
+    expect(plan.hasQueuedLocalWrites).toBe(true)
+    expect(plan.recommendations).toContainEqual({
+      destructive: false,
+      id: "preserve_queued_writes",
+      priority: "high",
+    })
+  })
+
+  it("recommends retrying sync when aggregate metadata is stale", async () => {
+    mockDb.count.mockImplementation(async (storeName: string) => {
+      if (storeName === "services") return 196
+      if (storeName === "embeddings") return 196
+      return 0
+    })
+    mockDb.get.mockImplementation(async (_storeName: string, key: string) => {
+      if (key === "lastSync") return { id: "lastSync", value: "2026-03-07T15:00:00.000Z" }
+      if (key === "version") return { id: "version", value: "export-v1" }
+      return undefined
+    })
+
+    const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+    const plan = buildOfflineLocalRecoveryPlan(snapshot)
+
+    expect(plan.hasQueuedLocalWrites).toBe(false)
+    expect(plan.recommendations).toContainEqual({
+      destructive: false,
+      id: "retry_offline_sync",
+      priority: "medium",
+    })
+  })
+
+  it("recommends running recovery diagnostics in the browser for server snapshots", () => {
+    const plan = buildOfflineLocalRecoveryPlan({
+      available: false,
+      counts: {
+        embeddings: null,
+        pendingFeedback: null,
+        pilotDraftLocalStorage: null,
+        pilotDraftSessionStorage: null,
+        services: null,
+      },
+      inspectedAt: "2026-03-08T16:00:00.000Z",
+      metadata: {
+        hasExportVersion: false,
+        hasLastSync: false,
+        lastSync: null,
+        lastSyncStatus: "unknown",
+      },
+      reason: "server",
+    })
+
+    expect(plan).toEqual({
+      hasQueuedLocalWrites: false,
+      recommendations: [
+        {
+          destructive: false,
+          id: "run_in_browser",
+          priority: "high",
+        },
+      ],
+    })
+  })
+
+  it("returns a no-action recommendation for healthy aggregate snapshots", async () => {
+    mockDb.count.mockImplementation(async (storeName: string) => {
+      if (storeName === "services") return 196
+      if (storeName === "embeddings") return 196
+      return 0
+    })
+
+    const snapshot = await buildOfflineLocalRecoverySnapshot(new Date("2026-03-08T16:00:00.000Z"))
+    const plan = buildOfflineLocalRecoveryPlan(snapshot)
+
+    expect(plan).toEqual({
+      hasQueuedLocalWrites: false,
+      recommendations: [
+        {
+          destructive: false,
+          id: "no_immediate_recovery_action",
+          priority: "low",
+        },
+      ],
+    })
+  })
+})

--- a/tests/lib/offline/pilot-draft-cleanup.test.ts
+++ b/tests/lib/offline/pilot-draft-cleanup.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  clearPilotDraftStorage,
+  clearPilotDraftStorageOnSignOut,
+  isPilotDraftExpired,
+  PILOT_DRAFT_MAX_AGE_MS,
+  PILOT_DRAFT_SCHEMA_VERSION,
+  PILOT_DRAFT_STORAGE_PREFIX,
+  pruneExpiredPilotDraftStorage,
+} from "@/lib/offline/pilot-draft-cleanup"
+import { logger } from "@/lib/logger"
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}))
+
+describe("pilot draft cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it("uses the max-age policy to identify expired drafts", () => {
+    const now = Date.parse("2026-03-08T16:00:00.000Z")
+    const fresh = new Date(now - PILOT_DRAFT_MAX_AGE_MS + 1).toISOString()
+    const expired = new Date(now - PILOT_DRAFT_MAX_AGE_MS - 1).toISOString()
+
+    expect(isPilotDraftExpired(fresh, now)).toBe(false)
+    expect(isPilotDraftExpired(expired, now)).toBe(true)
+    expect(isPilotDraftExpired("not-a-date", now)).toBe(true)
+  })
+
+  it("clears only reserved pilot draft keys", () => {
+    localStorage.setItem(`${PILOT_DRAFT_STORAGE_PREFIX}contact-attempt`, "{}")
+    localStorage.setItem("careconnect-high-contrast", "true")
+
+    expect(clearPilotDraftStorage(localStorage)).toEqual([`${PILOT_DRAFT_STORAGE_PREFIX}contact-attempt`])
+    expect(localStorage.getItem(`${PILOT_DRAFT_STORAGE_PREFIX}contact-attempt`)).toBeNull()
+    expect(localStorage.getItem("careconnect-high-contrast")).toBe("true")
+  })
+
+  it("prunes expired, malformed, and unknown-version draft envelopes", () => {
+    const now = Date.parse("2026-03-08T16:00:00.000Z")
+    const freshKey = `${PILOT_DRAFT_STORAGE_PREFIX}fresh`
+    const expiredKey = `${PILOT_DRAFT_STORAGE_PREFIX}expired`
+    const malformedKey = `${PILOT_DRAFT_STORAGE_PREFIX}malformed`
+    const unknownVersionKey = `${PILOT_DRAFT_STORAGE_PREFIX}unknown-version`
+
+    localStorage.setItem(
+      freshKey,
+      JSON.stringify({
+        createdAt: new Date(now - 60_000).toISOString(),
+        payload: { event: "contact_attempt" },
+        schemaVersion: PILOT_DRAFT_SCHEMA_VERSION,
+      })
+    )
+    localStorage.setItem(
+      expiredKey,
+      JSON.stringify({
+        createdAt: new Date(now - PILOT_DRAFT_MAX_AGE_MS - 1).toISOString(),
+        payload: { event: "contact_attempt" },
+        schemaVersion: PILOT_DRAFT_SCHEMA_VERSION,
+      })
+    )
+    localStorage.setItem(malformedKey, "{")
+    localStorage.setItem(
+      unknownVersionKey,
+      JSON.stringify({
+        createdAt: new Date(now).toISOString(),
+        payload: { event: "contact_attempt" },
+        schemaVersion: 999,
+      })
+    )
+
+    const removed = pruneExpiredPilotDraftStorage(localStorage, now)
+
+    expect(removed).toEqual(expect.arrayContaining([expiredKey, malformedKey, unknownVersionKey]))
+    expect(localStorage.getItem(freshKey)).not.toBeNull()
+    expect(localStorage.getItem(expiredKey)).toBeNull()
+    expect(localStorage.getItem(malformedKey)).toBeNull()
+    expect(localStorage.getItem(unknownVersionKey)).toBeNull()
+  })
+
+  it("clears reserved pilot draft keys from local and session storage on sign-out", async () => {
+    const localKey = `${PILOT_DRAFT_STORAGE_PREFIX}local-contact`
+    const sessionKey = `${PILOT_DRAFT_STORAGE_PREFIX}session-contact`
+
+    localStorage.setItem(localKey, "{}")
+    sessionStorage.setItem(sessionKey, "{}")
+    localStorage.setItem("careconnect-services-cache", "keep")
+
+    const removed = await clearPilotDraftStorageOnSignOut()
+
+    expect(removed).toEqual(expect.arrayContaining([localKey, sessionKey]))
+    expect(localStorage.getItem(localKey)).toBeNull()
+    expect(sessionStorage.getItem(sessionKey)).toBeNull()
+    expect(localStorage.getItem("careconnect-services-cache")).toBe("keep")
+  })
+
+  it("continues sign-out cleanup when one draft storage area cannot be inspected", async () => {
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(window, "localStorage")
+    const sessionKey = `${PILOT_DRAFT_STORAGE_PREFIX}session-contact`
+
+    sessionStorage.setItem(sessionKey, "{}")
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("blocked draft storage payload")
+      },
+    })
+
+    try {
+      const removed = await clearPilotDraftStorageOnSignOut()
+
+      expect(removed).toEqual([sessionKey])
+      expect(sessionStorage.getItem(sessionKey)).toBeNull()
+      expect(logger.warn).toHaveBeenCalledWith("Unable to clear pilot draft storage during sign-out", {
+        errorType: "Error",
+        storage: "localStorage",
+      })
+      expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain("blocked draft storage payload")
+    } finally {
+      if (originalLocalStorage) {
+        Object.defineProperty(window, "localStorage", originalLocalStorage)
+      }
+    }
+  })
+})

--- a/tests/lib/pilot/event-replay-policy.test.ts
+++ b/tests/lib/pilot/event-replay-policy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildPilotEventReplayFingerprint,
+  buildPilotEventReplayMaterial,
+  PILOT_EVENT_REPLAY_CRITERIA,
+  type PilotReplayPayloads,
+} from "@/lib/pilot/event-replay-policy"
+
+const contactAttemptPayload = {
+  pilot_cycle_id: "v22-cycle-1",
+  service_id: "kingston-food-bank",
+  recorded_by_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+  entity_key_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  attempt_channel: "phone",
+  attempt_outcome: "connected",
+  attempted_at: "2026-03-08T15:00:00.000Z",
+  resolved_at: "2026-03-08T15:05:00.000Z",
+  outcome_notes_code: "busy_signal",
+} satisfies PilotReplayPayloads["contact_attempt"]
+
+describe("pilot event replay policy", () => {
+  it("builds deterministic replay fingerprints from criteria fields", () => {
+    const fingerprint = buildPilotEventReplayFingerprint("contact_attempt", contactAttemptPayload)
+    const reorderedPayload = {
+      attempted_at: contactAttemptPayload.attempted_at,
+      attempt_outcome: contactAttemptPayload.attempt_outcome,
+      attempt_channel: contactAttemptPayload.attempt_channel,
+      entity_key_hash: contactAttemptPayload.entity_key_hash,
+      recorded_by_org_id: contactAttemptPayload.recorded_by_org_id,
+      service_id: contactAttemptPayload.service_id,
+      pilot_cycle_id: contactAttemptPayload.pilot_cycle_id,
+      outcome_notes_code: contactAttemptPayload.outcome_notes_code,
+      resolved_at: contactAttemptPayload.resolved_at,
+    } satisfies PilotReplayPayloads["contact_attempt"]
+
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/)
+    expect(buildPilotEventReplayFingerprint("contact_attempt", reorderedPayload)).toBe(fingerprint)
+  })
+
+  it("changes fingerprints when replay criteria change", () => {
+    const baseline = buildPilotEventReplayFingerprint("contact_attempt", contactAttemptPayload)
+    const changed = buildPilotEventReplayFingerprint("contact_attempt", {
+      ...contactAttemptPayload,
+      attempt_outcome: "no_response",
+    })
+
+    expect(changed).not.toBe(baseline)
+  })
+
+  it("includes event kind so different event types cannot collide on shared fields alone", () => {
+    const statusPayload = {
+      pilot_cycle_id: contactAttemptPayload.pilot_cycle_id,
+      org_id: contactAttemptPayload.recorded_by_org_id,
+      service_id: contactAttemptPayload.service_id,
+      checked_at: contactAttemptPayload.attempted_at,
+      status_code: "available",
+    } satisfies PilotReplayPayloads["service_status"]
+
+    expect(buildPilotEventReplayFingerprint("service_status", statusPayload)).not.toBe(
+      buildPilotEventReplayFingerprint("contact_attempt", contactAttemptPayload)
+    )
+  })
+
+  it("ignores fields outside the replay criteria", () => {
+    const payloadWithExtraField = {
+      ...contactAttemptPayload,
+      contact_phone: "555-0100",
+    } as PilotReplayPayloads["contact_attempt"]
+
+    const material = buildPilotEventReplayMaterial("contact_attempt", payloadWithExtraField)
+
+    expect(Object.keys(material.criteria)).toEqual([...PILOT_EVENT_REPLAY_CRITERIA.contact_attempt])
+    expect(JSON.stringify(material)).not.toContain("555-0100")
+  })
+})

--- a/tests/lib/pilot/readiness-audit.test.ts
+++ b/tests/lib/pilot/readiness-audit.test.ts
@@ -25,6 +25,14 @@ import {
 } from "@/lib/pilot/readiness-audit"
 import type { Service } from "@/types/service"
 
+function mockScopeQuery(result: unknown) {
+  mockOrder.mockResolvedValue(result)
+  mockEq.mockReturnValue({ eq: mockEq, order: mockOrder })
+  mockSelect.mockReturnValue({ eq: mockEq })
+  mockFrom.mockReturnValue({ select: mockSelect })
+  mockCreateClient.mockReturnValue({ from: mockFrom })
+}
+
 describe("pilot readiness audit", () => {
   afterEach(() => {
     vi.clearAllMocks()
@@ -39,31 +47,173 @@ describe("pilot readiness audit", () => {
     expect(entries).toEqual([{ service_id: "svc-1", sla_tier: "crisis" }])
   })
 
+  it("rejects invalid scope file entries without echoing raw values", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hb-scope-"))
+    const filePath = path.join(tempDir, "scope.json")
+    await fs.writeFile(
+      filePath,
+      JSON.stringify(
+        {
+          services: [
+            {
+              service_id: "svc-1",
+              sla_tier: "gold",
+              notes: "raw partner note that should not be echoed",
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    )
+
+    await expect(loadPilotScopeEntriesFromFile(filePath)).rejects.toThrow(
+      "Invalid pilot scope file entries: entry 1 sla_tier, entry 1 value"
+    )
+
+    try {
+      await loadPilotScopeEntriesFromFile(filePath)
+    } catch (error) {
+      expect(String(error)).not.toContain("gold")
+      expect(String(error)).not.toContain("raw partner note")
+    }
+  })
+
+  it("rejects malformed scope file shapes", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hb-scope-"))
+    const filePath = path.join(tempDir, "scope.json")
+    await fs.writeFile(filePath, JSON.stringify({ records: [] }, null, 2), "utf-8")
+
+    await expect(loadPilotScopeEntriesFromFile(filePath)).rejects.toThrow(
+      "Invalid pilot scope file: expected an array or an object with a services array"
+    )
+  })
+
+  it("rejects duplicate scope identities without echoing raw values", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hb-scope-"))
+    const filePath = path.join(tempDir, "scope.json")
+    await fs.writeFile(
+      filePath,
+      JSON.stringify(
+        [
+          { service_id: "svc-sensitive", sla_tier: "standard" },
+          { service_id: "svc-sensitive", sla_tier: "standard" },
+        ],
+        null,
+        2
+      ),
+      "utf-8"
+    )
+
+    try {
+      await loadPilotScopeEntriesFromFile(filePath)
+      throw new Error("Expected duplicate scope entry")
+    } catch (error) {
+      expect(String(error)).toContain("Invalid pilot scope file entries: entry 2 duplicates entry 1")
+      expect(String(error)).not.toContain("svc-sensitive")
+    }
+  })
+
+  it("allows the same scoped service under distinct org identities", async () => {
+    const firstOrgId = "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e"
+    const secondOrgId = "5002d45c-0b0c-4c8c-bf37-a270034471ca"
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "hb-scope-"))
+    const filePath = path.join(tempDir, "scope.json")
+    await fs.writeFile(
+      filePath,
+      JSON.stringify(
+        [
+          { service_id: "svc-1", sla_tier: "standard", org_id: firstOrgId },
+          { service_id: "svc-1", sla_tier: "standard", org_id: secondOrgId },
+        ],
+        null,
+        2
+      ),
+      "utf-8"
+    )
+
+    const entries = await loadPilotScopeEntriesFromFile(filePath)
+
+    expect(entries).toHaveLength(2)
+    expect(entries.map((entry) => entry.org_id)).toEqual([firstOrgId, secondOrgId])
+  })
+
   it("loads scope entries from Supabase in pilot-cycle mode", async () => {
-    mockOrder.mockResolvedValue({
-      data: [{ pilot_cycle_id: "v22-cycle-1", org_id: "org-1", service_id: "svc-1", sla_tier: "standard" }],
+    const orgId = "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e"
+    mockScopeQuery({
+      data: [{ pilot_cycle_id: "v22-cycle-1", org_id: orgId, service_id: "svc-1", sla_tier: "standard" }],
       error: null,
     })
-    mockEq.mockReturnValue({ eq: mockEq, order: mockOrder })
-    mockSelect.mockReturnValue({ eq: mockEq })
-    mockFrom.mockReturnValue({ select: mockSelect })
-    mockCreateClient.mockReturnValue({ from: mockFrom })
 
     const entries = await loadPilotScopeEntriesFromSupabase({
       supabaseUrl: "https://example.supabase.co",
       supabaseKey: "service-key",
       pilotCycleId: "v22-cycle-1",
-      orgId: "org-1",
+      orgId,
     })
 
     expect(entries).toEqual([
       {
         pilot_cycle_id: "v22-cycle-1",
-        org_id: "org-1",
+        org_id: orgId,
         service_id: "svc-1",
         sla_tier: "standard",
       },
     ])
+  })
+
+  it("sanitizes Supabase scope load errors", async () => {
+    mockScopeQuery({
+      data: null,
+      error: {
+        code: "42501",
+        message: "permission denied for partner-owned pilot scope with internal details",
+      },
+    })
+
+    try {
+      await loadPilotScopeEntriesFromSupabase({
+        supabaseUrl: "https://example.supabase.co",
+        supabaseKey: "service-key",
+        pilotCycleId: "v22-cycle-1",
+      })
+      throw new Error("Expected Supabase load failure")
+    } catch (error) {
+      expect(String(error)).toContain("Failed to load pilot scope from Supabase (42501)")
+      expect(String(error)).not.toContain("permission denied")
+      expect(String(error)).not.toContain("partner-owned")
+    }
+  })
+
+  it("rejects invalid Supabase scope rows without echoing raw values", async () => {
+    mockScopeQuery({
+      data: [{ pilot_cycle_id: "v22-cycle-1", org_id: "not-a-uuid", service_id: "svc-1", sla_tier: "urgent" }],
+      error: null,
+    })
+
+    try {
+      await loadPilotScopeEntriesFromSupabase({
+        supabaseUrl: "https://example.supabase.co",
+        supabaseKey: "service-key",
+        pilotCycleId: "v22-cycle-1",
+      })
+      throw new Error("Expected invalid Supabase scope row")
+    } catch (error) {
+      expect(String(error)).toContain("Invalid pilot scope Supabase entries: entry 1 sla_tier, entry 1 org_id")
+      expect(String(error)).not.toContain("urgent")
+      expect(String(error)).not.toContain("not-a-uuid")
+    }
+  })
+
+  it("rejects invalid direct report scope entries", () => {
+    try {
+      buildPilotReadinessReport([], [{ service_id: "svc-1", sla_tier: "gold" as never }])
+      throw new Error("Expected invalid report scope entry")
+    } catch (error) {
+      expect(String(error)).toContain("Invalid pilot scope report entries: entry 1 sla_tier")
+      expect(String(error)).not.toContain("gold")
+    }
   })
 
   it("builds a scoped readiness report and renders markdown/csv", () => {
@@ -133,5 +283,36 @@ describe("pilot readiness audit", () => {
     expect(csv.split("\n")[0]).toContain("service_id,name,category")
     expect(csv).toContain("svc-1")
     expect(csv).toContain("verification_action")
+  })
+
+  it("neutralizes spreadsheet formula prefixes in the readiness CSV", () => {
+    const services = [
+      {
+        id: "svc-formula",
+        name: '=HYPERLINK("https://example.test")',
+        description: "Food support",
+        url: "https://example.com",
+        verification_level: "L1",
+        intent_category: "Food",
+        provenance: {
+          verified_by: "tester",
+          verified_at: "2026-03-01T00:00:00.000Z",
+          evidence_url: "https://example.com",
+          method: "web",
+        },
+        identity_tags: [],
+        synthetic_queries: [],
+        scope: "kingston",
+        virtual_delivery: true,
+        published: true,
+      },
+    ] as unknown as Service[]
+
+    const report = buildPilotReadinessReport(services, [{ service_id: "svc-formula", sla_tier: "standard" }])
+    const csv = renderPilotReadinessCsv(report)
+    const row = csv.split("\n")[1]
+
+    expect(row).toContain("\"'" + '=HYPERLINK(""https://example.test"")"')
+    expect(row).not.toContain("svc-formula,=HYPERLINK")
   })
 })

--- a/tests/lib/pilot/responses.test.ts
+++ b/tests/lib/pilot/responses.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest"
+import { createPilotIdempotentRetryResponse, createPilotWriteSuccessResponse } from "@/lib/pilot/responses"
+
+vi.mock("@/lib/logger", () => ({
+  generateErrorId: vi.fn(() => "req-test"),
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+describe("pilot API responses", () => {
+  it("creates a no-store write success response", async () => {
+    const response = createPilotWriteSuccessResponse()
+    const json = (await response.json()) as { data: unknown }
+
+    expect(response.status).toBe(201)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(json.data).toEqual({ success: true })
+  })
+
+  it("creates a no-store idempotent retry response", async () => {
+    const response = createPilotIdempotentRetryResponse()
+    const json = (await response.json()) as { data: unknown }
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(json.data).toEqual({ success: true, duplicate: true })
+  })
+})

--- a/tests/lib/pilot/storage.test.ts
+++ b/tests/lib/pilot/storage.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getScorecardByCycle, insertContactAttempt, updateReferralEvent } from "@/lib/pilot/storage"
+import { withCircuitBreaker } from "@/lib/resilience/supabase-breaker"
+
+vi.mock("@/lib/resilience/supabase-breaker", () => ({
+  withCircuitBreaker: vi.fn(async <T>(operation: () => Promise<T>) => operation()),
+}))
+
+function createSupabaseMock(result: unknown) {
+  const single = vi.fn().mockResolvedValue(result)
+  const select = vi.fn(() => ({ single }))
+  const insert = vi.fn(() => ({ select }))
+  const from = vi.fn(() => ({ insert }))
+
+  return {
+    client: { from },
+    from,
+    insert,
+    select,
+    single,
+  }
+}
+
+function createUpdateSupabaseMock(result: unknown) {
+  const single = vi.fn().mockResolvedValue(result)
+  const select = vi.fn(() => ({ single }))
+  const eq = vi.fn(() => ({ select }))
+  const update = vi.fn(() => ({ eq }))
+  const from = vi.fn(() => ({ update }))
+
+  return {
+    client: { from },
+    from,
+    update,
+    eq,
+    select,
+    single,
+  }
+}
+
+function createScorecardSupabaseMock(result: unknown) {
+  const order = vi.fn().mockResolvedValue(result)
+  const query = {
+    eq: vi.fn(() => query),
+    order,
+  }
+  const select = vi.fn(() => query)
+  const from = vi.fn(() => ({ select }))
+
+  return {
+    client: { from },
+    from,
+    select,
+    eq: query.eq,
+    order,
+  }
+}
+
+const contactAttemptPayload = {
+  id: "11111111-1111-4111-8111-111111111111",
+  pilot_cycle_id: "v22-cycle-1",
+  service_id: "kingston-food-bank",
+  recorded_by_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+  entity_key_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  attempt_channel: "phone" as const,
+  attempt_outcome: "connected" as const,
+  attempted_at: "2026-03-08T15:00:00.000Z",
+}
+
+describe("pilot storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("wraps contact-attempt writes in the Supabase circuit breaker", async () => {
+    const supabase = createSupabaseMock({
+      data: { id: contactAttemptPayload.id },
+      error: null,
+    })
+
+    const result = await insertContactAttempt(supabase.client as never, contactAttemptPayload)
+
+    expect(result).toEqual({
+      data: { id: contactAttemptPayload.id },
+      duplicate: false,
+      error: null,
+      missingTable: false,
+    })
+    expect(withCircuitBreaker).toHaveBeenCalledTimes(1)
+    expect(withCircuitBreaker).toHaveBeenCalledWith(expect.any(Function))
+    expect(supabase.from).toHaveBeenCalledWith("pilot_contact_attempt_events")
+  })
+
+  it("wraps referral updates in the Supabase circuit breaker", async () => {
+    const supabase = createUpdateSupabaseMock({
+      data: { id: "22222222-2222-4222-8222-222222222222" },
+      error: null,
+    })
+    const updatePayload = {
+      referral_state: "connected" as const,
+      updated_at: "2026-03-08T16:00:00.000Z",
+      terminal_at: "2026-03-08T16:00:00.000Z",
+    }
+
+    const result = await updateReferralEvent(
+      supabase.client as never,
+      "22222222-2222-4222-8222-222222222222",
+      updatePayload
+    )
+
+    expect(result).toEqual({
+      data: { id: "22222222-2222-4222-8222-222222222222" },
+      duplicate: false,
+      error: null,
+      missingTable: false,
+    })
+    expect(withCircuitBreaker).toHaveBeenCalledTimes(1)
+    expect(supabase.from).toHaveBeenCalledWith("pilot_referral_events")
+    expect(supabase.update).toHaveBeenCalledWith(updatePayload)
+    expect(supabase.eq).toHaveBeenCalledWith("id", "22222222-2222-4222-8222-222222222222")
+  })
+
+  it("wraps scorecard reads in the Supabase circuit breaker", async () => {
+    const supabase = createScorecardSupabaseMock({
+      data: [
+        {
+          metric_id: "M1",
+          metric_value: 0.25,
+        },
+      ],
+      error: null,
+    })
+
+    const result = await getScorecardByCycle(
+      supabase.client as never,
+      "v22-cycle-1",
+      "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e"
+    )
+
+    expect(result.error).toBeNull()
+    expect(result.missingTable).toBe(false)
+    expect(result.data?.m1_failed_contact_rate).toBe(0.25)
+    expect(withCircuitBreaker).toHaveBeenCalledTimes(1)
+    expect(supabase.from).toHaveBeenCalledWith("pilot_metric_snapshots")
+    expect(supabase.select).toHaveBeenCalledWith("metric_id, metric_value")
+    expect(supabase.eq).toHaveBeenCalledWith("pilot_cycle_id", "v22-cycle-1")
+    expect(supabase.eq).toHaveBeenCalledWith("org_id", "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e")
+  })
+
+  it("treats duplicate primary-key errors as idempotent when a client event id is supplied", async () => {
+    const supabase = createSupabaseMock({
+      data: null,
+      error: {
+        code: "23505",
+        details: 'Key (id)=("11111111-1111-4111-8111-111111111111") already exists.',
+        message: 'duplicate key value violates unique constraint "pilot_contact_attempt_events_pkey"',
+      },
+    })
+
+    const result = await insertContactAttempt(supabase.client as never, contactAttemptPayload)
+
+    expect(result).toEqual({
+      data: null,
+      duplicate: true,
+      error: null,
+      missingTable: false,
+    })
+    expect(supabase.from).toHaveBeenCalledWith("pilot_contact_attempt_events")
+    expect(supabase.insert).toHaveBeenCalledWith(contactAttemptPayload)
+  })
+
+  it("does not suppress non-primary duplicate errors even when a client event id is supplied", async () => {
+    const error = {
+      code: "23505",
+      details:
+        "Key (pilot_cycle_id, service_id, attempted_at)=(v22-cycle-1, kingston-food-bank, 2026-03-08T15:00:00.000Z) already exists.",
+      message: 'duplicate key value violates unique constraint "pilot_contact_attempt_events_replay_key"',
+    }
+    const supabase = createSupabaseMock({
+      data: null,
+      error,
+    })
+
+    const result = await insertContactAttempt(supabase.client as never, contactAttemptPayload)
+
+    expect(result).toEqual({
+      data: null,
+      duplicate: false,
+      error,
+      missingTable: false,
+    })
+  })
+
+  it("does not suppress duplicate errors when no client event id was supplied", async () => {
+    const supabase = createSupabaseMock({
+      data: null,
+      error: {
+        code: "23505",
+        message: "duplicate key value violates unique constraint",
+      },
+    })
+    const { id: _id, ...payloadWithoutId } = contactAttemptPayload
+
+    const result = await insertContactAttempt(supabase.client as never, payloadWithoutId)
+
+    expect(result).toEqual({
+      data: null,
+      duplicate: false,
+      error: {
+        code: "23505",
+        message: "duplicate key value violates unique constraint",
+      },
+      missingTable: false,
+    })
+  })
+})

--- a/tests/lib/schemas/pilot-events.test.ts
+++ b/tests/lib/schemas/pilot-events.test.ts
@@ -14,6 +14,7 @@ import {
 describe("pilot-events schema", () => {
   it("accepts a valid contact attempt payload", () => {
     const result = PilotContactAttemptCreateSchema.safeParse({
+      id: "11111111-1111-4111-8111-111111111111",
       pilot_cycle_id: "v22-cycle-1",
       service_id: "kingston-food-bank",
       recorded_by_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
@@ -26,6 +27,21 @@ describe("pilot-events schema", () => {
     expect(result.success).toBe(true)
   })
 
+  it("rejects invalid client event ids", () => {
+    const result = PilotContactAttemptCreateSchema.safeParse({
+      id: "not-a-uuid",
+      pilot_cycle_id: "v22-cycle-1",
+      service_id: "kingston-food-bank",
+      recorded_by_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+      entity_key_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      attempt_channel: "phone",
+      attempt_outcome: "connected",
+      attempted_at: "2026-03-08T15:00:00.000Z",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
   it("rejects contact payload with disallowed privacy field", () => {
     const result = PilotContactAttemptCreateSchema.safeParse({
       pilot_cycle_id: "v22-cycle-1",
@@ -36,6 +52,21 @@ describe("pilot-events schema", () => {
       attempt_outcome: "connected",
       attempted_at: "2026-03-08T15:00:00.000Z",
       query_text: "i need food",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects contact payload with personal contact fields", () => {
+    const result = PilotContactAttemptCreateSchema.safeParse({
+      pilot_cycle_id: "v22-cycle-1",
+      service_id: "kingston-food-bank",
+      recorded_by_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+      entity_key_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      attempt_channel: "phone",
+      attempt_outcome: "connected",
+      attempted_at: "2026-03-08T15:00:00.000Z",
+      contact_phone: "555-0100",
     })
 
     expect(result.success).toBe(false)
@@ -66,6 +97,20 @@ describe("pilot-events schema", () => {
     })
 
     expect(result.success).toBe(true)
+  })
+
+  it("rejects referral payloads with raw contact identity fields", () => {
+    const result = PilotReferralCreateSchema.safeParse({
+      pilot_cycle_id: "v22-cycle-1",
+      source_org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+      target_service_id: "kingston-housing-help",
+      referral_state: "initiated",
+      created_at: "2026-03-08T15:00:00.000Z",
+      updated_at: "2026-03-08T15:00:00.000Z",
+      contact_email: "person@example.test",
+    })
+
+    expect(result.success).toBe(false)
   })
 
   it("rejects terminal referral state update without terminal_at", () => {
@@ -156,6 +201,20 @@ describe("pilot-events schema", () => {
       is_fatal: false,
       fatal_error_category: "wrong_or_disconnected_phone",
       verification_mode: "web_plus_call",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects data decay audits with free-text notes", () => {
+    const result = PilotDataDecayAuditCreateSchema.safeParse({
+      pilot_cycle_id: "v22-cycle-1",
+      org_id: "3e4f36f6-2b92-4fa8-af31-c7c5d75a3f5e",
+      service_id: "svc-1",
+      audited_at: "2026-03-08T15:30:00.000Z",
+      is_fatal: false,
+      verification_mode: "web_plus_call",
+      comments: "unstructured personal context",
     })
 
     expect(result.success).toBe(false)

--- a/tests/lib/schemas/privacy-guards.test.ts
+++ b/tests/lib/schemas/privacy-guards.test.ts
@@ -25,6 +25,28 @@ describe("privacy-guards", () => {
     expect(result).toContain("events.0.message")
   })
 
+  it("finds raw personal contact and free-text fields", () => {
+    const result = findDisallowedPrivacyKeyPaths({
+      client: {
+        full_name: "Example Person",
+        email_address: "person@example.test",
+        phone_number: "555-0100",
+        home_address: "1 Example Street",
+      },
+      free_text: "unstructured personal context",
+      outreach: [{ contact_phone: "555-0101" }],
+      comments: "do not persist this",
+    })
+
+    expect(result).toContain("client.full_name")
+    expect(result).toContain("client.email_address")
+    expect(result).toContain("client.phone_number")
+    expect(result).toContain("client.home_address")
+    expect(result).toContain("free_text")
+    expect(result).toContain("outreach.0.contact_phone")
+    expect(result).toContain("comments")
+  })
+
   it("returns an empty array when no disallowed keys exist", () => {
     const result = findDisallowedPrivacyKeyPaths({
       pilot_cycle_id: "v22-cycle-1",

--- a/tests/scripts/check-v22-evidence-intake.test.ts
+++ b/tests/scripts/check-v22-evidence-intake.test.ts
@@ -1,0 +1,847 @@
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+const scriptPath = path.join(process.cwd(), "scripts/check-v22-evidence-intake.sh")
+
+const tempRoots: string[] = []
+
+function createFixtureRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), "careconnect-gate0-"))
+  tempRoots.push(root)
+
+  mkdirSync(path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms"), {
+    recursive: true,
+  })
+  mkdirSync(path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops"), {
+    recursive: true,
+  })
+
+  return root
+}
+
+function writeBaseDocs(
+  root: string,
+  options: {
+    c1Gate?: string
+    c1Action?: string
+    c1Result?: string
+    d4Gate?: string
+    d4Action?: string
+  } = {}
+) {
+  const c1Gate = options.c1Gate ?? "pending"
+  const c1Action = options.c1Action ?? "pending"
+  const c1Result = options.c1Result ?? "pending"
+  const d4Gate = options.d4Gate ?? "pending"
+  const d4Action = options.d4Action ?? "pending"
+
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-gate-0-exit-checklist.md"),
+    [
+      "| Check ID | Requirement | Current Status (`pass` \\| `fail` \\| `pending`) | Evidence | Notes |",
+      "| -------- | ----------- | ------------------------------------------------ | -------- | ----- |",
+      `| G0-3 | C1 legal clause review complete | ${c1Gate} | C1 | note |`,
+      `| G0-8 | D4 partner ops execution evidence attached | ${d4Gate} | D4 | note |`,
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-gate-0-user-action-tracker.md"),
+    [
+      "| Action ID | Gate Check | Owner | Required Evidence | Current Status (`pending` \\| `in_progress` \\| `complete`) | Due Date | Last Update | Blocking If Missing (`yes` \\| `no`) | Notes |",
+      "| --------- | ---------- | ----- | ----------------- | --------------------------------------------------------- | -------- | ----------- | ----------------------------------- | ----- |",
+      `| UA-1 | G0-3 (C1 legal clause review) | jer | C1 evidence | ${c1Action} | 2026-03-21 | 2026-06-12 | yes | note |`,
+      `| UA-3 | G0-8 (D4 partner ops execution evidence) | jer | D4 evidence | ${d4Action} | 2026-03-21 | 2026-06-12 | yes | note |`,
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-control-c1-legal-review.md"),
+    ["# C1 Control", "", "## Decision", "", `- Result: \`${c1Result}\``].join("\n")
+  )
+}
+
+function writePrepEvidence(root: string) {
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms", "C1-20260428-submission.md"),
+    ["---", "evidence_status: prep_only", "---", "", "Final legal recommendation: pending"].join("\n")
+  )
+
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops", "D4-20260428-submission.md"),
+    ["---", "evidence_status: prep_only", "---", "", "Outreach owner:"].join("\n")
+  )
+}
+
+function writeCompleteEvidence(root: string) {
+  const c1Dir = path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms")
+  const d4Dir = path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops")
+
+  writeFileSync(
+    path.join(c1Dir, "C1-20260612-submission.md"),
+    [
+      "Submission ID: C1-20260612",
+      "Submitted by: jer",
+      "Reviewer: jer",
+      "Date: 2026-06-12",
+      "Partner: candidate partner",
+      "Partner artifact bundle location: C1-20260612-terms.pdf",
+      "Final legal recommendation: acceptable",
+      "Decision owner: jer",
+      "Sign-off date: 2026-06-12",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(c1Dir, "C1-20260612-clause-matrix.md"),
+    [
+      "| Clause ID | Source artifact | Source section / page | Requirement under review | Outcome | Notes / rationale | Required mitigation or fallback |",
+      "| --------- | --------------- | --------------------- | ------------------------ | ------- | ----------------- | ------------------------------- |",
+      "| C1-1 | C1-20260612-terms.pdf | section 1 | No raw query text | pass | ok | none |",
+      "| C1-2 | C1-20260612-terms.pdf | section 2 | No identifying telemetry | pass | ok | none |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 | No re-identification | pass | ok | none |",
+      "| C1-4 | C1-20260612-terms.pdf | section 4 | No governance conflict | pass | ok | none |",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(c1Dir, "C1-20260612-artifact-inventory.md"),
+    [
+      "| Artifact ID | Filename / location | Artifact type | Source / owner | Date received | Used in clause matrix | Notes |",
+      "| ----------- | ------------------- | ------------- | -------------- | ------------- | --------------------- | ----- |",
+      "| C1-A1 | C1-20260612-terms.pdf | contract and API terms | candidate partner | 2026-06-12 | yes | reviewed source |",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-submission.md"),
+    [
+      "Submission ID: D4-20260612",
+      "Submitted by: jer",
+      "Date: 2026-06-12",
+      "Outreach owner: jer",
+      "Number of dated contact attempts recorded: 1",
+      "Number of partners targeted: 5",
+      "Number of organizations targeted: 2",
+      "Is D4 auditable from the attached artifacts? yes",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-partner-list.md"),
+    [
+      "| Organization / Partner | Partner type | Primary contact | Contact channel | Priority | Status | Notes |",
+      "| ---------------------- | ------------ | --------------- | --------------- | -------- | ------ | ----- |",
+      "| Provider 1 | provider | contact | email | primary | planned | note |",
+      "| Provider 2 | provider | contact | email | primary | planned | note |",
+      "| Provider 3 | provider | contact | email | primary | planned | note |",
+      "| Provider 4 | provider | contact | email | primary | planned | note |",
+      "| Provider 5 | provider | contact | email | primary | planned | note |",
+      "| Frontline 1 | frontline organization | contact | email | primary | planned | note |",
+      "| Frontline 2 | frontline organization | contact | email | primary | planned | note |",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-outreach-log.csv"),
+    [
+      "date,organization_or_partner,contact_name,contact_role,channel,owner,attempt_number,outcome,next_step,source_artifact",
+      "2026-06-12,Provider 1,Contact,Role,email,jer,1,sent,follow up,D4-20260612-email.pdf",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-artifact-inventory.md"),
+    [
+      "| Artifact ID | Filename / location | Artifact type | Source / owner | Date captured | Supports outreach-log row | Notes |",
+      "| ----------- | ------------------- | ------------- | -------------- | ------------- | ------------------------- | ----- |",
+      "| D4-A1 | D4-20260612-email.pdf | email export | jer | 2026-06-12 | yes | outreach source |",
+    ].join("\n")
+  )
+}
+
+function overwriteD4OutreachLog(root: string, rows: string[]) {
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops", "D4-20260612-outreach-log.csv"),
+    rows.join("\n")
+  )
+}
+
+function overwriteC1Submission(root: string, rows: string[]) {
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms", "C1-20260612-submission.md"),
+    rows.join("\n")
+  )
+}
+
+function overwriteC1ClauseMatrix(root: string, rows: string[]) {
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms", "C1-20260612-clause-matrix.md"),
+    rows.join("\n")
+  )
+}
+
+function overwriteC1ArtifactInventory(root: string, rows: string[]) {
+  writeFileSync(
+    path.join(
+      root,
+      "docs",
+      "implementation",
+      "v22-0-evidence",
+      "c1-partner-terms",
+      "C1-20260612-artifact-inventory.md"
+    ),
+    rows.join("\n")
+  )
+}
+
+function overwriteD4Submission(root: string, rows: string[]) {
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops", "D4-20260612-submission.md"),
+    rows.join("\n")
+  )
+}
+
+function overwriteD4PartnerList(root: string, rows: string[]) {
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops", "D4-20260612-partner-list.md"),
+    rows.join("\n")
+  )
+}
+
+function overwriteD4ArtifactInventory(root: string, rows: string[]) {
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops", "D4-20260612-artifact-inventory.md"),
+    rows.join("\n")
+  )
+}
+
+function runEvidenceCheck(root: string) {
+  return spawnSync("bash", [scriptPath], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      GATE0_CHECKLIST_PATH: path.join(root, "docs", "implementation", "v22-0-gate-0-exit-checklist.md"),
+      GATE0_TRACKER_PATH: path.join(root, "docs", "implementation", "v22-0-gate-0-user-action-tracker.md"),
+      GATE0_C1_CONTROL_PATH: path.join(root, "docs", "implementation", "v22-0-control-c1-legal-review.md"),
+      GATE0_C1_EVIDENCE_DIR: path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms"),
+      GATE0_D4_EVIDENCE_DIR: path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops"),
+    },
+    encoding: "utf8",
+  })
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+describe("check-v22-evidence-intake", () => {
+  it("passes when C1 and D4 are still pending with prep-only evidence", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root)
+    writePrepEvidence(root)
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status, result.stdout + result.stderr).toBe(0)
+    expect(result.stdout).toContain("OK: v22.0 Gate 0 C1/D4 evidence intake is internally consistent.")
+  })
+
+  it("fails when C1 is marked complete but only prep-only evidence exists", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, { c1Gate: "pass", c1Action: "complete", c1Result: "complete" })
+    writePrepEvidence(root)
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("no non-prep C1 submission exists")
+  })
+
+  it("fails when D4 is marked complete but only prep-only evidence exists", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, { d4Gate: "pass", d4Action: "complete" })
+    writePrepEvidence(root)
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("no non-prep D4 submission exists")
+  })
+
+  it("passes when C1 and D4 are complete with non-prep closure evidence", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status, result.stdout + result.stderr).toBe(0)
+  })
+
+  it("passes when canonical Markdown table headers are formatter-aligned", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1ClauseMatrix(root, [
+      "| Clause ID | Source artifact        | Source section / page | Requirement under review | Outcome | Notes / rationale | Required mitigation or fallback |",
+      "| --------- | ---------------------- | --------------------- | ------------------------ | ------- | ----------------- | ------------------------------- |",
+      "| C1-1 | C1-20260612-terms.pdf | section 1 | No raw query text | pass | ok | none |",
+      "| C1-2 | C1-20260612-terms.pdf | section 2 | No identifying telemetry | pass | ok | none |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 | No re-identification | pass | ok | none |",
+      "| C1-4 | C1-20260612-terms.pdf | section 4 | No governance conflict | pass | ok | none |",
+    ])
+    overwriteC1ArtifactInventory(root, [
+      "| Artifact ID | Filename / location    | Artifact type          | Source / owner    | Date received | Used in clause matrix | Notes           |",
+      "| ----------- | ---------------------- | ---------------------- | ----------------- | ------------- | --------------------- | --------------- |",
+      "| C1-A1 | C1-20260612-terms.pdf | contract and API terms | candidate partner | 2026-06-12 | yes | reviewed source |",
+    ])
+    overwriteD4PartnerList(root, [
+      "| Organization / Partner | Partner type          | Primary contact | Contact channel | Priority | Status  | Notes |",
+      "| ---------------------- | --------------------- | --------------- | --------------- | -------- | ------- | ----- |",
+      "| Provider 1 | provider | contact | email | primary | planned | note |",
+      "| Provider 2 | provider | contact | email | primary | planned | note |",
+      "| Provider 3 | provider | contact | email | primary | planned | note |",
+      "| Provider 4 | provider | contact | email | primary | planned | note |",
+      "| Provider 5 | provider | contact | email | primary | planned | note |",
+      "| Frontline 1 | frontline organization | contact | email | primary | planned | note |",
+      "| Frontline 2 | frontline organization | contact | email | primary | planned | note |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status, result.stdout + result.stderr).toBe(0)
+  })
+
+  it("passes when a C1 conditional clause includes rationale and fallback", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1Submission(root, [
+      "Submission ID: C1-20260612",
+      "Submitted by: jer",
+      "Reviewer: jer",
+      "Date: 2026-06-12",
+      "Partner: candidate partner",
+      "Partner artifact bundle location: C1-20260612-terms.pdf",
+      "Final legal recommendation: acceptable_with_conditions",
+      "Decision owner: jer",
+      "Sign-off date: 2026-06-12",
+    ])
+    overwriteC1ClauseMatrix(root, [
+      "| Clause ID | Source artifact | Source section / page | Requirement under review | Outcome | Notes / rationale | Required mitigation or fallback |",
+      "| --------- | --------------- | --------------------- | ------------------------ | ------- | ----------------- | ------------------------------- |",
+      "| C1-1 | C1-20260612-terms.pdf | section 1 | No raw query text | pass | ok | none |",
+      "| C1-2 | C1-20260612-terms.pdf | section 2 | No identifying telemetry | pass | ok | none |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 | No re-identification | acceptable_with_conditions | clause narrowed by addendum | disable integration until addendum signed |",
+      "| C1-4 | C1-20260612-terms.pdf | section 4 | No governance conflict | pass | ok | none |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status, result.stdout + result.stderr).toBe(0)
+  })
+
+  it("fails when a C1 non-pass clause omits rationale or fallback", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1ClauseMatrix(root, [
+      "| Clause ID | Source artifact | Source section / page | Requirement under review | Outcome | Notes / rationale | Required mitigation or fallback |",
+      "| --------- | --------------- | --------------------- | ------------------------ | ------- | ----------------- | ------------------------------- |",
+      "| C1-1 | C1-20260612-terms.pdf | section 1 | No raw query text | pass | ok | none |",
+      "| C1-2 | C1-20260612-terms.pdf | section 2 | No identifying telemetry | pass | ok | none |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 | No re-identification | fail |  |  |",
+      "| C1-4 | C1-20260612-terms.pdf | section 4 | No governance conflict | pass | ok | none |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("row C1-3 must include notes / rationale for non-pass outcomes")
+    expect(result.stdout).toContain("row C1-3 must include required mitigation or fallback for non-pass outcomes")
+  })
+
+  it("fails when the C1 clause matrix does not use the canonical header", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1ClauseMatrix(root, [
+      "| Clause ID | Source artifact | Source section / page | Outcome |",
+      "| --------- | --------------- | --------------------- | ------- |",
+      "| C1-1 | C1-20260612-terms.pdf | section 1 | pass |",
+      "| C1-2 | C1-20260612-terms.pdf | section 2 | pass |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 | pass |",
+      "| C1-4 | C1-20260612-terms.pdf | section 4 | pass |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("canonical C1 clause matrix header")
+  })
+
+  it("fails when the C1 clause matrix repeats a required clause row", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1ClauseMatrix(root, [
+      "| Clause ID | Source artifact | Source section / page | Requirement under review | Outcome | Notes / rationale | Required mitigation or fallback |",
+      "| --------- | --------------- | --------------------- | ------------------------ | ------- | ----------------- | ------------------------------- |",
+      "| C1-1 | C1-20260612-terms.pdf | section 1 | No raw query text | pass | ok | none |",
+      "| C1-2 | C1-20260612-terms.pdf | section 2 | No identifying telemetry | pass | ok | none |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 | No re-identification | pass | ok | none |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 addendum | No re-identification | pass | ok | none |",
+      "| C1-4 | C1-20260612-terms.pdf | section 4 | No governance conflict | pass | ok | none |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("must include exactly one row for C1-3; found 2")
+  })
+
+  it("fails when C1 closure evidence is missing the artifact inventory", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    rmSync(
+      path.join(
+        root,
+        "docs",
+        "implementation",
+        "v22-0-evidence",
+        "c1-partner-terms",
+        "C1-20260612-artifact-inventory.md"
+      ),
+      { force: true }
+    )
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("C1 artifact inventory not found")
+  })
+
+  it("fails when C1 matrix source artifacts are absent from the inventory", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1ArtifactInventory(root, [
+      "| Artifact ID | Filename / location | Artifact type | Source / owner | Date received | Used in clause matrix | Notes |",
+      "| ----------- | ------------------- | ------------- | -------------- | ------------- | --------------------- | ----- |",
+      "| C1-A2 | C1-20260612-addendum.pdf | addendum | candidate partner | 2026-06-12 | yes | reviewed source |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("source artifact 'C1-20260612-terms.pdf'")
+    expect(result.stdout).toContain("must appear as an Artifact ID or Filename / location")
+  })
+
+  it("fails when the C1 submission ID does not match the filename", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1Submission(root, [
+      "Submission ID: C1-20260613",
+      "Submitted by: jer",
+      "Reviewer: jer",
+      "Date: 2026-06-12",
+      "Partner: candidate partner",
+      "Partner artifact bundle location: C1-20260612-terms.pdf",
+      "Final legal recommendation: acceptable",
+      "Decision owner: jer",
+      "Sign-off date: 2026-06-12",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("Submission ID 'C1-20260613'")
+    expect(result.stdout).toContain("filename-derived ID 'C1-20260612'")
+  })
+
+  it("fails when C1 submission dates are not YYYY-MM-DD", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteC1Submission(root, [
+      "Submission ID: C1-20260612",
+      "Submitted by: jer",
+      "Reviewer: jer",
+      "Date: June 12, 2026",
+      "Partner: candidate partner",
+      "Partner artifact bundle location: C1-20260612-terms.pdf",
+      "Final legal recommendation: acceptable",
+      "Decision owner: jer",
+      "Sign-off date: 06/12/2026",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("'Date' value in YYYY-MM-DD format")
+    expect(result.stdout).toContain("'Sign-off date' value in YYYY-MM-DD format")
+  })
+
+  it("fails when D4 submission counts are not positive integers", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4Submission(root, [
+      "Submission ID: D4-20260612",
+      "Submitted by: jer",
+      "Date: 2026-06-12",
+      "Outreach owner: jer",
+      "Number of dated contact attempts recorded: many",
+      "Number of partners targeted: 0",
+      "Number of organizations targeted: two",
+      "Is D4 auditable from the attached artifacts? yes",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("positive integer 'Number of dated contact attempts recorded'")
+    expect(result.stdout).toContain("positive integer 'Number of partners targeted'")
+    expect(result.stdout).toContain("positive integer 'Number of organizations targeted'")
+  })
+
+  it("fails when the D4 submission ID does not match the filename", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4Submission(root, [
+      "Submission ID: D4-20260613",
+      "Submitted by: jer",
+      "Date: 2026-06-12",
+      "Outreach owner: jer",
+      "Number of dated contact attempts recorded: 1",
+      "Number of partners targeted: 5",
+      "Number of organizations targeted: 2",
+      "Is D4 auditable from the attached artifacts? yes",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("Submission ID 'D4-20260613'")
+    expect(result.stdout).toContain("filename-derived ID 'D4-20260612'")
+  })
+
+  it("fails when D4 submitted counts do not match attached artifacts", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4Submission(root, [
+      "Submission ID: D4-20260612",
+      "Submitted by: jer",
+      "Date: 2026-06-12",
+      "Outreach owner: jer",
+      "Number of dated contact attempts recorded: 2",
+      "Number of partners targeted: 6",
+      "Number of organizations targeted: 3",
+      "Is D4 auditable from the attached artifacts? yes",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("must match outreach log execution rows (1)")
+    expect(result.stdout).toContain("must match provider rows in the partner list (5)")
+    expect(result.stdout).toContain("must match frontline organization rows in the partner list (2)")
+  })
+
+  it("fails when D4 closure evidence is missing the artifact inventory", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    rmSync(
+      path.join(
+        root,
+        "docs",
+        "implementation",
+        "v22-0-evidence",
+        "d4-partner-ops",
+        "D4-20260612-artifact-inventory.md"
+      ),
+      { force: true }
+    )
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("D4 artifact inventory not found")
+  })
+
+  it("fails when D4 outreach source artifacts are absent from the inventory", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4ArtifactInventory(root, [
+      "| Artifact ID | Filename / location | Artifact type | Source / owner | Date captured | Supports outreach-log row | Notes |",
+      "| ----------- | ------------------- | ------------- | -------------- | ------------- | ------------------------- | ----- |",
+      "| D4-A2 | D4-20260612-follow-up.pdf | email export | jer | 2026-06-12 | yes | different source |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("source_artifact 'D4-20260612-email.pdf'")
+    expect(result.stdout).toContain("must appear as an Artifact ID or Filename / location")
+  })
+
+  it("fails when D4 partner list does not use the canonical header", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4PartnerList(root, [
+      "| Organization | Type | Status |",
+      "| ------------ | ---- | ------ |",
+      "| Provider 1 | provider | planned |",
+      "| Provider 2 | provider | planned |",
+      "| Provider 3 | provider | planned |",
+      "| Provider 4 | provider | planned |",
+      "| Provider 5 | provider | planned |",
+      "| Frontline 1 | frontline organization | planned |",
+      "| Frontline 2 | frontline organization | planned |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("canonical D4 partner-list header")
+  })
+
+  it("fails when D4 partner list rows use loose partner types", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4PartnerList(root, [
+      "| Organization / Partner | Partner type | Primary contact | Contact channel | Priority | Status | Notes |",
+      "| ---------------------- | ------------ | --------------- | --------------- | -------- | ------ | ----- |",
+      "| Provider 1 | provider candidate | contact | email | primary | planned | note |",
+      "| Provider 2 | provider | contact | email | primary | planned | note |",
+      "| Provider 3 | provider | contact | email | primary | planned | note |",
+      "| Provider 4 | provider | contact | email | primary | planned | note |",
+      "| Provider 5 | provider | contact | email | primary | planned | note |",
+      "| Frontline 1 | frontline organization / provider | contact | email | primary | planned | note |",
+      "| Frontline 2 | frontline organization | contact | email | primary | planned | note |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("partner type other than provider or frontline organization")
+  })
+
+  it("fails when D4 partner list repeats an organization", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4PartnerList(root, [
+      "| Organization / Partner | Partner type | Primary contact | Contact channel | Priority | Status | Notes |",
+      "| ---------------------- | ------------ | --------------- | --------------- | -------- | ------ | ----- |",
+      "| Provider 1 | provider | contact | email | primary | planned | note |",
+      "| Provider 1 | provider | contact | email | primary | planned | note |",
+      "| Provider 2 | provider | contact | email | primary | planned | note |",
+      "| Provider 3 | provider | contact | email | primary | planned | note |",
+      "| Provider 4 | provider | contact | email | primary | planned | note |",
+      "| Provider 5 | provider | contact | email | primary | planned | note |",
+      "| Frontline 1 | frontline organization | contact | email | primary | planned | note |",
+      "| Frontline 2 | frontline organization | contact | email | primary | planned | note |",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("duplicate organization / partner row")
+  })
+
+  it("fails when D4 outreach log does not use the canonical header", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4OutreachLog(root, ["date,organization,owner,outcome", "2026-06-12,Provider 1,jer,sent"])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("canonical D4 outreach CSV header")
+  })
+
+  it("fails when D4 outreach log dates are not YYYY-MM-DD", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4OutreachLog(root, [
+      "date,organization_or_partner,contact_name,contact_role,channel,owner,attempt_number,outcome,next_step,source_artifact",
+      "06/12/2026,Provider 1,Contact,Role,email,jer,1,sent,follow up,D4-20260612-email.pdf",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("non-YYYY-MM-DD date")
+  })
+
+  it("fails when D4 outreach log rows omit attempt number or source artifact", () => {
+    const root = createFixtureRoot()
+    writeBaseDocs(root, {
+      c1Gate: "pass",
+      c1Action: "complete",
+      c1Result: "complete",
+      d4Gate: "pass",
+      d4Action: "complete",
+    })
+    writeCompleteEvidence(root)
+    overwriteD4OutreachLog(root, [
+      "date,organization_or_partner,contact_name,contact_role,channel,owner,attempt_number,outcome,next_step,source_artifact",
+      "2026-06-12,Provider 1,Contact,Role,email,jer,0,sent,follow up,",
+    ])
+
+    const result = runEvidenceCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("missing or non-positive attempt_number")
+    expect(result.stdout).toContain("missing source_artifact traceability")
+  })
+
+  it("is wired into the Gate 0 release guard", () => {
+    const result = spawnSync("bash", [path.join(process.cwd(), "scripts/check-v22-gate0-exit.sh")], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("OK: v22.0 Gate 0 C1/D4 evidence intake is internally consistent.")
+    expect(result.stdout).toContain("BLOCKED: v22.0 Gate 0 decision is 'NO-GO'")
+  })
+})

--- a/tests/scripts/check-v22-gate0-exit.test.ts
+++ b/tests/scripts/check-v22-gate0-exit.test.ts
@@ -1,0 +1,247 @@
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+const scriptPath = path.join(process.cwd(), "scripts/check-v22-gate0-exit.sh")
+
+const tempRoots: string[] = []
+
+function createFixtureRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), "careconnect-gate0-exit-"))
+  tempRoots.push(root)
+
+  mkdirSync(path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms"), {
+    recursive: true,
+  })
+  mkdirSync(path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops"), {
+    recursive: true,
+  })
+
+  return root
+}
+
+function writeChecklist(
+  root: string,
+  options: {
+    decision: "GO" | "NO-GO"
+    g03?: "pass" | "pending" | "fail"
+    g08?: "pass" | "pending" | "fail"
+    blockingChecks?: string
+  }
+) {
+  const g03 = options.g03 ?? "pending"
+  const g08 = options.g08 ?? "pending"
+  const blockingChecks = options.blockingChecks ?? "G0-3, G0-8"
+
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-gate-0-exit-checklist.md"),
+    [
+      "| Check ID | Requirement | Current Status (`pass` \\| `fail` \\| `pending`) | Evidence | Notes |",
+      "| -------- | ----------- | ------------------------------------------------ | -------- | ----- |",
+      "| G0-1 | Step 1 approvals D1-D7 locked | pass | approvals | note |",
+      "| G0-2 | Baseline execution recorded | pass | baseline | note |",
+      `| G0-3 | C1 legal clause review complete | ${g03} | C1 | note |`,
+      "| G0-4 | C2 retention mapping approved | pass | C2 | note |",
+      "| G0-5 | C3 activation guard in force | pass | C3 | note |",
+      "| G0-6 | External claim revalidation closed | pass | claims | note |",
+      "| G0-7 | Threat model critical findings resolved | pass | threat model | note |",
+      `| G0-8 | D4 partner ops execution evidence attached | ${g08} | D4 | note |`,
+      "",
+      "| Field | Value |",
+      "| ----- | ----- |",
+      `| Gate 0 Exit Decision | **${options.decision}** |`,
+      `| Blocking Checks | ${blockingChecks} |`,
+    ].join("\n")
+  )
+}
+
+function writeTracker(
+  root: string,
+  options: {
+    ua1?: "pending" | "in_progress" | "complete"
+    ua3?: "pending" | "in_progress" | "complete"
+    c1Result?: "pending" | "complete"
+  } = {}
+) {
+  const ua1 = options.ua1 ?? "pending"
+  const ua3 = options.ua3 ?? "pending"
+  const c1Result = options.c1Result ?? "pending"
+
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-gate-0-user-action-tracker.md"),
+    [
+      "| Action ID | Gate Check | Owner | Required Evidence | Current Status (`pending` \\| `in_progress` \\| `complete`) | Due Date | Last Update | Blocking If Missing (`yes` \\| `no`) | Notes |",
+      "| --------- | ---------- | ----- | ----------------- | --------------------------------------------------------- | -------- | ----------- | ----------------------------------- | ----- |",
+      `| UA-1 | G0-3 (C1 legal clause review) | jer | C1 evidence | ${ua1} | 2026-03-21 | 2026-06-12 | yes | note |`,
+      `| UA-3 | G0-8 (D4 partner ops execution evidence) | jer | D4 evidence | ${ua3} | 2026-03-21 | 2026-06-12 | yes | note |`,
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(root, "docs", "implementation", "v22-0-control-c1-legal-review.md"),
+    ["# C1 Control", "", "## Decision", "", `- Result: \`${c1Result}\``].join("\n")
+  )
+}
+
+function writeCompleteEvidence(root: string) {
+  const c1Dir = path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms")
+  const d4Dir = path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops")
+
+  writeFileSync(
+    path.join(c1Dir, "C1-20260612-submission.md"),
+    [
+      "Submission ID: C1-20260612",
+      "Submitted by: jer",
+      "Reviewer: jer",
+      "Date: 2026-06-12",
+      "Partner: candidate partner",
+      "Partner artifact bundle location: C1-20260612-terms.pdf",
+      "Final legal recommendation: acceptable",
+      "Decision owner: jer",
+      "Sign-off date: 2026-06-12",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(c1Dir, "C1-20260612-clause-matrix.md"),
+    [
+      "| Clause ID | Source artifact | Source section / page | Requirement under review | Outcome | Notes / rationale | Required mitigation or fallback |",
+      "| --------- | --------------- | --------------------- | ------------------------ | ------- | ----------------- | ------------------------------- |",
+      "| C1-1 | C1-20260612-terms.pdf | section 1 | No raw query text | pass | ok | none |",
+      "| C1-2 | C1-20260612-terms.pdf | section 2 | No identifying telemetry | pass | ok | none |",
+      "| C1-3 | C1-20260612-terms.pdf | section 3 | No re-identification | pass | ok | none |",
+      "| C1-4 | C1-20260612-terms.pdf | section 4 | No governance conflict | pass | ok | none |",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(c1Dir, "C1-20260612-artifact-inventory.md"),
+    [
+      "| Artifact ID | Filename / location | Artifact type | Source / owner | Date received | Used in clause matrix | Notes |",
+      "| ----------- | ------------------- | ------------- | -------------- | ------------- | --------------------- | ----- |",
+      "| C1-A1 | C1-20260612-terms.pdf | contract and API terms | candidate partner | 2026-06-12 | yes | reviewed source |",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-submission.md"),
+    [
+      "Submission ID: D4-20260612",
+      "Submitted by: jer",
+      "Date: 2026-06-12",
+      "Outreach owner: jer",
+      "Number of dated contact attempts recorded: 1",
+      "Number of partners targeted: 5",
+      "Number of organizations targeted: 2",
+      "Is D4 auditable from the attached artifacts? yes",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-partner-list.md"),
+    [
+      "| Organization / Partner | Partner type | Primary contact | Contact channel | Priority | Status | Notes |",
+      "| ---------------------- | ------------ | --------------- | --------------- | -------- | ------ | ----- |",
+      "| Provider 1 | provider | contact | email | primary | planned | note |",
+      "| Provider 2 | provider | contact | email | primary | planned | note |",
+      "| Provider 3 | provider | contact | email | primary | planned | note |",
+      "| Provider 4 | provider | contact | email | primary | planned | note |",
+      "| Provider 5 | provider | contact | email | primary | planned | note |",
+      "| Frontline 1 | frontline organization | contact | email | primary | planned | note |",
+      "| Frontline 2 | frontline organization | contact | email | primary | planned | note |",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-outreach-log.csv"),
+    [
+      "date,organization_or_partner,contact_name,contact_role,channel,owner,attempt_number,outcome,next_step,source_artifact",
+      "2026-06-12,Provider 1,Contact,Role,email,jer,1,sent,follow up,D4-20260612-email.pdf",
+    ].join("\n")
+  )
+
+  writeFileSync(
+    path.join(d4Dir, "D4-20260612-artifact-inventory.md"),
+    [
+      "| Artifact ID | Filename / location | Artifact type | Source / owner | Date captured | Supports outreach-log row | Notes |",
+      "| ----------- | ------------------- | ------------- | -------------- | ------------- | ------------------------- | ----- |",
+      "| D4-A1 | D4-20260612-email.pdf | email export | jer | 2026-06-12 | yes | outreach source |",
+    ].join("\n")
+  )
+}
+
+function runGateCheck(root: string) {
+  return spawnSync("bash", [scriptPath], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      GATE0_CHECKLIST_PATH: path.join(root, "docs", "implementation", "v22-0-gate-0-exit-checklist.md"),
+      GATE0_TRACKER_PATH: path.join(root, "docs", "implementation", "v22-0-gate-0-user-action-tracker.md"),
+      GATE0_C1_CONTROL_PATH: path.join(root, "docs", "implementation", "v22-0-control-c1-legal-review.md"),
+      GATE0_C1_EVIDENCE_DIR: path.join(root, "docs", "implementation", "v22-0-evidence", "c1-partner-terms"),
+      GATE0_D4_EVIDENCE_DIR: path.join(root, "docs", "implementation", "v22-0-evidence", "d4-partner-ops"),
+    },
+    encoding: "utf8",
+  })
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+describe("check-v22-gate0-exit", () => {
+  it("blocks current NO-GO state when blocking checks match non-pass statuses", () => {
+    const root = createFixtureRoot()
+    writeChecklist(root, { decision: "NO-GO" })
+    writeTracker(root)
+
+    const result = runGateCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("BLOCKED: v22.0 Gate 0 decision is 'NO-GO'")
+    expect(result.stdout).toContain("Blocking checks: G0-3, G0-8")
+    expect(result.stdout).not.toContain("does not match required-check statuses")
+  })
+
+  it("reports stale NO-GO blocking checks", () => {
+    const root = createFixtureRoot()
+    writeChecklist(root, { decision: "NO-GO", blockingChecks: "G0-3" })
+    writeTracker(root)
+
+    const result = runGateCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("ERROR: Gate 0 Blocking Checks row does not match required-check statuses.")
+    expect(result.stdout).toContain("Expected blocking checks: G0-3,G0-8")
+    expect(result.stdout).toContain("Actual blocking checks: G0-3")
+  })
+
+  it("blocks GO when any required check is still non-pass", () => {
+    const root = createFixtureRoot()
+    writeChecklist(root, { decision: "GO", g03: "pass", g08: "pending", blockingChecks: "G0-8" })
+    writeTracker(root, { ua1: "complete", ua3: "pending", c1Result: "complete" })
+    writeCompleteEvidence(root)
+
+    const result = runGateCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("BLOCKED: Gate 0 decision is GO but required checks are not all pass.")
+    expect(result.stdout).toContain("G0-8:PENDING")
+  })
+
+  it("passes GO only when all required checks pass and evidence is structurally complete", () => {
+    const root = createFixtureRoot()
+    writeChecklist(root, { decision: "GO", g03: "pass", g08: "pass", blockingChecks: "" })
+    writeTracker(root, { ua1: "complete", ua3: "complete", c1Result: "complete" })
+    writeCompleteEvidence(root)
+
+    const result = runGateCheck(root)
+
+    expect(result.status, result.stdout + result.stderr).toBe(0)
+    expect(result.stdout).toContain("OK: v22.0 Gate 0 decision is GO and all required checks are pass.")
+  })
+})

--- a/tests/scripts/check-v22-threat-model.test.ts
+++ b/tests/scripts/check-v22-threat-model.test.ts
@@ -1,0 +1,153 @@
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+const scriptPath = path.join(process.cwd(), "scripts/check-v22-threat-model.sh")
+
+const tempRoots: string[] = []
+
+function createFixtureRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), "careconnect-threat-model-"))
+  tempRoots.push(root)
+  return root
+}
+
+function writeThreatModel(
+  root: string,
+  options: {
+    criticalVerified?: "yes" | "no"
+    criticalOutcome?: "GO" | "NO-GO"
+    highOwner?: string
+    highDueDate?: string
+    highPlan?: string
+    highOutcome?: "GO" | "NO-GO"
+    signoffLine?: string
+    signoffOutcome?: "GO" | "NO-GO"
+  } = {}
+) {
+  const criticalVerified = options.criticalVerified
+  const criticalOutcome = options.criticalOutcome ?? "GO"
+  const highOwner = options.highOwner ?? "Engineering"
+  const highDueDate = options.highDueDate ?? "2026-03-21"
+  const highPlan = options.highPlan ?? "Minimize payload fields and keep identifiers non-personal"
+  const highOutcome = options.highOutcome ?? "GO"
+  const signoffLine = options.signoffLine ?? "- Security/governance owner review: `jer` (2026-03-09)"
+  const signoffOutcome = options.signoffOutcome ?? "GO"
+
+  const mitigationRows = [
+    "| Finding ID | Severity | Mitigation Plan | Owner | Due Date | Verification Method | Verified |",
+    "| ---------- | -------- | --------------- | ----- | -------- | ------------------- | -------- |",
+    `| F1 | high | ${highPlan} | ${highOwner} | ${highDueDate} | Schema + payload inspection | no |`,
+    "| F2 | medium | Define local corruption recovery steps | Engineering | 2026-03-21 | Dry-run execution | no |",
+  ]
+
+  if (criticalVerified) {
+    mitigationRows.push(
+      `| F9 | critical | Resolve critical local-data issue | Engineering | 2026-03-21 | Security review | ${criticalVerified} |`
+    )
+  }
+
+  writeFileSync(
+    path.join(root, "threat-model.md"),
+    [
+      "# Threat Model",
+      "",
+      "## Mitigation Tracking",
+      "",
+      ...mitigationRows,
+      "",
+      "## 2026-06-12 Mitigation Evidence Audit",
+      "",
+      "| Finding ID | Evidence Inspected | Current Result |",
+      "| ---------- | ------------------ | -------------- |",
+      "| F1 | `lib/schemas/privacy-guards.ts` | Partially mitigated; Verified stays `no`. |",
+      "",
+      "## Sign-Off",
+      "",
+      signoffLine,
+      "",
+      "## Gate 0 Security Outcome",
+      "",
+      "| Criterion | Status |",
+      "| --------- | ------ |",
+      `| Critical findings resolved | ${criticalOutcome} |`,
+      `| High findings have owners and mitigation plans | ${highOutcome} |`,
+      `| Threat model signed by security/governance owner | ${signoffOutcome} |`,
+    ].join("\n")
+  )
+}
+
+function runThreatModelCheck(root: string) {
+  return spawnSync("bash", [scriptPath], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      V22_THREAT_MODEL_PATH: path.join(root, "threat-model.md"),
+    },
+    encoding: "utf8",
+  })
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+describe("check-v22-threat-model", () => {
+  it("passes when high findings are unverified but have owners, due dates, and mitigation plans", () => {
+    const root = createFixtureRoot()
+    writeThreatModel(root)
+
+    const result = runThreatModelCheck(root)
+
+    expect(result.status, result.stdout + result.stderr).toBe(0)
+    expect(result.stdout).toContain("OK: v22.0 threat-model Gate 0 security outcome is internally consistent.")
+  })
+
+  it("fails unresolved critical findings", () => {
+    const root = createFixtureRoot()
+    writeThreatModel(root, { criticalVerified: "no" })
+
+    const result = runThreatModelCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("Unresolved critical findings block Gate 0 security outcome: F9")
+  })
+
+  it("fails high findings without complete mitigation ownership metadata", () => {
+    const root = createFixtureRoot()
+    writeThreatModel(root, { highOwner: "pending", highDueDate: "TBD", highPlan: "" })
+
+    const result = runThreatModelCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("F1 must include a mitigation plan")
+    expect(result.stdout).toContain("F1 must include an owner")
+    expect(result.stdout).toContain("F1 must include a due date")
+    expect(result.stdout).toContain("High findings are missing owner, due date, or mitigation plan: F1")
+  })
+
+  it("fails when the Gate 0 outcome contradicts the mitigation matrix", () => {
+    const root = createFixtureRoot()
+    writeThreatModel(root, { criticalOutcome: "NO-GO", highOutcome: "NO-GO" })
+
+    const result = runThreatModelCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("Critical findings resolved must be GO")
+    expect(result.stdout).toContain("High findings have owners and mitigation plans must be GO")
+  })
+
+  it("fails a GO sign-off outcome without a concrete sign-off line", () => {
+    const root = createFixtureRoot()
+    writeThreatModel(root, { signoffLine: "- Security/governance owner review: pending" })
+
+    const result = runThreatModelCheck(root)
+
+    expect(result.status).toBe(1)
+    expect(result.stdout).toContain("sign-off line is missing or placeholder")
+  })
+})

--- a/tests/unit/documentation-hygiene.test.ts
+++ b/tests/unit/documentation-hygiene.test.ts
@@ -218,6 +218,42 @@ describe("documentation hygiene", () => {
     }
   })
 
+  it("keeps C2 retention evidence aligned with its completed Gate 0 status", () => {
+    const gateChecklist = readDoc("docs/implementation/v22-0-gate-0-exit-checklist.md")
+    const c2Readme = readDoc("docs/implementation/v22-0-evidence/c2-retention/README.md")
+    const c2Submission = readDoc("docs/implementation/v22-0-evidence/c2-retention/C2-20260329.md")
+
+    expect(gateChecklist).toContain("G0-4")
+    expect(gateChecklist).toContain("C2 retention mapping approved")
+    expect(gateChecklist).toContain("Policy approved and dated verification evidence attached")
+
+    expect(c2Readme).toContain("Attached human-supplied artifacts")
+    expect(c2Readme).toContain("Dated read-only verification evidence")
+    expect(c2Readme).not.toContain("Human-supplied artifacts still required")
+
+    expect(c2Submission).toContain("Verification evidence:")
+    expect(c2Submission).toContain("- Status: complete")
+    expect(c2Submission).toContain("Observed result:")
+    expect(c2Submission).not.toContain("verification_evidence: pending dated read-only query output")
+  })
+
+  it("keeps baseline execution evidence distinct from pending formal sign-off", () => {
+    const gateChecklist = readDoc("docs/implementation/v22-0-gate-0-exit-checklist.md")
+    const baselineReport = readDoc("docs/implementation/v22-0-phase-0-baseline-report-2026-03-09.md")
+
+    expect(gateChecklist).toContain("Baseline M1/M3 execution completed and recorded")
+    expect(gateChecklist).toContain("Values are `NULL` due zero denominator in baseline window")
+
+    expect(baselineReport).toContain("| M1")
+    expect(baselineReport).toContain("| M3")
+    expect(baselineReport).toContain("Executed at (UTC)")
+    expect(baselineReport).toContain("Product owner: `pending`")
+    expect(baselineReport).toContain("Governance owner: `pending`")
+    expect(baselineReport).toContain("M1/M3 execution evidence is recorded above")
+    expect(baselineReport).toContain("sign-off fields remain pending and are not used as Gate 0 closure evidence")
+    expect(baselineReport).not.toContain("ready for value entry once database execution context is available")
+  })
+
   it("keeps public deploy docs free of live host commands", () => {
     const readme = readDoc("README.md")
     const productionChecklist = readDoc("docs/deployment/production-checklist.md")

--- a/tests/unit/lib/offline/sync.test.ts
+++ b/tests/unit/lib/offline/sync.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { syncOfflineData } from "@/lib/offline/sync"
 import * as db from "@/lib/offline/db"
 import { resetServiceDataCache } from "@/lib/search/data"
+import { logger } from "@/lib/logger"
 
 // Mock DB
 vi.mock("@/lib/offline/db", () => ({
@@ -16,6 +17,13 @@ vi.mock("@/lib/search/data", () => ({
   resetServiceDataCache: vi.fn(),
 }))
 
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
 // Mock Fetch
 const mockFetch = vi.fn()
 global.fetch = mockFetch
@@ -26,7 +34,9 @@ vi.spyOn(console, "error").mockImplementation(() => {})
 
 describe("Offline Sync", () => {
   beforeEach(() => {
+    vi.unstubAllGlobals()
     vi.clearAllMocks()
+    mockFetch.mockReset()
     vi.mocked(db.getMeta).mockImplementation(async (key: string) => {
       if (key === "lastSync") return undefined
       if (key === "version") return undefined
@@ -135,6 +145,44 @@ describe("Offline Sync", () => {
     const result = await syncOfflineData()
 
     expect(result.status).toBe("error")
+    expect(result.error).toEqual({ errorType: "Error" })
     expect(mockFetch).toHaveBeenCalledTimes(3) // Initial + 2 retries
+    expect(logger.warn).toHaveBeenCalledWith("Offline sync error", {
+      attempt: 3,
+      errorType: "Error",
+    })
+    expect(JSON.stringify(result)).not.toContain("Permanent Failure")
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain("Permanent Failure")
+  })
+
+  it("should return sanitized HTTP failure metadata after max retries", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "backend included internal details",
+    })
+
+    vi.stubGlobal(
+      "setTimeout",
+      vi.fn((cb) => cb())
+    )
+
+    const result = await syncOfflineData()
+
+    expect(result).toEqual({
+      status: "error",
+      error: {
+        errorType: "HttpError",
+        httpStatus: 503,
+      },
+    })
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(logger.warn).toHaveBeenCalledWith("Offline sync error", {
+      attempt: 3,
+      errorType: "HttpError",
+      httpStatus: 503,
+    })
+    expect(JSON.stringify(result)).not.toContain("backend included internal details")
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain("backend included internal details")
   })
 })

--- a/tests/unit/openapi-pilot-events.test.ts
+++ b/tests/unit/openapi-pilot-events.test.ts
@@ -1,0 +1,352 @@
+import { readdirSync, readFileSync } from "fs"
+import { join } from "path"
+import { describe, expect, it } from "vitest"
+
+const openApi = readFileSync(join(process.cwd(), "docs/api/openapi.yaml"), "utf8")
+const pilotRouteRoot = join(process.cwd(), "app/api/v1/pilot")
+
+type ImplementedPilotRoute = {
+  path: string
+  methods: string[]
+}
+
+type ComponentKind = "schemas" | "responses"
+
+function collectRouteFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      return collectRouteFiles(entryPath)
+    }
+
+    return entry.isFile() && entry.name === "route.ts" ? [entryPath] : []
+  })
+}
+
+function routeFileToOpenApiPath(routeFile: string): string {
+  const routeSegments = routeFile
+    .slice(pilotRouteRoot.length + 1)
+    .split(/[\\/]/)
+    .slice(0, -1)
+    .map((segment) => {
+      if (segment.startsWith("[") && segment.endsWith("]")) {
+        return `{${segment.slice(1, -1)}}`
+      }
+
+      return segment
+    })
+
+  return `/pilot/${routeSegments.join("/")}`
+}
+
+function routeFileMethods(routeFile: string): string[] {
+  const source = readFileSync(routeFile, "utf8")
+  const methods: string[] = []
+
+  for (const match of source.matchAll(/\bexport\s+async\s+function\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b/g)) {
+    const method = match[1]
+    if (method) {
+      methods.push(method.toLowerCase())
+    }
+  }
+
+  if (methods.length === 0) {
+    throw new Error(`No exported HTTP methods found in ${routeFile}`)
+  }
+
+  return [...new Set(methods)].sort()
+}
+
+function implementedPilotRoutes(): ImplementedPilotRoute[] {
+  return collectRouteFiles(pilotRouteRoot)
+    .map((routeFile) => ({
+      path: routeFileToOpenApiPath(routeFile),
+      methods: routeFileMethods(routeFile),
+    }))
+    .sort((a, b) => a.path.localeCompare(b.path))
+}
+
+function documentedPilotPaths(): string[] {
+  const paths: string[] = []
+
+  for (const match of openApi.matchAll(/^  (\/pilot\/[^:\n]+):/gm)) {
+    const path = match[1]
+    if (path) {
+      paths.push(path)
+    }
+  }
+
+  return paths.sort()
+}
+
+function documentedPilotMethods(path: string): string[] {
+  const methods: string[] = []
+
+  for (const match of pathSection(path).matchAll(/^    (get|post|put|patch|delete|head|options):$/gm)) {
+    const method = match[1]
+    if (method) {
+      methods.push(method)
+    }
+  }
+
+  return methods.sort()
+}
+
+function componentSection(kind: ComponentKind): string {
+  const componentsStart = openApi.indexOf("\ncomponents:")
+  expect(componentsStart).toBeGreaterThanOrEqual(0)
+
+  const marker = `\n  ${kind}:`
+  const start = openApi.indexOf(marker, componentsStart)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const rest = openApi.slice(start + marker.length)
+  const nextComponentKind = /\n  [A-Za-z][A-Za-z0-9]*:/.exec(rest)
+  const end = nextComponentKind ? start + marker.length + nextComponentKind.index : undefined
+
+  return openApi.slice(start, end)
+}
+
+function componentNames(kind: ComponentKind): string[] {
+  return [...componentSection(kind).matchAll(/\n    ([A-Za-z][A-Za-z0-9]*):/g)]
+    .map(([, name]) => name)
+    .filter((name): name is string => Boolean(name))
+    .sort()
+}
+
+function localComponentRefs(): Array<{ kind: ComponentKind; name: string }> {
+  const refsByKey = new Map<string, { kind: ComponentKind; name: string }>()
+
+  for (const match of openApi.matchAll(/\$ref:\s+"#\/components\/(schemas|responses)\/([A-Za-z][A-Za-z0-9]*)"/g)) {
+    const kind = match[1] as ComponentKind | undefined
+    const name = match[2]
+
+    if (kind && name) {
+      refsByKey.set(`${kind}/${name}`, { kind, name })
+    }
+  }
+
+  return [...refsByKey.values()].sort((a, b) => `${a.kind}/${a.name}`.localeCompare(`${b.kind}/${b.name}`))
+}
+
+function pathSection(path: string): string {
+  const marker = `  ${path}:`
+  const start = openApi.indexOf(marker)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const nextPath = openApi.indexOf("\n  /", start + marker.length)
+  return openApi.slice(start, nextPath === -1 ? undefined : nextPath)
+}
+
+function operationSection(path: string, method: string): string {
+  const section = pathSection(path)
+  const marker = `\n    ${method}:`
+  const start = section.indexOf(marker)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const rest = section.slice(start + marker.length)
+  const nextMethod = /\n    (get|post|put|patch|delete|head|options):/.exec(rest)
+  const end = nextMethod ? start + marker.length + nextMethod.index : undefined
+
+  return section.slice(start, end)
+}
+
+function operationId(path: string, method: string): string {
+  const match = /\n      operationId: ([A-Za-z][A-Za-z0-9]*)\n/.exec(operationSection(path, method))
+  expect(match?.[1]).toBeDefined()
+
+  return match?.[1] ?? ""
+}
+
+function schemaSection(schemaName: string): string {
+  const marker = `    ${schemaName}:`
+  const start = openApi.indexOf(marker)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const rest = openApi.slice(start + marker.length)
+  const nextSchemaMatch = /\n    [A-Za-z0-9]+:/.exec(rest)
+  const end = nextSchemaMatch ? start + marker.length + nextSchemaMatch.index : undefined
+
+  return openApi.slice(start, end)
+}
+
+describe("OpenAPI pilot contract", () => {
+  const pilotRoutes = implementedPilotRoutes()
+  const pilotPaths = pilotRoutes.map(({ path }) => path)
+  const pilotMethods = pilotRoutes.flatMap(({ path, methods }) => methods.map((method) => [method, path] as const))
+  const pilotJsonWriteOperations = pilotMethods.filter(([method]) => method !== "get")
+  const componentsByKind = {
+    responses: componentNames("responses"),
+    schemas: componentNames("schemas"),
+  } satisfies Record<ComponentKind, string[]>
+
+  it.each(localComponentRefs())("resolves local OpenAPI component ref #/components/$kind/$name", ({ kind, name }) => {
+    expect(componentsByKind[kind]).toContain(name)
+  })
+
+  it("documents exactly the implemented pilot route paths", () => {
+    expect(documentedPilotPaths()).toEqual(pilotPaths)
+  })
+
+  it.each(pilotPaths)("documents implemented pilot route %s", (path) => {
+    expect(pathSection(path)).toContain(path)
+  })
+
+  it.each(pilotMethods)("documents implemented pilot method %s %s", (method, path) => {
+    expect(pathSection(path)).toContain(`\n    ${method}:`)
+  })
+
+  it.each(pilotRoutes)("documents exactly the implemented pilot methods for $path", ({ path, methods }) => {
+    expect(documentedPilotMethods(path)).toEqual(methods)
+  })
+
+  it.each(pilotMethods)("documents cookie auth for implemented pilot operation %s %s", (method, path) => {
+    expect(operationSection(path, method)).toContain("\n      security:\n        - cookieAuth: []")
+  })
+
+  it.each(pilotMethods)("documents an operationId for implemented pilot operation %s %s", (method, path) => {
+    expect(operationId(path, method)).toMatch(/^[A-Za-z][A-Za-z0-9]*$/)
+  })
+
+  it("uses unique pilot operationIds", () => {
+    const operationIds = pilotMethods.map(([method, path]) => operationId(path, method))
+
+    expect(new Set(operationIds).size).toBe(operationIds.length)
+  })
+
+  const eventPaths = [
+    "/pilot/events/contact-attempt",
+    "/pilot/events/referral",
+    "/pilot/events/connection",
+    "/pilot/events/service-status",
+    "/pilot/events/data-decay-audit",
+    "/pilot/events/preference-fit",
+  ]
+
+  it.each(eventPaths)("documents supplied-id duplicate responses for %s", (path) => {
+    const section = pathSection(path)
+
+    expect(section).toContain('"200":')
+    expect(section).toContain("Idempotent retry accepted")
+    expect(section).toContain("#/components/schemas/PilotWriteSuccess")
+    expect(section).toContain('"201":')
+  })
+
+  it.each(pilotJsonWriteOperations)("documents JSON request bodies for pilot write operation %s %s", (method, path) => {
+    const section = operationSection(path, method)
+
+    expect(section).toContain("\n      requestBody:")
+    expect(section).toContain("\n          application/json:")
+  })
+
+  it.each(pilotJsonWriteOperations)(
+    "documents unsupported media type responses for pilot write operation %s %s",
+    (method, path) => {
+      const section = operationSection(path, method)
+
+      expect(section).toContain('"415":')
+      expect(section).toContain("request body must be application/json")
+    }
+  )
+
+  const createSchemas = [
+    "PilotContactAttemptCreate",
+    "PilotReferralCreate",
+    "PilotConnectionCreate",
+    "PilotServiceStatusCreate",
+    "PilotDataDecayAuditCreate",
+    "PilotPreferenceFitCreate",
+  ]
+
+  it.each(createSchemas)("documents optional client event id for %s", (schemaName) => {
+    const section = schemaSection(schemaName)
+
+    expect(section).toContain("id:")
+    expect(section).toContain("format: uuid")
+    expect(section).toContain("Optional client-generated event id for idempotent offline retries.")
+  })
+
+  it("documents duplicate retry payload shape", () => {
+    const section = schemaSection("PilotWriteSuccess")
+
+    expect(section).toContain("success:")
+    expect(section).toContain("duplicate:")
+    expect(section).toContain("supplied client event id was already recorded")
+  })
+
+  it("documents pilot update and decision success envelopes", () => {
+    const referralUpdate = pathSection("/pilot/events/referral/{id}")
+    const integrationDecision = pathSection("/pilot/integration-feasibility")
+
+    expect(referralUpdate).toContain("operationId: updatePilotReferralEvent")
+    expect(referralUpdate).toContain('"200":')
+    expect(referralUpdate).toContain("#/components/schemas/PilotWriteSuccess")
+
+    expect(integrationDecision).toContain("operationId: recordIntegrationFeasibilityDecision")
+    expect(integrationDecision).toContain('"201":')
+    expect(integrationDecision).toContain("#/components/schemas/PilotWriteSuccess")
+  })
+
+  it("documents the privacy-safe pilot service scope endpoint", () => {
+    const path = pathSection("/pilot/scope/services")
+    const schema = schemaSection("PilotServiceScopeCreate")
+
+    expect(path).toContain("operationId: upsertPilotServiceScope")
+    expect(path).toContain("#/components/schemas/PilotServiceScopeCreate")
+    expect(path).toContain('"201":')
+    expect(path).not.toContain('"200":')
+
+    expect(schema).toContain("pilot_cycle_id:")
+    expect(schema).toContain("org_id:")
+    expect(schema).toContain("service_id:")
+    expect(schema).toContain("sla_tier:")
+    expect(schema).toContain("enum: [crisis, high_demand, standard]")
+    expect(schema).toContain("Raw query text, client identifiers, and contact fields are not accepted.")
+  })
+
+  it("documents the pilot metrics recompute endpoint", () => {
+    const path = pathSection("/pilot/metrics/recompute")
+    const requestSchema = schemaSection("PilotMetricsRecomputeRequest")
+    const resultSchema = schemaSection("PilotMetricsRecomputeResult")
+
+    expect(path).toContain("operationId: recomputePilotMetrics")
+    expect(path).toContain("#/components/schemas/PilotMetricsRecomputeRequest")
+    expect(path).toContain("#/components/schemas/PilotMetricsRecomputeResult")
+    expect(path).toContain('"200":')
+    expect(path).toContain('"501":')
+
+    expect(requestSchema).toContain("pilot_cycle_id:")
+    expect(requestSchema).toContain("org_id:")
+    expect(requestSchema).toContain("format: uuid")
+    expect(requestSchema).toContain("Raw query text, client identifiers, and contact fields are not accepted.")
+
+    expect(resultSchema).toContain("success:")
+    expect(resultSchema).toContain("calculatedAt:")
+    expect(resultSchema).toContain("snapshotsWritten:")
+    expect(resultSchema).toContain("#/components/schemas/PilotScorecard")
+  })
+
+  it("documents the pilot scorecard response and not-found status", () => {
+    const path = pathSection("/pilot/metrics/scorecard")
+    const responseSchema = schemaSection("PilotScorecardResponse")
+    const gateEvaluationSchema = schemaSection("Gate1ThresholdEvaluation")
+
+    expect(path).toContain("operationId: getPilotScorecard")
+    expect(path).toContain("#/components/schemas/PilotScorecardResponse")
+    expect(path).toContain('"404":')
+    expect(path).toContain("Pilot scorecard not found")
+
+    expect(responseSchema).toContain("scorecard:")
+    expect(responseSchema).toContain("#/components/schemas/PilotScorecard")
+    expect(responseSchema).toContain("gate1Evaluation:")
+    expect(responseSchema).toContain("#/components/schemas/Gate1ThresholdEvaluation")
+
+    expect(gateEvaluationSchema).toContain("failedContactRateReductionPass:")
+    expect(gateEvaluationSchema).toContain("timeToConnectionReductionPass:")
+    expect(gateEvaluationSchema).toContain("freshnessSlaPass:")
+    expect(gateEvaluationSchema).toContain("referralCapturePass:")
+    expect(gateEvaluationSchema).toContain("fatalErrorRatePass:")
+    expect(gateEvaluationSchema).toContain("passedAll:")
+  })
+})


### PR DESCRIPTION
## Summary

- Finish the v22 Gate 0 C1/D4 evidence guards, including dated D4 artifact-inventory requirements and outreach source-artifact validation.
- Checkpoint the already-started autonomous hardening slice: offline privacy/recovery, pilot event retry/idempotency contracts, OpenAPI coverage, readiness input validation, and privacy-key guards.
- Archive the completed v22 autonomous maintenance record, refresh the checkpoint inventory, and align the roadmap so the remaining path is limited to external C1 legal/API evidence and D4 partner-ops execution evidence.
- Keep authorship guidance human-only across agent docs; `CLAUDE.md` and `GEMINI.md` remain relative symlinks to `AGENTS.md`.

## Validation

Latest docs-only maintenance commit uses `[skip ci]` to conserve GitHub Actions free-tier minutes. Local validation on the latest head:

- `npm test` from pre-push hook: 198 files passed; 1599 tests passed; 24 skipped.
- Targeted maintenance tests: `node node_modules/vitest/vitest.mjs run tests/unit/documentation-hygiene.test.ts tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts`.
- Static/sanity checks: targeted Prettier, `tsc --noEmit`, `node --import tsx scripts/check-references.ts`, `git diff --check`, and `bash scripts/check-root-hygiene.sh`.
- Expected Gate 0 result remains `GATE0_EXIT_NONZERO` with blockers `G0-3` and `G0-8`.

Earlier CI on this branch passed validate, actionlint, analyze, static-analysis, unit tests, DB integration, build, and Docker smoke before the docs-only `[skip ci]` maintenance commit.