### PR TITLE
docs: close Brampton roadmap status

### DIFF
--- a/docs/launch/brampton-readiness-report.md
+++ b/docs/launch/brampton-readiness-report.md
@@ -77,7 +77,7 @@ Branch: `main` after PR #33 merge
 - Targeted Vitest suite: pass, 15 files and 230 tests passed in the original Brampton readiness pass.
 - Autonomous closeout targeted suite: pass, `npm test -- tests/scripts/broad-coverage-production-correction.test.ts tests/api/v1/search-api.test.ts tests/hooks/useServices.test.ts tests/lib/places/coverage.test.ts --run`, 4 files and 53 tests passed on 2026-07-08.
 - Brampton promotion suite: pass, 5 files and 39 tests passed.
-- Full Vitest suite: pass, 218 files and 1730 tests passed, 24 skipped on 2026-07-08.
+- Full Vitest suite: pass, 218 files and 1732 tests passed, 24 skipped on 2026-07-08.
 - Lint: pass, `npm run lint`.
 - Type check: pass, `npm run type-check`.
 - Format check: pass, `npm run format:check`.
@@ -93,7 +93,7 @@ Branch: `main` after PR #33 merge
 - Visual QA capture: pass, `npx playwright test tests/e2e/brampton-visual-qa.spec.ts --project=chromium`, 6 Chromium screenshot tests.
 - DB smoke: pass, `npm run test:db:smoke`, 2 smoke tests against the disposable local Supabase stack, rerun on 2026-07-08.
 - Restricted production control-plane preflight: pass, dev-space readiness and wrapper-gated CareConnect preflight/status/service-health checks completed without sensitive-output collection.
-- Production approval packet: prepared; migration, deployment, and seven-row production data sync applied after approval; broad-record coverage correction dry-run is prepared and remains separately approval-gated.
+- Production approval packet: prepared; migration, deployment, seven-row production data sync, and broad-record coverage correction applied after approval.
 - Production data sync: applied after approval for exactly seven Brampton L1 records; post-sync DB and core API smokes completed.
 - Future verification queue: prepared as draft-only; no additional Brampton records promoted.
 
@@ -103,7 +103,7 @@ Branch: `main` after PR #33 merge
 - Production migration was applied after explicit approval. The application deployment was performed on 2026-07-08 and health checks passed.
 - Live Supabase schema inspection completed through the Supabase CLI and authenticated Supabase tooling. The Brampton coverage migration is applied in production.
 - Production data inspection confirmed the seven approved Brampton rows are in production with `primary_place_id = 'brampton-on'`, null legacy `scope`, explicit coverage, and embeddings.
-- Existing production broad records still need a separate approved data correction because the migration backfilled several repo-broad records as Kingston-local from the previous live values. Apply and rollback SQL have been prepared from a read-only production snapshot but not executed.
+- Existing production broad records were corrected after approval because the migration had backfilled several repo-broad records as Kingston-local from the previous live values. Rollback SQL remains prepared but is not indicated and must not be executed without explicit approval.
 - Provider-assisted CareConnect restore evidence has been received from Supabase Support and post-restore checks passed. Recurring autonomous restore-proof automation remains a private-ops hardening follow-up.
 
 ## Browser And Accessibility QA

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -15,7 +15,7 @@ tags: [planning, roadmap, v22.0, governance, multi-city, brampton]
 ## Current State
 
 - **Services**: 203 manually curated social services. Kingston remains live, and Brampton has a seven-record L1 first launch set focused on urgent and core supports.
-- **Tests**: default Vitest suite green as of 2026-07-08 (`218` files; `1730` passed; `24` skipped during `npm test -- --run` in the Brampton closeout pass)
+- **Tests**: default Vitest suite green as of 2026-07-08 (`218` files; `1732` passed; `24` skipped during `npm test -- --run` in the Brampton closeout pass)
 - **DB integration lane**: PR DB integration checks are green, local Supabase-backed retrieval, route, export, search, and policy tests remain healthy, and `npm run test:db:smoke` passed on 2026-07-07 with 2 DB smoke tests.
 - **Coverage**: `74.14%` statements / `78.85%` branches / `84.26%` functions / `74.14%` lines from `npm run test:coverage` on 2026-07-05
 - **Repo hygiene**: `npm run check:refs`, `npm run check:embeddings`, typed service DB write paths, dashboard server actions, and dependency cleanup are complete
@@ -126,7 +126,7 @@ or owner-owned items:
    - Admin-facing data-quality dashboard.
    - Browser-console follow-up only for new repeat findings from future browser QA runs.
 6. **Brampton bounded launch gates**
-   - Prepare and decide the broad Ontario/Canada coverage correction after the first seven Brampton rows are live.
+   - Broad Ontario/Canada coverage correction is applied and verified for the first launch.
    - Keep land acknowledgment and official/partner wording human-approved.
    - Queue deferred Brampton candidates and L2/L3 verification after the first launch is stable.
 
@@ -150,9 +150,9 @@ As of 2026-04-15, CareConnect follows the shared documentation-platform policy u
 
 ## Active Work
 
-### Brampton Constrained Multi-City Launch Closeout 🔄 ACTIVE
+### Brampton Constrained Multi-City Launch Closeout ✅ PRODUCTION COMPLETE
 
-**Status**: Foundation, first L1 records, local QA, merge, production DB migration, deployment, seven-row production data sync, and broad-record coverage correction are complete; public wording and future expansion remain gated
+**Status**: Foundation, first L1 records, local QA, merge, production DB migration, deployment, seven-row production data sync, broad-record coverage correction, and restore-evidence recording are complete; public wording and future expansion remain gated
 **Priority**: High, bounded
 **Created**: 2026-07-06
 
@@ -182,7 +182,7 @@ Brampton is the next supported-place step, not a broad regional expansion. Kings
 
 **Next agent-suitable work**
 
-1. Keep docs, tests, and data-validation evidence aligned with production correction evidence.
+1. Keep docs, tests, and data-validation evidence aligned if production state changes.
 2. Continue deferred Brampton verification only when a specific candidate is approved for the L1 workflow.
 
 **Human-gated work**

--- a/tests/scripts/check-v22-gate0-exit.test.ts
+++ b/tests/scripts/check-v22-gate0-exit.test.ts
@@ -5,6 +5,7 @@ import path from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 
 const scriptPath = path.join(process.cwd(), "scripts/check-v22-gate0-exit.sh")
+const gate0ScriptTimeoutMs = 15_000
 
 const tempRoots: string[] = []
 
@@ -233,15 +234,19 @@ describe("check-v22-gate0-exit", () => {
     expect(result.stdout).toContain("G0-8:PENDING")
   })
 
-  it("passes GO only when all required checks pass and evidence is structurally complete", () => {
-    const root = createFixtureRoot()
-    writeChecklist(root, { decision: "GO", g03: "pass", g08: "pass", blockingChecks: "" })
-    writeTracker(root, { ua1: "complete", ua3: "complete", c1Result: "complete" })
-    writeCompleteEvidence(root)
+  it(
+    "passes GO only when all required checks pass and evidence is structurally complete",
+    () => {
+      const root = createFixtureRoot()
+      writeChecklist(root, { decision: "GO", g03: "pass", g08: "pass", blockingChecks: "" })
+      writeTracker(root, { ua1: "complete", ua3: "complete", c1Result: "complete" })
+      writeCompleteEvidence(root)
 
-    const result = runGateCheck(root)
+      const result = runGateCheck(root)
 
-    expect(result.status, result.stdout + result.stderr).toBe(0)
-    expect(result.stdout).toContain("OK: v22.0 Gate 0 decision is GO and all required checks are pass.")
-  })
+      expect(result.status, result.stdout + result.stderr).toBe(0)
+      expect(result.stdout).toContain("OK: v22.0 Gate 0 decision is GO and all required checks are pass.")
+    },
+    gate0ScriptTimeoutMs
+  )
 })


### PR DESCRIPTION
## Summary
- mark the Brampton bounded launch closeout and broad coverage correction as production-complete in roadmap/readiness docs
- update current validation counts and residual-risk language after the approved production correction
- make the slow Gate 0 GO-path script test explicit about its timeout so full pre-push runs are stable

## Verification
- npm test -- tests/scripts/check-v22-gate0-exit.test.ts --run
- npm test -- tests/scripts/check-v22-evidence-intake.test.ts tests/scripts/check-v22-gate0-exit.test.ts --run
- npx prettier --check tests/scripts/check-v22-gate0-exit.test.ts docs/planning/roadmap.md docs/launch/brampton-readiness-report.md
- npm run check:refs
- git diff --check
- pre-push: npm run test -- --run (1732 passed | 24 skipped)
