### PR TITLE
chore: add critical-only notification mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,12 @@ AXIOM_DATASET=careconnect-dev
 # Create incoming webhook at https://slack.com/apps/A0F7XDUAZ-incoming-webhooks
 SLACK_WEBHOOK_URL=
 
+# Notification mode controls
+# normal = send configured operator/user notifications
+# critical_only = suppress non-critical operator alerts and non-emergency user pushes
+OPERATIONAL_NOTIFICATION_MODE=normal
+USER_NOTIFICATION_MODE=normal
+
 # Cron Job Authentication (v18.0 Phase 2)
 # Generate a secure random string: openssl rand -base64 32
 CRON_SECRET=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ version: 2
 # Dependabot Configuration for CareConnect
 # Automatically updates dependencies to keep the project secure and up-to-date
 # See: docs/development/dependency-management.md for handling update PRs
+# Critical-only mode: version-update PRs are paused with
+# open-pull-requests-limit: 0; security updates can still use this config.
 
 updates:
   # npm production dependencies
@@ -29,7 +31,7 @@ updates:
         update-types:
           - "patch"
           - "minor"
-    open-pull-requests-limit: 10 # Increased from 5 to handle grouped updates
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
@@ -63,7 +65,7 @@ updates:
     schedule:
       interval: "monthly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "ci"
     labels:

--- a/.github/workflows/crisis-verification-reminder.yml
+++ b/.github/workflows/crisis-verification-reminder.yml
@@ -1,9 +1,8 @@
 name: Monthly Crisis Service Verification
 
 on:
-  schedule:
-    # Run at 9am ET on the 1st of each month
-    - cron: "0 14 1 * *"
+  # Critical-only mode: manual dispatch only. Emergency/crisis user surfaces
+  # remain active; this workflow only creates operator reminder issues.
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,8 +1,8 @@
 name: Monthly Health Check
 
 on:
-  schedule:
-    - cron: "0 8 1 * *" # 8 AM UTC on the 1st of each month
+  # Critical-only mode: manual dispatch only so URL drift creates a work item
+  # when intentionally requested, not a scheduled operator interruption.
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -2,7 +2,7 @@ name: Production Smoke
 
 on:
   schedule:
-    - cron: "17 */6 * * *"
+    - cron: "17 12 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/quarterly-verification-reminder.yml
+++ b/.github/workflows/quarterly-verification-reminder.yml
@@ -1,9 +1,8 @@
 name: Quarterly General Service Verification
 
 on:
-  schedule:
-    # Run at 9am ET on Jan 1, Apr 1, Jul 1, Oct 1
-    - cron: "0 14 1 1,4,7,10 *"
+  # Critical-only mode: manual dispatch only so verification reminders do not
+  # create scheduled operator issue noise.
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/staleness-check.yml
+++ b/.github/workflows/staleness-check.yml
@@ -1,9 +1,8 @@
 name: Monthly Staleness Check
 
 on:
-  schedule:
-    # Run at 9am ET on the 1st of each month
-    - cron: "0 14 1 * *"
+  # Critical-only mode: manual dispatch only so staleness drift is reviewed
+  # deliberately instead of opening scheduled reminder issues.
   workflow_dispatch:
     inputs:
       dry_run:

--- a/app/api/admin/push/route.ts
+++ b/app/api/admin/push/route.ts
@@ -145,6 +145,15 @@ export async function POST(request: NextRequest) {
     }
 
     const { title, message, url, type, target, filters } = validation.data
+    const notificationType = type || "general"
+
+    if ((env.USER_NOTIFICATION_MODE ?? "normal") === "critical_only" && notificationType !== "emergency") {
+      return createApiError("Notification mode restricted", 403, {
+        code: "notification_mode_restricted",
+        mode: "critical_only",
+        allowedTypes: ["emergency"],
+      })
+    }
 
     if (!env.ONESIGNAL_REST_API_KEY || !env.NEXT_PUBLIC_ONESIGNAL_APP_ID) {
       return createApiError("OneSignal not configured", 500)
@@ -170,7 +179,7 @@ export async function POST(request: NextRequest) {
           ? { included_segments: oneSignalFilters.included_segments }
           : { filters: oneSignalFilters.filters }),
         data: {
-          type: type || "general",
+          type: notificationType,
           url: url || "/",
         },
       }),
@@ -188,7 +197,7 @@ export async function POST(request: NextRequest) {
     const { error: notificationAuditError } = await supabase.from("notification_audit").insert({
       title,
       message,
-      notification_type: type,
+      notification_type: notificationType,
       onesignal_id: result.id,
       sent_by: user.id,
       sent_at: new Date().toISOString(),
@@ -208,7 +217,7 @@ export async function POST(request: NextRequest) {
       record_id: result.id,
       operation: "CREATE",
       performed_by: user.id,
-      metadata: { title, type },
+      metadata: { title, type: notificationType },
     })
     if (auditLogError) {
       auditWarnings.push("audit_logs")
@@ -227,6 +236,7 @@ export async function POST(request: NextRequest) {
         title,
         message,
         target,
+        type: notificationType,
         notification_id: result.id,
         has_filters: !!filters,
       },

--- a/docs/observability/alerting-setup.md
+++ b/docs/observability/alerting-setup.md
@@ -1,6 +1,6 @@
 # Observability And Alerting Notes
 
-**Last Updated:** 2026-06-04
+**Last Updated:** 2026-06-27
 
 CareConnect includes optional observability and alerting hooks so maintainers can detect service degradation without collecting user search queries.
 
@@ -32,6 +32,21 @@ The application can expose or derive these aggregate signals:
 For local development, observability integrations are optional. The app should run without alerting provider credentials.
 
 Use `.env.example` for supported variable names and keep live values in ignored environment files or a password manager.
+
+## Critical-Only Mode
+
+CareConnect supports a reversible critical-only posture for low-interruption
+operation:
+
+1. `OPERATIONAL_NOTIFICATION_MODE=critical_only` suppresses noncritical
+   operational alert notifications while preserving sustained critical outage
+   paths and future security/privacy incidents.
+2. `USER_NOTIFICATION_MODE=critical_only` allows emergency user broadcasts and
+   blocks general or noncritical service-update broadcasts.
+3. Recovery notifications should only send when the original incident produced
+   a critical notification.
+
+Use `normal` for either mode to restore the standard notification behavior.
 
 ## Related Docs
 

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -34,7 +34,7 @@ tags: [planning, roadmap, v22.0, governance]
 - **Stale-data governance**: search now excludes records beyond the 180-day freshness window, freshness badges distinguish expired records, and direct-linked detail pages show an explicit stale-record warning
 - **Freshness policy alignment**: governance and planning docs now treat 180 days as the hard visibility limit, 90 days as a priority-service target, and the v22 90-day window as a review checkpoint rather than a guaranteed build schedule
 - **Workflow runtime hygiene**: active GitHub Actions use Node-24-compatible major versions, and release automation uses `gh release create` instead of the archived release action
-- **GitHub automation hygiene**: bundle analysis, Dependabot review gates, scheduled governance reminders, and finding workflows now run quiet-by-default with sticky comments/issues only when action is required
+- **GitHub automation hygiene**: bundle analysis, Dependabot review gates, scheduled governance reminders, and finding workflows now run quiet-by-default; critical-only mode keeps repo reminders manual unless action is required
 - **URL health governance**: the monthly health check writes an Actions summary, auto-closes its finding issue when the report returns clean, and can use bounded official provider override probes for repeat CI-only false positives without changing curated public URLs
 - **Lint hygiene**: repo-wide ESLint now ignores local MkDocs build output under `site/`, so `npm run lint` remains actionable even when docs artifacts exist locally
 - **Semantic search resilience**: browser embedding-worker failures now fail closed to keyword-only search, and embedding request errors settle cleanly instead of emitting synthetic vectors
@@ -47,7 +47,7 @@ tags: [planning, roadmap, v22.0, governance]
 - **Partner write hardening**: partner-facing service mutation routes now use explicit editable-field allowlists, role-aware service ownership checks, and owner/admin-only delete semantics
 - **Search parity and freshness**: local and server search now align on `location` and `openNow` filters, including empty-query open-now browsing; local and server ranking now share the same scoring engine; offline export fingerprints are stable and successful syncs invalidate the in-memory service cache
 - **Privacy-safe sharing and analytics**: share-target hydration now uses a short-lived first-party cookie, printable cards generate inline QR codes locally, search analytics store only locale + result count, and detail-page analytics distinguish internal views from outbound referrals
-- **Observability**: Axiom metrics, Slack alerting, SLO monitoring, and runbooks are live
+- **Observability**: Axiom metrics, Slack alerting, SLO monitoring, and runbooks are live; `OPERATIONAL_NOTIFICATION_MODE=critical_only` gates interrupting Slack alerts to critical incidents and matching recoveries
 - **Health visibility**: `/api/v1/health` is public and read-only, while `/api/v1/health/probe` is the authenticated uptime-sampling and alert-evaluation path
 - **Proxy auth resilience**: refreshed Supabase session cookies now survive the locale proxy pass and protected-route redirects
 - **DB-authoritative runtime data**: search/detail loading no longer overlays live DB reads with local JSON metadata when Supabase is available

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -31,6 +31,9 @@ export const env = createEnv({
     AXIOM_DATASET: z.string().optional().default("careconnect-dev"),
     // Slack Integration (v18.0 Phase 2)
     SLACK_WEBHOOK_URL: z.string().url().optional(),
+    // Critical-only notification controls
+    OPERATIONAL_NOTIFICATION_MODE: z.enum(["normal", "critical_only"]).optional().default("normal"),
+    USER_NOTIFICATION_MODE: z.enum(["normal", "critical_only"]).optional().default("normal"),
     // Cron Job Authentication (v18.0 Phase 2)
     CRON_SECRET: z.string().optional(),
     // Health probe authentication (v20.1)

--- a/lib/integrations/slack.ts
+++ b/lib/integrations/slack.ts
@@ -15,6 +15,14 @@
 import { logger } from "@/lib/logger"
 import { CircuitState } from "@/lib/resilience/circuit-breaker"
 import { REPOSITORY_URL, getPublicAppUrl } from "@/lib/brand"
+import {
+  getOperationalNotificationMode,
+  markOpsIncidentNotified,
+  resolveOpsIncident,
+  shouldSendOpsNotification,
+  wasOpsIncidentNotified,
+  type OpsNotificationPolicy,
+} from "@/lib/observability/ops-notification-policy"
 
 /**
  * Slack message block types
@@ -86,6 +94,39 @@ function getSlackWebhookUrl(): string | null {
 
 function getRepoDocUrl(path: string): string {
   return `${REPOSITORY_URL}/blob/main/${path}`
+}
+
+async function sendPolicyGatedSlackMessage(policy: OpsNotificationPolicy, message: SlackMessage): Promise<boolean> {
+  if (!shouldSendOpsNotification(policy)) {
+    logger.info("Ops Slack alert suppressed by notification mode", {
+      component: "slack",
+      tier: policy.tier,
+      incidentKey: policy.incidentKey,
+      isRecovery: Boolean(policy.isRecovery),
+    })
+    return false
+  }
+
+  const mode = policy.mode ?? getOperationalNotificationMode()
+  if (mode === "critical_only" && policy.isRecovery && !(await wasOpsIncidentNotified(policy.incidentKey))) {
+    logger.info("Ops Slack recovery suppressed because the incident did not page", {
+      component: "slack",
+      incidentKey: policy.incidentKey,
+    })
+    return false
+  }
+
+  const sent = await sendSlackMessage(message)
+  if (!sent) {
+    return false
+  }
+
+  if (policy.isRecovery) {
+    await resolveOpsIncident(policy.incidentKey)
+  } else {
+    await markOpsIncidentNotified(policy)
+  }
+  return true
 }
 
 /**
@@ -252,6 +293,31 @@ function formatCircuitBreakerMessage(event: CircuitBreakerEvent): SlackMessage {
  * @param event - Circuit breaker event data
  */
 export async function sendCircuitBreakerAlert(event: CircuitBreakerEvent): Promise<void> {
+  const policy: OpsNotificationPolicy = {
+    tier: event.state === CircuitState.OPEN ? "P2" : "P3",
+    incidentKey: "circuit-breaker:database",
+    isRecovery: event.state === CircuitState.CLOSED,
+    channel: "slack",
+  }
+
+  if (!shouldSendOpsNotification(policy)) {
+    logger.info("Circuit breaker alert suppressed by notification mode", {
+      component: "slack",
+      state: event.state,
+      tier: policy.tier,
+    })
+    return
+  }
+
+  const mode = policy.mode ?? getOperationalNotificationMode()
+  if (mode === "critical_only" && policy.isRecovery && !(await wasOpsIncidentNotified(policy.incidentKey))) {
+    logger.info("Circuit breaker recovery suppressed because the incident did not page", {
+      component: "slack",
+      state: event.state,
+    })
+    return
+  }
+
   // Import throttling dynamically to avoid circular dependencies
   const { shouldSendAlert } = await import("@/lib/observability/alert-throttle")
 
@@ -269,7 +335,15 @@ export async function sendCircuitBreakerAlert(event: CircuitBreakerEvent): Promi
 
   // Send alert
   const message = formatCircuitBreakerMessage(event)
-  await sendSlackMessage(message)
+  const sent = await sendSlackMessage(message)
+  if (!sent) {
+    return
+  }
+  if (policy.isRecovery) {
+    await resolveOpsIncident(policy.incidentKey)
+  } else {
+    await markOpsIncidentNotified(policy)
+  }
 }
 
 /**
@@ -279,6 +353,21 @@ export async function sendCircuitBreakerAlert(event: CircuitBreakerEvent): Promi
  * @param threshold - Threshold that was exceeded
  */
 export async function sendHighErrorRateAlert(errorRate: number, threshold: number): Promise<void> {
+  const policy: OpsNotificationPolicy = {
+    tier: "P2",
+    incidentKey: "slo:high-error-rate",
+    channel: "slack",
+  }
+  if (!shouldSendOpsNotification(policy)) {
+    logger.info("High error rate alert suppressed by notification mode", {
+      component: "slack",
+      errorRate,
+      threshold,
+      tier: policy.tier,
+    })
+    return
+  }
+
   // Import throttling dynamically to avoid circular dependencies
   const { shouldSendAlert } = await import("@/lib/observability/alert-throttle")
 
@@ -341,7 +430,7 @@ export async function sendHighErrorRateAlert(errorRate: number, threshold: numbe
     ],
   }
 
-  await sendSlackMessage(message)
+  await sendPolicyGatedSlackMessage(policy, message)
 }
 
 /**
@@ -447,6 +536,21 @@ function formatSLOViolationMessage(event: SLOViolationEvent): SlackMessage {
  * @param event - SLO violation event data
  */
 export async function sendSLOViolationAlert(event: SLOViolationEvent): Promise<void> {
+  const policy: OpsNotificationPolicy = {
+    tier: event.type === "uptime" && event.severity === "critical" ? "P1" : "P2",
+    incidentKey: `slo:${event.type}`,
+    channel: "slack",
+  }
+  if (!shouldSendOpsNotification(policy)) {
+    logger.info("SLO violation alert suppressed by notification mode", {
+      component: "slack",
+      type: event.type,
+      severity: event.severity,
+      tier: policy.tier,
+    })
+    return
+  }
+
   // Import throttling dynamically to avoid circular dependencies
   const { shouldSendAlert } = await import("@/lib/observability/alert-throttle")
 
@@ -470,5 +574,5 @@ export async function sendSLOViolationAlert(event: SLOViolationEvent): Promise<v
 
   // Send alert
   const message = formatSLOViolationMessage(event)
-  await sendSlackMessage(message)
+  await sendPolicyGatedSlackMessage(policy, message)
 }

--- a/lib/observability/ops-notification-policy.ts
+++ b/lib/observability/ops-notification-policy.ts
@@ -1,0 +1,136 @@
+import { createClient } from "@supabase/supabase-js"
+import { logger } from "@/lib/logger"
+
+export type NotificationTier = "P0" | "P1" | "P2" | "P3"
+export type NotificationMode = "normal" | "critical_only"
+
+export interface OpsNotificationPolicy {
+  tier: NotificationTier
+  incidentKey: string
+  isRecovery?: boolean
+  channel?: "slack" | "push" | "email"
+  mode?: NotificationMode
+}
+
+const criticalTiers = new Set<NotificationTier>(["P0", "P1"])
+const inMemoryNotifiedIncidents = new Set<string>()
+
+function normalizeNotificationMode(value: string | undefined): NotificationMode {
+  return value === "critical_only" ? "critical_only" : "normal"
+}
+
+export function getOperationalNotificationMode(): NotificationMode {
+  return normalizeNotificationMode(process.env.OPERATIONAL_NOTIFICATION_MODE)
+}
+
+export function getUserNotificationMode(): NotificationMode {
+  return normalizeNotificationMode(process.env.USER_NOTIFICATION_MODE)
+}
+
+export function shouldSendOpsNotification(policy: OpsNotificationPolicy): boolean {
+  const mode = policy.mode ?? getOperationalNotificationMode()
+  if (mode === "critical_only") {
+    return criticalTiers.has(policy.tier)
+  }
+  return true
+}
+
+function createOpsStateClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SECRET_KEY
+  if (!supabaseUrl || !serviceKey) {
+    return null
+  }
+  return createClient(supabaseUrl, serviceKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+}
+
+export async function markOpsIncidentNotified(policy: OpsNotificationPolicy): Promise<void> {
+  if (!criticalTiers.has(policy.tier)) {
+    return
+  }
+
+  inMemoryNotifiedIncidents.add(policy.incidentKey)
+  const client = createOpsStateClient()
+  if (!client) {
+    return
+  }
+
+  const now = new Date().toISOString()
+  const { error } = await client.from("ops_alert_state").upsert({
+    incident_key: policy.incidentKey,
+    channel: policy.channel ?? "slack",
+    notification_tier: policy.tier,
+    active: true,
+    opened_at: now,
+    last_notified_at: now,
+    updated_at: now,
+  })
+
+  if (error) {
+    logger.error("Failed to persist ops alert notification state", {
+      component: "ops-notification-policy",
+      incidentKey: policy.incidentKey,
+      error: error.message,
+    })
+  }
+}
+
+export async function wasOpsIncidentNotified(incidentKey: string): Promise<boolean> {
+  if (inMemoryNotifiedIncidents.has(incidentKey)) {
+    return true
+  }
+
+  const client = createOpsStateClient()
+  if (!client) {
+    return false
+  }
+
+  const { data, error } = await client
+    .from("ops_alert_state")
+    .select("incident_key")
+    .eq("incident_key", incidentKey)
+    .eq("active", true)
+    .in("notification_tier", ["P0", "P1"])
+    .maybeSingle()
+
+  if (error) {
+    logger.error("Failed to read ops alert notification state", {
+      component: "ops-notification-policy",
+      incidentKey,
+      error: error.message,
+    })
+    return false
+  }
+
+  return Boolean(data)
+}
+
+export async function resolveOpsIncident(incidentKey: string): Promise<void> {
+  inMemoryNotifiedIncidents.delete(incidentKey)
+  const client = createOpsStateClient()
+  if (!client) {
+    return
+  }
+
+  const { error } = await client
+    .from("ops_alert_state")
+    .update({
+      active: false,
+      last_resolved_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq("incident_key", incidentKey)
+
+  if (error) {
+    logger.error("Failed to resolve ops alert notification state", {
+      component: "ops-notification-policy",
+      incidentKey,
+      error: error.message,
+    })
+  }
+}

--- a/supabase/migrations/20260627120000_add_ops_alert_state.sql
+++ b/supabase/migrations/20260627120000_add_ops_alert_state.sql
@@ -1,0 +1,21 @@
+-- Durable operator notification state for critical-only recovery gating.
+
+CREATE TABLE IF NOT EXISTS ops_alert_state (
+  incident_key TEXT PRIMARY KEY,
+  channel TEXT NOT NULL DEFAULT 'slack',
+  notification_tier TEXT NOT NULL CHECK (notification_tier IN ('P0', 'P1', 'P2', 'P3')),
+  active BOOLEAN NOT NULL DEFAULT true,
+  opened_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_notified_at TIMESTAMPTZ,
+  last_resolved_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ops_alert_state_active_tier
+  ON ops_alert_state(active, notification_tier)
+  WHERE active = true;
+
+ALTER TABLE ops_alert_state ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE ops_alert_state IS
+  'Durable operator alert state used to send recovery notifications only after a P0/P1 incident paged.';

--- a/tests/api/admin/push.test.ts
+++ b/tests/api/admin/push.test.ts
@@ -8,14 +8,17 @@ vi.mock("@/lib/auth/authorization", () => ({
   assertAdminRole: vi.fn().mockResolvedValue(true),
 }))
 
+const mockEnv = vi.hoisted(() => ({
+  NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "test-key",
+  NEXT_PUBLIC_ONESIGNAL_APP_ID: "test-app-id",
+  ONESIGNAL_REST_API_KEY: "test-rest-key",
+  USER_NOTIFICATION_MODE: "normal",
+}))
+
 // Mock env
 vi.mock("@/lib/env", () => ({
-  env: {
-    NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
-    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "test-key",
-    NEXT_PUBLIC_ONESIGNAL_APP_ID: "test-app-id",
-    ONESIGNAL_REST_API_KEY: "test-rest-key",
-  },
+  env: mockEnv,
 }))
 
 const mockGetUser = vi.fn().mockResolvedValue({
@@ -46,6 +49,7 @@ global.fetch = mockFetch
 describe("Push API", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockEnv.USER_NOTIFICATION_MODE = "normal"
     mockGetUser.mockResolvedValue({
       data: { user: { id: "admin1", app_metadata: { role: "admin" } } },
       error: null,
@@ -125,5 +129,47 @@ describe("Push API", () => {
     expect(body.data.success).toBe(true)
     expect(body.data.auditStatus).toBe("degraded")
     expect(body.data.warnings).toEqual(["notification_audit", "audit_logs", "admin_actions"])
+  })
+
+  it("rejects non-emergency broadcasts in critical-only mode", async () => {
+    mockEnv.USER_NOTIFICATION_MODE = "critical_only"
+
+    const request = new NextRequest("http://localhost:3000/api/admin/push", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Test push",
+        message: "Body of push",
+        type: "service_update",
+      }),
+    })
+
+    const response = await POST(request)
+    const body = (await response.json()) as {
+      error: { details: { code: string; allowedTypes: string[] } }
+    }
+
+    expect(response.status).toBe(403)
+    expect(body.error.details.code).toBe("notification_mode_restricted")
+    expect(body.error.details.allowedTypes).toEqual(["emergency"])
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("allows emergency broadcasts in critical-only mode", async () => {
+    mockEnv.USER_NOTIFICATION_MODE = "critical_only"
+
+    const request = new NextRequest("http://localhost:3000/api/admin/push", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Emergency",
+        message: "Emergency update",
+        type: "emergency",
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalled()
   })
 })

--- a/tests/lib/integrations/slack.test.ts
+++ b/tests/lib/integrations/slack.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { sendSlackMessage, sendCircuitBreakerAlert, sendHighErrorRateAlert } from "@/lib/integrations/slack"
+import {
+  sendSlackMessage,
+  sendCircuitBreakerAlert,
+  sendHighErrorRateAlert,
+  sendSLOViolationAlert,
+} from "@/lib/integrations/slack"
 import { CircuitState } from "@/lib/resilience/circuit-breaker"
 import { resetAllThrottles } from "@/lib/observability/alert-throttle"
 
@@ -248,6 +253,21 @@ describe("Slack Integration", () => {
       expect(hasFailureRate).toBe(true)
       expect(hasFailureCount).toBe(true)
     })
+
+    it("suppresses circuit breaker alerts in critical-only mode", async () => {
+      vi.stubEnv("OPERATIONAL_NOTIFICATION_MODE", "critical_only")
+
+      await sendCircuitBreakerAlert({
+        state: CircuitState.OPEN,
+        previousState: CircuitState.CLOSED,
+        failureCount: 7,
+        successCount: 0,
+        failureRate: 0.85,
+        timestamp: Date.now(),
+      })
+
+      expect(fetch).not.toHaveBeenCalled()
+    })
   })
 
   describe("sendHighErrorRateAlert", () => {
@@ -329,6 +349,53 @@ describe("Slack Integration", () => {
       const hasThreshold = fieldsBlock.fields.some((f: any) => f.text.includes("20%"))
       expect(hasErrorRate).toBe(true)
       expect(hasThreshold).toBe(true)
+    })
+
+    it("suppresses high error rate alerts in critical-only mode", async () => {
+      vi.stubEnv("OPERATIONAL_NOTIFICATION_MODE", "critical_only")
+
+      await sendHighErrorRateAlert(25.8, 20)
+
+      expect(fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("sendSLOViolationAlert", () => {
+    it("allows critical uptime alerts in critical-only mode", async () => {
+      vi.stubEnv("OPERATIONAL_NOTIFICATION_MODE", "critical_only")
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      } as Response)
+
+      await sendSLOViolationAlert({
+        type: "uptime",
+        severity: "critical",
+        actual: 0.9,
+        target: 0.99,
+        timestamp: Date.now(),
+        message: "Uptime below target",
+      })
+
+      expect(fetch).toHaveBeenCalled()
+      const [, requestInit] = vi.mocked(fetch).mock.calls[0] ?? []
+      const body = JSON.parse((requestInit?.body as string | undefined) ?? "{}") as Record<string, any>
+      expect(body.text).toContain("Uptime SLO")
+    })
+
+    it("suppresses latency alerts in critical-only mode", async () => {
+      vi.stubEnv("OPERATIONAL_NOTIFICATION_MODE", "critical_only")
+
+      await sendSLOViolationAlert({
+        type: "latency",
+        severity: "critical",
+        actual: 2500,
+        target: 1000,
+        timestamp: Date.now(),
+        message: "Latency above target",
+      })
+
+      expect(fetch).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Adds `OPERATIONAL_NOTIFICATION_MODE` and `USER_NOTIFICATION_MODE` controls with documented defaults.
- Suppresses scheduled reminder/noise workflows and reduces production smoke cadence for critical-only posture.
- Gates operator Slack alerts by severity tier and tracks P0/P1 incident notification state for recovery-message behavior.
- Restricts admin user push broadcasts to `emergency` type when user notifications are in critical-only mode.
- Adds `ops_alert_state` migration for durable operator incident notification state.

## Verification

- `npx vitest run tests/api/admin/push.test.ts tests/lib/integrations/slack.test.ts --maxWorkers=1`
- `npm run type-check`
- `npm run format:check`
- `npm run lint`
- `npm run check:refs`
- `npm run check:root`
- pre-push `npm test`: 199 files passed, 1614 tests passed, 24 skipped

## Notes

- Draft because this changes operational notification posture and includes a Supabase migration.
- Do not apply the migration to production without the repo's required read-only live-schema preflight and shared operations review.