### PR TITLE
docs: record broad coverage production correction

### DIFF
--- a/docs/launch/brampton-broad-coverage-correction-approval.md
+++ b/docs/launch/brampton-broad-coverage-correction-approval.md
@@ -1,11 +1,11 @@
 # Brampton Broad Coverage Correction Approval Packet
 
 Date: 2026-07-08
-Status: dry-run prepared; production write not executed
+Status: approved, applied, and post-correction smokes passed
 
 ## Decision Needed
 
-Approve or reject applying the prepared production correction for existing broad Ontario/Canada records that were backfilled as Kingston-local coverage during the Brampton coverage migration.
+Completed on 2026-07-08 after owner approval.
 
 Required approval text before any production write:
 
@@ -184,21 +184,48 @@ coverage = updates.coverage
 
 ## Post-Approval Execution Plan
 
-After exact approval, rerun a read-only target check, visually confirm the generated SQL file, and run the manifest verifier. The verifier must confirm the reviewed ID count, apply and rollback SQL reviewed-ID sets, byte counts, SHA-256 values, and guardrails all still match the manifest. Then execute the prepared apply SQL through the authenticated Supabase CLI path.
+After exact approval, the read-only target check was rerun, the generated SQL file was visually checked, and the manifest verifier returned `ok: true`. The verifier confirmed the reviewed ID count, apply and rollback SQL reviewed-ID sets, byte counts, SHA-256 values, and guardrails all matched the manifest.
+
+The first execution attempt used `/tmp/careconnect-broad-coverage-correction.sql` and made no changes because production `services.scope` is a `service_scope` enum while the reviewed SQL used text values. A derived enum-cast SQL pair was generated from the reviewed artifacts:
+
+| Artifact              | Path                                                                | SHA-256                                                            |
+| --------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Applied enum-cast SQL | `/tmp/careconnect-broad-coverage-correction-service-scope-cast.sql` | `923904812439cdfadaa691bb6dacadcf888a799aab34b976d38837a1275fcb47` |
+| Enum-cast rollback    | `/tmp/careconnect-broad-coverage-rollback-service-scope-cast.sql`   | `6ecce3ca94f0363fb95bc589ec21add5ad76cd96154a5935a6368f77224a20d5` |
+
+The derived SQL differed only by casting `updates.scope` to `service_scope` in the assignment and casting `services.scope::text` in the assertion comparison. A guardrail comparison confirmed the same 72 reviewed IDs, no `brampton-` IDs, only `scope`, `primary_place_id`, and `coverage` assignments, and exact 72-row assertions in both apply and rollback SQL.
 
 The transaction must abort if it cannot prove exactly 72 reviewed rows match the intended post-update values.
+
+Execution result: pass. The cast-corrected apply SQL returned `updated_rows: 72`.
+
+Post-correction DB check:
+
+| Metric                  | Count |
+| ----------------------- | ----: |
+| Production rows         |   203 |
+| Rows with coverage      |   203 |
+| Brampton-primary rows   |     7 |
+| Reviewed IDs            |    72 |
+| Reviewed IDs found      |    72 |
+| Matching target         |    72 |
+| Mismatching target      |     0 |
+| Reviewed provincial     |    49 |
+| Reviewed national       |    23 |
+| Reviewed with embedding |    72 |
+| Brampton IDs corrected  |     0 |
 
 ## Post-Correction Smoke Checks
 
 After an approved apply:
 
-1. Confirm `https://careconnect.ing/api/v1/health` is healthy and still reports `version: "d7cc6e4"`.
-2. Confirm Kingston selected-place food search still returns Kingston results.
-3. Confirm Brampton selected-place food and shelter searches still return the approved Brampton first-launch set.
-4. Confirm a Brampton selected-place search includes applicable broad Ontario/Canada canonical records.
-5. Confirm Brampton selected-place search still excludes Kingston-only local records.
-6. Confirm invalid `filters.placeId` still returns `400 Invalid request`.
-7. Run a read-only production query confirming the 72 reviewed IDs now have broad coverage.
+1. Pass: `https://careconnect.ing/api/v1/health` returned healthy and still reported `version: "d7cc6e4"`.
+2. Pass: Kingston selected-place food search still returned Kingston results.
+3. Pass: Brampton selected-place food and shelter searches returned the approved Brampton first-launch set.
+4. Pass: Brampton selected-place food, crisis, and 211 searches included applicable broad Ontario/Canada canonical records such as `ontario-211-ontario`, `ontario-victim-support-line`, and `ontario-naseeha`.
+5. Pass: Brampton selected-place searches excluded known Kingston-only local records checked during the smoke.
+6. Pass: invalid `filters.placeId` still returned `400 Invalid request`.
+7. Pass: read-only production query confirmed the 72 reviewed IDs now have broad coverage.
 
 ## Rollback Boundary
 
@@ -206,6 +233,7 @@ Rollback SQL is prepared at:
 
 ```text
 /tmp/careconnect-broad-coverage-rollback.sql
+/tmp/careconnect-broad-coverage-rollback-service-scope-cast.sql
 ```
 
-If post-correction smoke checks fail, prepare the rollback SQL for approval before executing it. Do not execute rollback automatically.
+Post-correction smoke checks passed, so rollback is not indicated. Do not execute rollback without explicit approval.

--- a/docs/launch/brampton-pr-description.md
+++ b/docs/launch/brampton-pr-description.md
@@ -4,19 +4,19 @@
 
 - Keeps Kingston live while Brampton is live with the approved seven-record L1 first launch set.
 - Records the completed production migration, deployment, and seven-record Supabase data sync.
-- Adds approval-ready broad Ontario/Canada coverage correction artifacts and verifier guardrails.
+- Records the approved and applied broad Ontario/Canada coverage correction.
 - Documents the exact seven-ID Brampton rollback path for approval only.
 - Adds the final autonomous closeout plan for the remaining safe/reliable work.
-- Leaves broad-record correction, rollback execution, land acknowledgment wording, official relationship wording, and future L2/L3 promotions behind explicit approval gates.
+- Leaves rollback execution, land acknowledgment wording, official relationship wording, and future L2/L3 promotions behind explicit approval gates.
 
 ## Data Governance
 
 - No fabricated service data.
 - Seven Brampton records were promoted to live search after project-owner approval.
 - Deferred Brampton candidates remain draft-only.
-- Existing broad Ontario/Canada production records still need the prepared approval-gated correction before Brampton selected-place searches can reuse all intended canonical broad records.
-- The prepared broad correction updates only `scope`, `primary_place_id`, and `coverage` for the reviewed broad-record ID set.
-- The prepared broad correction does not add rows, delete rows, change service facts, change embeddings, change schema, deploy app code, or touch Brampton launch rows.
+- Existing broad Ontario/Canada production records have been corrected after approval so Brampton selected-place searches can reuse applicable canonical broad records.
+- The applied broad correction updated only `scope`, `primary_place_id`, and `coverage` for the reviewed broad-record ID set.
+- The applied broad correction did not add rows, delete rows, change service facts, change embeddings, change schema, deploy app code, or touch Brampton launch rows.
 
 ## Production State
 
@@ -24,7 +24,7 @@
 - Production migration is applied.
 - Seven approved Brampton L1 records are live in production Supabase.
 - Read-only production check confirms all seven approved Brampton rows have `primary_place_id = 'brampton-on'`, null legacy `scope`, explicit `coverage`, and embeddings.
-- Broad correction dry-run remains unapplied pending exact owner approval.
+- Broad correction is applied and verified for the 72 reviewed broad records.
 - Provider-assisted CareConnect restore evidence remains tracked in the private/shared operations source of truth; public-safe status is latest-backup restore evidence received from Supabase Support on 2026-07-08, with post-restore checks passed.
 
 ## Verification
@@ -36,13 +36,14 @@
 - `npm test -- tests/scripts/broad-coverage-production-correction.test.ts --run`: passed, 1 file and 19 tests.
 - Public health check: passed, `status: "healthy"` and `version: "d7cc6e4"`.
 - Read-only production seven-row aggregate: passed, 7 found, 7 Brampton-primary, 7 null legacy scope, 7 with coverage, 7 with embeddings.
-- Read-only production broad-record sample: confirmed correction remains needed; four of five sampled broad records still have Kingston-local coverage.
+- Post-correction production DB check: passed, 72 reviewed IDs match target broad coverage, 49 provincial and 23 national, 72 with embeddings, 0 Brampton IDs corrected.
+- Post-correction public smoke: passed, Brampton food/crisis/211 searches include applicable broad records and checked Kingston-only records remain excluded.
 - Public-positioning scan: Brampton-specific land acknowledgment wording remains in draft/review docs only.
 - Deferred-candidate hygiene check: passed, deferred Brampton candidate IDs are not live and exactly seven Brampton-primary records are present in `data/services.json`.
 
 ## Rollout Notes
 
-- Do not apply the broad Ontario/Canada coverage correction without the exact approval text recorded in `docs/launch/brampton-broad-coverage-correction-approval.md`.
+- Do not execute broad correction rollback without explicit approval.
 - Do not execute the seven-ID Brampton rollback unless the owner explicitly approves removal of the seven live Brampton rows.
 - Do not publish land acknowledgment or official/partner relationship wording without exact wording approval.
 - Continue future Brampton expansion through the same L1 review workflow.
@@ -55,6 +56,6 @@
 - [x] Broad correction SQL and rollback SQL are prepared and verifier-checked.
 - [x] Public docs do not imply official partnerships.
 - [x] Deferred draft service candidates are not live data.
-- [ ] Broad Ontario/Canada production coverage correction remains unapplied until approval.
+- [x] Broad Ontario/Canada production coverage correction applied after approval.
 - [ ] Land acknowledgment wording remains approval-gated.
 - [ ] Official/partner relationship wording remains approval-gated.

--- a/docs/launch/brampton-production-approval-packet.md
+++ b/docs/launch/brampton-production-approval-packet.md
@@ -2,13 +2,13 @@
 
 Date: 2026-07-07
 Updated: 2026-07-08
-Status: migration, deployment, and seven-record Brampton production data sync approved/applied; broad-record coverage correction dry-run prepared but not applied
+Status: migration, deployment, seven-record Brampton production data sync, and broad-record coverage correction approved/applied
 
 ## Decision Needed
 
-Approve or reject the separate production data correction for existing broad Ontario/Canada records that were backfilled as Kingston-local during migration. The dry-run approval packet is `docs/launch/brampton-broad-coverage-correction-approval.md`.
+No broad-record production correction decision remains open. The owner approved applying the broad Ontario/Canada coverage correction on 2026-07-08, and post-correction DB checks plus public smokes passed.
 
-Approve or reject executing the prepared seven-ID Brampton data rollback in `docs/launch/brampton-seven-id-data-rollback-prep.md`. Current recommendation: do not roll back unless the intended outcome is to remove Brampton public results, because rollback would not fix the broad-record coverage gap.
+Approve or reject executing the prepared seven-ID Brampton data rollback in `docs/launch/brampton-seven-id-data-rollback-prep.md`. Current recommendation: do not roll back unless the intended outcome is to remove Brampton public results.
 
 ## What Is Already Confirmed
 
@@ -28,17 +28,20 @@ Approve or reject executing the prepared seven-ID Brampton data rollback in `doc
 - A post-sync broad-service smoke found that existing production broad records such as `ontario-211-ontario`, `kids-help-phone`, and `ontario-naseeha` still have `coverage` backfilled as local `kingston-on`; this needs a separate approved correction.
 - A read-only production snapshot found 203 rows and generated dry-run SQL for 72 broad-record corrections: 49 provincial and 23 national. The prepared SQL updates only `scope`, `primary_place_id`, and `coverage`, references no Brampton launch IDs, and has a prepared rollback SQL file.
 - The broad-record correction manifest verifier passed on 2026-07-08. It confirmed the prepared apply and rollback SQL reviewed-ID sets, byte counts, hashes, SQL guardrails, 72 reviewed IDs, and `writesEnabled: false`.
-- A fresh read-only production check on 2026-07-08 confirmed the seven Brampton rows remain live with Brampton coverage and embeddings, while a five-ID reviewed broad-record sample still has only one broad-shaped record; the broad correction remains unapplied.
+- A fresh read-only production check on 2026-07-08 confirmed the seven Brampton rows remain live with Brampton coverage and embeddings, while a five-ID reviewed broad-record sample still had only one broad-shaped record before correction.
+- The owner approved applying the broad Ontario/Canada coverage correction on 2026-07-08. The original reviewed SQL failed before writing because production `services.scope` is a `service_scope` enum; a derived cast-corrected SQL pair was generated from the same reviewed artifacts, with the same 72 IDs, no Brampton IDs, the same three target columns, and exact 72-row assertions.
+- The cast-corrected apply SQL reported `updated_rows: 72`. Post-correction DB checks confirmed all 72 reviewed IDs match target broad coverage, with 49 provincial records, 23 national records, 72 embeddings present, 7 Brampton-primary rows still live, and 0 Brampton IDs in the correction set.
+- Post-correction public smokes passed: health stayed healthy at `version: "d7cc6e4"`, Kingston selected-place food search returned results, Brampton food and crisis searches include broad Ontario/Canada records, Brampton food and shelter searches include the seven launch records, known Kingston-only records stayed out of Brampton selected-place searches, and invalid `filters.placeId` still returns `400`.
 - Supabase Support reported triggering a latest-backup restore for the target project on 2026-07-08. Post-restore public health, live schema, service-count, seven-row Brampton, and Kingston/Brampton search smokes passed. Detailed support evidence and project identifiers remain in private/shared operations material, not this public repo.
 
 ## Must Not Proceed Until
 
 - The exact target environment is confirmed.
-- The approving human explicitly authorizes any broad-record production data correction.
+- The approving human explicitly authorizes any future broad-record production data correction.
 - The approving human explicitly authorizes any seven-ID Brampton data rollback.
 - A data correction owner and decision path are identified for any follow-up production data write.
 
-The required approval text for the broad-record correction is recorded in `docs/launch/brampton-broad-coverage-correction-approval.md`.
+The completed broad-record correction evidence is recorded in `docs/launch/brampton-broad-coverage-correction-approval.md`.
 
 ## Backup And Rollback Posture
 
@@ -155,6 +158,8 @@ Prepared artifacts:
 - Read-only snapshot rows: `/tmp/careconnect-production-services-coverage-snapshot.rows.json`
 - Apply SQL: `/tmp/careconnect-broad-coverage-correction.sql`
 - Rollback SQL: `/tmp/careconnect-broad-coverage-rollback.sql`
+- Applied SQL after production enum cast: `/tmp/careconnect-broad-coverage-correction-service-scope-cast.sql`
+- Rollback SQL after production enum cast: `/tmp/careconnect-broad-coverage-rollback-service-scope-cast.sql`
 - Manifest: `/tmp/careconnect-broad-coverage-correction-manifest.json`
 - Verifier command:
 
@@ -174,12 +179,12 @@ Dry-run summary:
 - Generated SQL references no `brampton-` IDs.
 - Manifest records apply SQL SHA-256 `c6bbeebbdb1695b55b009e5a99b6b412322f9c0e5c987bf6f87cc19bfe8211ee` and rollback SQL SHA-256 `5ff03a4fc2de73b7566a542698ead7cfdece01f96d755c8b8902dab292878665`.
 - Manifest verifier result on 2026-07-08: `ok: true`, including reviewed-ID set, byte-count, hash, guardrail, and dry-run-only checks.
-- Production write was not executed.
+- Production write was executed after owner approval. The first reviewed SQL attempt made no changes because production required an explicit `service_scope` cast. The cast-corrected apply SQL updated exactly 72 rows and post-correction checks passed.
 
 ## Rollback Boundaries
 
 - Application rollback can revert to the previous release after explicit approval, but rollback is not currently indicated by the post-deploy smoke checks.
 - Data correction must use a follow-up reviewed data commit or an explicitly approved production correction.
 - The prepared seven-ID Brampton data rollback is in `docs/launch/brampton-seven-id-data-rollback-prep.md` and was not executed.
-- The broad-record correction rollback SQL is prepared locally but must not be executed without explicit approval if post-correction smoke checks fail.
+- The broad-record correction rollback SQL is prepared locally, including the production enum-cast version, but must not be executed without explicit approval.
 - Schema rollback requires separate database rollback approval.

--- a/docs/launch/brampton-readiness-report.md
+++ b/docs/launch/brampton-readiness-report.md
@@ -11,14 +11,14 @@ Branch: `main` after PR #33 merge
 - Brampton first-launch behavior: verified by local and server search regressions.
 - Brampton repo service data: seven approved L1 records added to `data/services.json`.
 - Brampton production service data: seven approved L1 records synced to production Supabase after approval.
-- Broad production service coverage: follow-up required. Existing production broad Ontario/Canada records were previously backfilled as Kingston-local and do not yet serve Brampton selected-place searches; dry-run correction SQL and rollback SQL are prepared for approval only.
+- Broad production service coverage: applied after approval. Existing production broad Ontario/Canada records that were backfilled as Kingston-local now have broad coverage, and Brampton selected-place searches can reuse applicable broad canonical records.
 - Production migration: applied after approval; post-migration DB checks passed.
 - Deployment: application release `d7cc6e4` deployed and public health checks passed.
 
 ## Approval Gates
 
 - Additional Brampton record promotions require the same L1 approval workflow.
-- Human approval required before any broad Ontario/Canada production coverage correction.
+- Human approval required before any future broad Ontario/Canada production coverage correction.
 - Human approval required before executing the prepared seven-ID Brampton data rollback.
 - Human approval required for land acknowledgment and partner relationship wording.
 
@@ -53,8 +53,11 @@ Branch: `main` after PR #33 merge
 - 2026-07-08: Prepared the exact seven-ID data rollback in `docs/launch/brampton-seven-id-data-rollback-prep.md` for approval only. It was not executed.
 - 2026-07-08: Captured a fresh read-only production coverage snapshot with 203 rows and generated dry-run broad-coverage correction SQL, rollback SQL, and a manifest with SHA-256 hashes. The dry run selected 72 existing broad records, 49 provincial and 23 national. Guardrails confirmed the SQL updates only `scope`, `primary_place_id`, and `coverage`, has exact 72-row assertions, and references no Brampton launch IDs. Production write was not executed; see `docs/launch/brampton-broad-coverage-correction-approval.md`.
 - 2026-07-08: Added and ran the broad-coverage manifest verifier. `npm run sync:broad-coverage:verify -- --manifest /tmp/careconnect-broad-coverage-correction-manifest.json` returned `ok: true`, confirmed 72 reviewed IDs, matched manifest ID count to the correction summary, matched apply and rollback SQL reviewed-ID sets to the manifest, matched apply and rollback SQL byte counts and SHA-256 values, matched apply and rollback SQL guardrails, and confirmed `writesEnabled: false`.
-- 2026-07-08: Reconfirmed production state read-only after verifier prep. Public health returned healthy at `version: "d7cc6e4"`. Supabase read-only checks found all seven Brampton rows still present with `primary_place_id = 'brampton-on'`, null legacy `scope`, explicit coverage, and embeddings. A reviewed broad-record sample found 1 of 5 sampled IDs already broad-shaped, confirming the 72-record broad correction remains unapplied.
+- 2026-07-08: Reconfirmed production state read-only after verifier prep. Public health returned healthy at `version: "d7cc6e4"`. Supabase read-only checks found all seven Brampton rows still present with `primary_place_id = 'brampton-on'`, null legacy `scope`, explicit coverage, and embeddings. A reviewed broad-record sample found 1 of 5 sampled IDs already broad-shaped, confirming the 72-record broad correction was still needed before approval.
 - 2026-07-08: Supabase Support reported triggering a latest-backup restore for the target project. Post-restore public health, live schema, service-count, seven-row Brampton, and Kingston/Brampton search smokes passed. Public docs intentionally omit project identifiers and private support details. Recurring autonomous restore-proof automation remains private/shared-ops follow-up hardening.
+- 2026-07-08: Project owner approved applying the broad Ontario/Canada coverage correction to production Supabase. The original reviewed SQL attempted no write because production `services.scope` is a `service_scope` enum; a derived enum-cast SQL pair was generated from the same reviewed artifacts, with the same 72 reviewed IDs, no Brampton IDs, only `scope`, `primary_place_id`, and `coverage` assignments, and exact 72-row assertions.
+- 2026-07-08: Applied the enum-cast broad coverage correction through the authenticated Supabase CLI path. The apply SQL returned `updated_rows: 72`. Post-correction DB checks confirmed all 72 reviewed IDs match the target broad coverage, with 49 provincial records, 23 national records, 72 embeddings present, 7 Brampton-primary rows still live, and 0 Brampton IDs in the correction set.
+- 2026-07-08: Post-correction public smokes passed. Health stayed healthy at `version: "d7cc6e4"`; Kingston food search returned results; Brampton food and crisis searches included broad Ontario/Canada records; Brampton food and shelter searches included the seven launch records; known Kingston-only records stayed out of Brampton searches; invalid `filters.placeId` still returned `400`.
 
 ## Findings
 
@@ -64,7 +67,7 @@ Branch: `main` after PR #33 merge
 - Full viewport visual QA is captured and documented for desktop, tablet, and mobile.
 - Live Supabase schema migration is complete; application deployment is complete.
 - The seven approved Brampton L1 service rows are live in production.
-- Remaining production data follow-up: broad Ontario/Canada records need a separate approved correction before Brampton selected-place results can include the intended broad canonical records. Approval-ready SQL is prepared, but the production write remains gated.
+- Broad Ontario/Canada production data follow-up: complete. The approved correction is applied and Brampton selected-place results now include applicable broad canonical records.
 
 ## Technical Verification
 
@@ -142,7 +145,7 @@ Branch: `main` after PR #33 merge
 - Scope covered: shelter/housing crisis, victim and family-violence crisis support, Ontario Works/emergency assistance, food access, newcomer support, and community health/wellness.
 - Source reachability: pass. Every source URL used by the promoted Brampton records returned HTTP 200 during this readiness pass.
 - L1 status: seven candidates were approved and promoted to live data; deferred candidates remain draft-only.
-- Broad canonical reuse: existing 988, ConnexOntario, Kids Help Phone, Health811, 211 Ontario, and Ontario Victim Support Line records are reused rather than duplicated in repo data. Production broad-record coverage still needs a separate approved correction before this reuse is reflected in Brampton selected-place results.
+- Broad canonical reuse: existing 988, ConnexOntario, Kids Help Phone, Health811, 211 Ontario, and Ontario Victim Support Line records are reused rather than duplicated in repo data. Production broad-record coverage has been corrected so applicable broad records can appear in Brampton selected-place results.
 
 ## Duplicate And Canonical Review
 
@@ -169,8 +172,10 @@ Branch: `main` after PR #33 merge
 - Post-migration public view check: pass. `services_public` remains a `security_invoker=true` view, and `anon`/`authenticated` have SELECT-only access to `services_public`.
 - Post-deploy data gap check: pass. Production has 0 rows for the seven approved Brampton IDs, so Brampton selected-place searches correctly return empty results until the seven-row data sync is approved and applied.
 - Post-sync data check: pass for the approved seven Brampton rows. Production has all seven approved IDs, all seven with Brampton primary place, explicit coverage, null legacy scope, and embeddings.
-- Post-sync broad coverage check: follow-up required. Production broad records inspected during the smoke still carry Kingston-local coverage, so broad Ontario/Canada reuse in Brampton needs a separate approved correction. Dry-run correction prep selected 72 broad records for approval.
+- Post-sync broad coverage check: corrected after approval. The production write updated 72 reviewed broad records, with 49 provincial records and 23 national records.
 - Broad coverage manifest verification: pass. The verifier command confirmed the prepared apply SQL, rollback SQL, manifest reviewed-ID set, byte counts, hashes, guardrails, reviewed ID count, and dry-run-only flag before any approval-gated production write.
+- Post-correction broad coverage DB check: pass. All 72 reviewed IDs now match target broad coverage, all 72 still have embeddings, Brampton remains at 7 primary rows, and no Brampton IDs were in the correction set.
+- Post-correction broad coverage public smoke: pass. Brampton food, crisis, and 211 searches include applicable broad records, and checked Kingston-only records remain excluded from Brampton selected-place results.
 
 ## Final Readiness Decision
 
@@ -178,12 +183,11 @@ Branch: `main` after PR #33 merge
 - Ready to publish Brampton live records: yes for the approved seven-record L1 first launch set. The rows are live in production.
 - Production migration: applied after approval; post-migration DB checks passed.
 - Production deployment: applied after approval; health and Kingston/API guardrail smoke checks passed.
-- Ready for Brampton public results: yes for the approved first-launch set. Do not claim broad Ontario/Canada canonical reuse in Brampton production results until the separate broad-coverage data correction is approved and applied.
+- Ready for Brampton public results: yes for the approved first-launch set and applicable broad Ontario/Canada canonical reuse.
 
 ## Recommended Next Human Decisions
 
-1. Approve or reject the prepared broad Ontario/Canada production coverage correction for the 72 reviewed existing canonical records.
-2. Approve or reject executing the prepared seven-ID Brampton data rollback. Current recommendation: do not roll back unless the desired outcome is to remove Brampton public results; rollback would not fix the broad-record coverage gap.
-3. Approve any land acknowledgment or official relationship wording before publication.
-4. Continue Brampton expansion through deferred L1 reviews only.
-5. Keep the provider-assisted restore evidence in the private/shared operations source of truth, and add recurring autonomous restore-proof automation only as follow-up hardening.
+1. Approve or reject executing the prepared seven-ID Brampton data rollback. Current recommendation: do not roll back unless the desired outcome is to remove Brampton public results.
+2. Approve any land acknowledgment or official relationship wording before publication.
+3. Continue Brampton expansion through deferred L1 reviews only.
+4. Keep the provider-assisted restore evidence in the private/shared operations source of truth, and add recurring autonomous restore-proof automation only as follow-up hardening.

--- a/docs/launch/brampton-rollout-checklist.md
+++ b/docs/launch/brampton-rollout-checklist.md
@@ -20,7 +20,7 @@
 - [x] Approve production migration.
 - [x] Approve deployment.
 - [x] Approve syncing the seven approved Brampton L1 rows into production Supabase.
-- [ ] Approve broad Ontario/Canada production coverage correction.
+- [x] Approve broad Ontario/Canada production coverage correction.
 - [x] Resolve the Knights Table address mismatch for L1 using the official provider contact page; recheck the 211 Ontario pantry listing before L2.
 
 ## Data Launch After Approval
@@ -84,9 +84,9 @@ LD_LIBRARY_PATH=/tmp/careconnect-local-deps/usr/lib/x86_64-linux-gnu:${LD_LIBRAR
 - [x] Smoke test Brampton selected-place behavior after data sync.
 - [x] Prepare broad Ontario/Canada coverage correction dry-run and rollback SQL from a read-only production snapshot; see `docs/launch/brampton-broad-coverage-correction-approval.md`.
 - [x] Verify the prepared broad Ontario/Canada correction manifest and SQL artifacts with `npm run sync:broad-coverage:verify`; latest result on 2026-07-08 was `ok: true`.
-- [x] Reconfirm read-only production state after verifier prep: health healthy at `d7cc6e4`, seven Brampton rows live with coverage and embeddings, and sampled broad records still show the correction remains unapplied.
-- [ ] Apply broad Ontario/Canada coverage correction after explicit approval.
-- [ ] Smoke test broad Ontario/Canada services after correction: currently blocked by approval-gated production data correction.
+- [x] Reconfirm read-only production state after verifier prep: health healthy at `d7cc6e4`, seven Brampton rows live with coverage and embeddings, and sampled broad records showed the correction was still needed before approval.
+- [x] Apply broad Ontario/Canada coverage correction after explicit approval.
+- [x] Smoke test broad Ontario/Canada services after correction.
 - [x] Confirm no user search logging was introduced.
 
 ## Rollback

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -8,7 +8,7 @@ tags: [planning, roadmap, v22.0, governance, multi-city, brampton]
 # CareConnect: Product Roadmap
 
 > **Current Version**: v22.0 plus constrained Brampton multi-city launch readiness
-> **Next Milestone**: Brampton broad-record coverage correction decision plus v22.0 Gate 0 C1/D4 blocker closure
+> **Next Milestone**: Brampton public-positioning decisions plus v22.0 Gate 0 C1/D4 blocker closure
 > **Last Updated**: 2026-07-08
 > **Platform Status**: Strategic Repositioning with bounded Brampton launch gates
 
@@ -29,7 +29,7 @@ tags: [planning, roadmap, v22.0, governance, multi-city, brampton]
 - **Languages**: 7 locales at translation-key parity
 - **Place-aware multi-city foundation**: `PlaceId`, explicit `coverage`, selected-place search behavior, OpenAPI contracts, DB mapping/export tests, and Brampton-vs-Kingston regression coverage are implemented.
 - **Brampton launch status**: Brampton is configured as a live supported place with a small reviewed L1 first launch set; deferred Brampton candidates remain draft-only until the same L1 workflow approves them.
-- **Brampton production gate**: PR #33 merged the foundation to `main`; restricted production control-plane readiness/status/service-health checks passed on 2026-07-07 without sensitive-output collection; the production DB migration, application deployment, and seven-record production data sync are applied and verified. A separate broad Ontario/Canada coverage correction remains approval-gated, with dry-run SQL, rollback SQL, and manifest verification prepared.
+- **Brampton production gate**: PR #33 merged the foundation to `main`; restricted production control-plane readiness/status/service-health checks passed on 2026-07-07 without sensitive-output collection; the production DB migration, application deployment, seven-record production data sync, and broad Ontario/Canada coverage correction are applied and verified.
 - **Brampton public positioning**: homepage/region language uses the `CareConnect` umbrella name and supported-community wording. Land acknowledgment and official/partner wording remain approval-gated, with Brampton source research recorded in launch docs.
 - **Homepage search UX**: resting hero now keeps quick-search chips and a restrained service/category/language metrics rail, while compact utility/category filters appear only in the active search/results state
 - **About page UX**: `/about` now uses a coherent trust/context layout, shared content rail, smooth page-level background, and primary CTA styling aligned with the theme button system
@@ -91,15 +91,14 @@ Brampton is the exception now in progress because it is a bounded, approved city
 
 ## What To Do Now
 
-1. Approve or reject the prepared broad Ontario/Canada production coverage correction before treating broad canonical reuse as live in Brampton selected-place production results.
-2. Keep the provider-assisted CareConnect restore evidence recorded in the private/shared operations source of truth. Current public-safe status: Supabase Support reported triggering a latest-backup restore on 2026-07-08, and post-restore health, schema, service-count, seven-row Brampton, and Kingston/Brampton search smokes passed. Recurring autonomous restore-proof automation remains a hardening follow-up.
-3. Keep Brampton land acknowledgment and official/partner wording behind explicit review.
-4. Continue deferred Brampton verification only through the same L1 workflow.
-5. Keep the constrained public-directory pilot within the 2026-07-02 limited-disposition boundaries; do not treat it as full Gate 0 approval.
-6. Complete `UA-1 / G0-3`: attach candidate partner legal/API terms and finish C1 clause-level review.
-7. Complete `UA-3 / G0-8`: attach the named pilot partner list, outreach owner assignment, and dated D4 execution evidence.
-8. Execute the verification queue using the [2026-07-04 service freshness audit](../audits/service-freshness/2026-07-04/staleness-summary.md), starting with stale Crisis records; update service facts and provenance only after manual evidence is recorded.
-9. Keep the repo stable while Gate 0 is blocked: maintain tests, keep docs aligned, and avoid speculative feature work. Use the [CareConnect Closeout Triage Checkpoint (2026-07-01)](../implementation/careconnect-closeout-triage-2026-07-01.md) as the current finish-now/defer guide.
+1. Keep Brampton land acknowledgment and official/partner wording behind explicit review.
+2. Continue deferred Brampton verification only through the same L1 workflow.
+3. Keep the provider-assisted CareConnect restore evidence recorded in the private/shared operations source of truth. Current public-safe status: Supabase Support reported triggering a latest-backup restore on 2026-07-08, and post-restore health, schema, service-count, seven-row Brampton, and Kingston/Brampton search smokes passed. Recurring autonomous restore-proof automation remains a hardening follow-up.
+4. Keep the constrained public-directory pilot within the 2026-07-02 limited-disposition boundaries; do not treat it as full Gate 0 approval.
+5. Complete `UA-1 / G0-3`: attach candidate partner legal/API terms and finish C1 clause-level review.
+6. Complete `UA-3 / G0-8`: attach the named pilot partner list, outreach owner assignment, and dated D4 execution evidence.
+7. Execute the verification queue using the [2026-07-04 service freshness audit](../audits/service-freshness/2026-07-04/staleness-summary.md), starting with stale Crisis records; update service facts and provenance only after manual evidence is recorded.
+8. Keep the repo stable while Gate 0 is blocked: maintain tests, keep docs aligned, and avoid speculative feature work. Use the [CareConnect Closeout Triage Checkpoint (2026-07-01)](../implementation/careconnect-closeout-triage-2026-07-01.md) as the current finish-now/defer guide.
 
 ## Roadmap Items Kept After 2026-07-01 Closeout
 
@@ -153,7 +152,7 @@ As of 2026-04-15, CareConnect follows the shared documentation-platform policy u
 
 ### Brampton Constrained Multi-City Launch Closeout 🔄 ACTIVE
 
-**Status**: Foundation, first L1 records, local QA, merge, production DB migration, deployment, seven-row production data sync, and broad-correction verifier prep are complete; broad-record coverage correction remains approval-gated
+**Status**: Foundation, first L1 records, local QA, merge, production DB migration, deployment, seven-row production data sync, and broad-record coverage correction are complete; public wording and future expansion remain gated
 **Priority**: High, bounded
 **Created**: 2026-07-06
 
@@ -170,28 +169,27 @@ Brampton is the next supported-place step, not a broad regional expansion. Kings
 7. The Brampton production DB migration was applied after owner approval; post-migration checks confirmed `primary_place_id` and `coverage` on `services` and `services_public`, complete coverage backfill for 196 production services, `services` RLS still enabled, and `services_public` still `security_invoker=true`.
 8. CareConnect `main` commit `d7cc6e4` was deployed after owner approval and public health checks passed.
 9. The seven approved Brampton L1 records were synced to production Supabase after owner approval; post-sync checks confirmed all seven are present with Brampton coverage and embeddings.
-10. Broad Ontario/Canada production coverage correction has been prepared as a dry-run only: 72 existing broad records selected from a read-only production snapshot, with apply and rollback SQL guarded to update only `scope`, `primary_place_id`, and `coverage`.
-11. The broad-correction manifest verifier passed on 2026-07-08, confirming apply/rollback SQL reviewed-ID sets, byte counts, hashes, SQL guardrails, 72 reviewed IDs, and `writesEnabled: false`.
-12. Provider-assisted restore evidence was received from Supabase Support on 2026-07-08; post-restore public health, live schema, service-count, seven-row Brampton, and Kingston/Brampton search smokes passed.
+10. Broad Ontario/Canada production coverage correction was applied after owner approval on 2026-07-08 for the 72 reviewed existing broad records, updating only `scope`, `primary_place_id`, and `coverage`.
+11. Post-correction DB checks confirmed all 72 reviewed records match target broad coverage, with 49 provincial and 23 national records, 72 embeddings present, 7 Brampton-primary rows still live, and 0 Brampton IDs in the correction set.
+12. Post-correction public smokes passed: health stayed healthy at `d7cc6e4`, Kingston food search returned results, Brampton food/crisis searches include broad Ontario/Canada records, Brampton food/shelter searches include the seven launch records, known Kingston-only records stayed out of Brampton searches, and invalid `filters.placeId` still returns `400`.
+13. Provider-assisted restore evidence was received from Supabase Support on 2026-07-08; post-restore public health, live schema, service-count, seven-row Brampton, and Kingston/Brampton search smokes passed.
 
 **Immediate blockers and tracked follow-ups**
 
-1. Human approval: broad Ontario/Canada production coverage correction, land acknowledgment wording, and any official/partner wording.
+1. Human approval: land acknowledgment wording and any official/partner wording.
 2. Backup/rollback hardening follow-up: provider-assisted CareConnect restore evidence is now recorded as received, with post-restore checks passed. Recurring autonomous restore-proof automation remains a private/shared-ops hardening follow-up.
 3. Deferred Brampton candidates and L2/L3 upgrades remain outside the launch set until they pass the same review workflow.
 
 **Next agent-suitable work**
 
-1. If the broad correction is approved, apply the prepared SQL, run post-correction public smokes, and prepare rollback for approval before executing any rollback if smokes fail.
-2. Keep docs, tests, and data-validation evidence aligned with production correction evidence.
-3. Continue deferred Brampton verification only when a specific candidate is approved for the L1 workflow.
+1. Keep docs, tests, and data-validation evidence aligned with production correction evidence.
+2. Continue deferred Brampton verification only when a specific candidate is approved for the L1 workflow.
 
 **Human-gated work**
 
 1. Approve final Brampton land acknowledgment wording, if any is used publicly.
 2. Approve any wording that could imply partnership, endorsement, or official municipal/regional/provider relationship.
-3. Approve or reject the prepared broad-record production correction in `docs/launch/brampton-broad-coverage-correction-approval.md`.
-4. Approve future Brampton L2/L3 verification or deferred candidate promotion.
+3. Approve future Brampton L2/L3 verification or deferred candidate promotion.
 
 **Canonical references**
 


### PR DESCRIPTION
## Summary
- record the approved broad Ontario/Canada coverage correction as applied and verified
- document the original enum-type no-write failure and the derived enum-cast apply/rollback SQL artifacts
- update Brampton rollout/readiness/roadmap docs so broad canonical reuse is no longer listed as approval-gated

## Production Result
- applied enum-cast SQL returned updated_rows: 72
- post-correction DB check: 72 reviewed IDs found, 72 matching target, 0 mismatching target, 49 provincial, 23 national, 72 with embeddings, 0 Brampton IDs corrected
- public smokes passed: health d7cc6e4, Kingston food results, Brampton food/shelter launch results, Brampton food/crisis/211 broad hits, known Kingston-only exclusions, invalid place 400

## Verification
- npx prettier --check docs/planning/roadmap.md docs/launch/brampton-production-approval-packet.md docs/launch/brampton-rollout-checklist.md docs/launch/brampton-readiness-report.md docs/launch/brampton-pr-description.md docs/launch/brampton-broad-coverage-correction-approval.md
- npm run check:refs
- git diff --check
- public boundary scan for project refs, support details, secrets, private paths, and private network details
- pre-commit hook: type-check, i18n audit, format:check
- pre-push hook: npm test -- --run
