### PR TITLE
docs: clarify Brampton rollout closeout posture

### DIFF
--- a/docs/launch/brampton-manual-qa.md
+++ b/docs/launch/brampton-manual-qa.md
@@ -1,7 +1,7 @@
 # Brampton Manual QA
 
 Date: 2026-07-06
-Updated: 2026-07-07
+Updated: 2026-07-08
 
 ## Environment
 
@@ -92,4 +92,5 @@ LD_LIBRARY_PATH=/tmp/careconnect-local-deps/usr/lib/x86_64-linux-gnu:${LD_LIBRAR
 
 - The user-space dependency path under `/tmp/careconnect-local-deps` is ephemeral; recreate it or install system packages before future local browser and DB smoke reruns.
 - Deferred Brampton draft services still require L1 approval before live data entry.
-- Production migration, deployment, land acknowledgment wording, and official relationship wording remain approval-gated.
+- Land acknowledgment wording and official relationship wording remain approval-gated.
+- Production rollback remains approval-gated; migration, deployment, seven-row data sync, and broad coverage correction were approved, applied, and smoke-tested on 2026-07-08.

--- a/docs/launch/brampton-rollout-checklist.md
+++ b/docs/launch/brampton-rollout-checklist.md
@@ -89,13 +89,13 @@ LD_LIBRARY_PATH=/tmp/careconnect-local-deps/usr/lib/x86_64-linux-gnu:${LD_LIBRAR
 - [x] Smoke test broad Ontario/Canada services after correction.
 - [x] Confirm no user search logging was introduced.
 
-## Rollback
+## Rollback Posture
 
-- [ ] Revert application deployment to prior release.
-- [ ] If data records caused the issue, remove or correct the approved Brampton records in a follow-up data commit.
+- Application rollback is not indicated after the successful deployment and smoke checks. If a future incident requires it, revert only after explicit approval through the documented app rollback path.
+- If approved Brampton data records cause a future issue, remove or correct them only through an approved follow-up data commit or an explicitly approved production correction.
 - [x] Prepare exact seven-ID data rollback for approval after the broad-service post-sync smoke miss; see `docs/launch/brampton-seven-id-data-rollback-prep.md`. Do not execute without explicit approval.
 - [x] Prepare broad-record correction rollback SQL. Do not execute without explicit approval after a failed approved correction smoke.
-- [ ] Do not roll back production schema without explicit database rollback approval.
+- Production schema rollback is not indicated and must not run without explicit database rollback approval.
 
 ## Post-Launch
 


### PR DESCRIPTION
## Summary
- remove stale manual-QA wording that still described production migration/deployment as approval-gated
- clarify rollback as prepared posture, not current unfinished rollout work

## Verification
- npx prettier --check docs/launch/brampton-manual-qa.md docs/launch/brampton-rollout-checklist.md
- npm run check:refs
- git diff --check
- pre-push: npm run test -- --run (1732 passed | 24 skipped)
