### PR TITLE
Test the calculateScore contract

### DIFF
--- a/docs/superpowers/plans/2026-07-10-search-scoring-contract-tests.md
+++ b/docs/superpowers/plans/2026-07-10-search-scoring-contract-tests.md
@@ -1,0 +1,39 @@
+# Search Scoring Contract Tests Implementation Plan
+
+**Goal:** Replace stale placeholder coverage for `calculateScore` with meaningful behavioral assertions without changing production behavior.
+
+**Architecture:** Exercise the exported `calculateScore` facade using the existing deterministic service fixture. Compare observable scores instead of duplicating internal calculations or coupling tests to incidental tokenization details.
+
+**Tech Stack:** TypeScript, Vitest, Next.js repository validation scripts.
+
+---
+
+### Task 1: Clarify the scoring facade contract
+
+**Files:**
+
+- Modify: `tests/lib/search/scoring.test.ts`
+
+**Steps:**
+
+1. Remove the obsolete placeholder label and comments.
+2. Assert that a relevant food query scores above zero.
+3. Assert that an unrelated query scores zero.
+4. Compare the same identity-tag query with and without opted-in matching user context; require the contextual score to be higher.
+5. Run the focused scoring test suites.
+
+### Task 2: Validate repository compatibility
+
+**Steps:**
+
+1. Run the search golden-set tests.
+2. Run formatting, lint, type-check, reference, and root checks.
+3. Inspect the diff for unintended production or data changes.
+
+### Task 3: Review and deliver
+
+**Steps:**
+
+1. Obtain an independent code review against this design.
+2. Address any findings and rerun affected validation.
+3. Commit, push, and open a focused pull request if all required checks pass.

--- a/docs/superpowers/specs/2026-07-10-search-scoring-contract-tests-design.md
+++ b/docs/superpowers/specs/2026-07-10-search-scoring-contract-tests-design.md
@@ -1,0 +1,26 @@
+# Search Scoring Contract Tests Design
+
+## Context
+
+`tests/lib/search/scoring.test.ts` still labels `calculateScore` as a placeholder and only proves that it returns a non-negative number. The implementation now delegates to the production keyword-scoring pipeline, so those assertions no longer describe or protect its behavior.
+
+## Decision
+
+Replace the placeholder assertions with focused contract tests that prove:
+
+- a relevant query produces a positive score;
+- an unrelated query produces no score; and
+- opted-in matching identity context increases the score relative to the same query without context.
+
+Use the existing fixture and public `calculateScore` API. Do not change ranking code, weights, service data, schemas, or production behavior.
+
+## Validation
+
+Run the focused scoring suites first, then the search golden set, lint, type-check, formatting, and repository reference/root checks. A passing test-only change demonstrates that the current implementation already satisfies the clarified contract.
+
+## Boundaries
+
+- No scoring-weight or search-behavior changes.
+- No curated data changes.
+- No browser, database, credential, or production dependency.
+- Keep the batch independently reviewable from other roadmap work.

--- a/tests/lib/search/scoring.test.ts
+++ b/tests/lib/search/scoring.test.ts
@@ -109,25 +109,28 @@ describe("Search Scoring", () => {
     })
   })
 
-  describe("calculateScore (Placeholder)", () => {
-    it("should return a non-negative score", () => {
-      // Current implementation is a placeholder but might have identity boost logic
-      const score = calculateScore(mockService, "query")
-      expect(score).toBeGreaterThanOrEqual(0)
+  describe("calculateScore", () => {
+    it("should score a relevant query", () => {
+      const score = calculateScore(mockService, "food")
+      expect(score).toBeGreaterThan(0)
     })
 
-    it("should apply identity boost", () => {
+    it("should return zero for an unrelated query", () => {
+      const score = calculateScore(mockService, "unrelated")
+      expect(score).toBe(0)
+    })
+
+    it("should increase the score for opted-in matching identity context", () => {
       const context: UserContext = {
         identities: ["indigenous"],
         ageGroup: "youth",
         hasOptedIn: true,
       }
-      // calculateScore has some identity boost logic in the placeholder
-      // but base score is 0. 0 * boost = 0.
-      // So this test might just verify it doesn't crash unless we modify the impl to have a base score.
-      // The impl creates 'score = 0' then multiplies, so it stays 0.
-      const score = calculateScore(mockService, "query", undefined, { userContext: context })
-      expect(score).toBe(0)
+
+      const baselineScore = calculateScore(mockService, "indigenous")
+      const contextualScore = calculateScore(mockService, "indigenous", undefined, { userContext: context })
+
+      expect(contextualScore).toBeGreaterThan(baselineScore)
     })
   })
 })


### PR DESCRIPTION
## Summary
- replace stale placeholder assertions for the public `calculateScore` facade
- prove relevant, unrelated, and opted-in identity-context scoring behavior
- document the bounded design and implementation plan

## Validation
- `npm test -- --run tests/lib/search/scoring.test.ts tests/unit/search/scoring.test.ts` (24 passed)
- `npm test -- --run tests/search/golden-set.test.ts` (61 passed)
- `npm test -- --run` (218 files; 1,734 passed; 24 credential-gated skips)
- `npm run lint`
- `npm run type-check`
- `npm run format:check`
- `npm run check:refs` (156 files)
- `npm run check:root`
- pre-commit and pre-push hooks

## Boundaries
- test and planning documentation only
- no production scoring, weights, service data, schema, or environment changes
- independently reviewed with no findings