### PR TITLE
Protect admin service saves with the circuit breaker

### DIFF
--- a/app/api/admin/save/route.ts
+++ b/app/api/admin/save/route.ts
@@ -6,6 +6,7 @@ import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import { env } from "@/lib/env"
 import { mapServiceToDatabaseUpsert } from "@/lib/service-db"
+import { withCircuitBreaker } from "@/lib/resilience/supabase-breaker"
 import type { Service } from "@/types/service"
 
 export async function POST(req: NextRequest) {
@@ -38,15 +39,19 @@ export async function POST(req: NextRequest) {
     }
 
     // 1. Fetch current data for audit log (optional but good practice)
-    const { data: oldService } = await supabase.from("services").select("*").eq("id", service.id).single()
+    const { data: oldService } = await withCircuitBreaker(async () => {
+      const result = await supabase.from("services").select("*").eq("id", service.id).single()
+      if (result.error && result.error.code !== "PGRST116") throw result.error
+      return result
+    })
 
     // 2. Transact to Supabase
     // We use upsert to create or update
-    const { error: upsertError } = await supabase.from("services").upsert(mapServiceToDatabaseUpsert(service))
-
-    if (upsertError) {
-      return createApiError(`Database error: ${upsertError.message}`, 500)
-    }
+    await withCircuitBreaker(async () => {
+      const result = await supabase.from("services").upsert(mapServiceToDatabaseUpsert(service))
+      if (result.error) throw result.error
+      return result
+    })
 
     // 3. Audit Log
     await supabase.from("audit_logs").insert({

--- a/docs/adr/016-performance-tracking-and-circuit-breaker.md
+++ b/docs/adr/016-performance-tracking-and-circuit-breaker.md
@@ -443,6 +443,9 @@ CIRCUIT_BREAKER_TIMEOUT=30000
 ### Phase 3: Complete Rollout (In Progress ⚠️)
 
 - [ ] Protect remaining API routes (POST, PUT, DELETE endpoints)
+  - [x] Protect the admin service-save read and upsert, including resolved Supabase errors.
+  - [ ] Decide transactional or explicitly degraded semantics before coupling post-save audit writes to the breaker.
+  - [ ] Continue with the remaining admin push/reindex and other direct Supabase mutation routes.
 - [ ] Protect authorization checks (consider trade-offs)
 - [ ] Add authentication to health check endpoint
 - [ ] Add `/api/v1/metrics` endpoint (dev/staging only)

--- a/docs/superpowers/plans/2026-07-10-admin-save-circuit-breaker.md
+++ b/docs/superpowers/plans/2026-07-10-admin-save-circuit-breaker.md
@@ -1,0 +1,55 @@
+# Admin Save Circuit Breaker Implementation Plan
+
+**Goal:** Close one explicit ADR-016 mutation-route resilience gap by protecting the admin service-save database operations.
+
+**Architecture:** Keep authentication and authorization outside this route-level change because centralized authorization already applies its risk-aware circuit-breaker policy. Wrap the critical service read and upsert locally with the shared Supabase breaker and no fallback, converting returned Supabase errors into rejected operations. Preserve the existing mixed audit path: resolved Supabase errors are ignored, while rejected/network failures can already return `500` after the primary upsert persists. Consistent transactional audit semantics are separate work.
+
+**Tech Stack:** Next.js App Router, TypeScript, Supabase, Vitest.
+
+---
+
+### Task 1: Add failing route contract tests
+
+**Files:**
+
+- Modify: `tests/api/admin/save.test.ts`
+
+**Steps:**
+
+1. Mock `withCircuitBreaker` as a pass-through wrapper.
+2. Require the successful update flow to invoke it for the service read and upsert only.
+3. Require read and upsert wrapper rejection to return a handled `500` before later mutations.
+4. Prove resolved Supabase errors reject inside the wrapper, not after it returns.
+5. Run the focused test and confirm the new expectations fail before production changes.
+
+### Task 2: Protect admin save operations
+
+**Files:**
+
+- Modify: `app/api/admin/save/route.ts`
+
+**Steps:**
+
+1. Import `withCircuitBreaker`.
+2. Wrap the existing-service read and service upsert independently with no fallback.
+3. Reject non-`PGRST116` read errors and all upsert errors inside the wrapper.
+4. Run the focused route test until green.
+
+### Task 3: Record partial ADR progress
+
+**Files:**
+
+- Modify: `docs/adr/016-performance-tracking-and-circuit-breaker.md`
+
+**Steps:**
+
+1. Add a checked nested item for the admin save route.
+2. Leave the overall remaining-route rollout item unchecked and name representative remaining work.
+
+### Task 4: Validate and deliver
+
+**Steps:**
+
+1. Run related resilience/integration tests.
+2. Run format, lint, type-check, reference, root, diff, and full Vitest checks.
+3. Obtain independent review, address findings, then commit, push, and open a focused PR.

--- a/docs/superpowers/specs/2026-07-10-admin-save-circuit-breaker-design.md
+++ b/docs/superpowers/specs/2026-07-10-admin-save-circuit-breaker-design.md
@@ -1,0 +1,25 @@
+# Admin Save Circuit Breaker Design
+
+## Context
+
+ADR-016 keeps Phase 3 open until remaining mutation routes use the shared Supabase circuit breaker. `POST /api/admin/save` is an authenticated, admin-only service mutation route whose critical service read and upsert currently call Supabase directly.
+
+## Decision
+
+Protect the service read and upsert with `withCircuitBreaker` and no fallback. Convert their resolved Supabase errors into rejected operations so the breaker observes ordinary database failures. Treat the expected `PGRST116` read result as a create path, not a breaker failure. Authentication, RBAC, validation, and database mapping remain unchanged.
+
+Keep the post-save audit insert and admin-action RPC on their existing mixed path: resolved Supabase errors are ignored, while rejected/network failures bubble to the route catch and can return `500` after the primary upsert persisted. Guarding them independently would not resolve that non-atomic response risk; consistent audit semantics require a separate transaction/schema decision. Add route-level tests that prove the two critical operations use the shared wrapper, that resolved database errors reject inside it, and that read/upsert wrapper rejection stops before later mutations. Circuit state transitions remain covered by the circuit-breaker library tests.
+
+Record this route as partial Phase 3 progress in ADR-016 while leaving the broader remaining-route checkbox open.
+
+## Boundaries
+
+- No curated service-data, schema, migration, RBAC, environment, or production changes.
+- No fallback for the service read, upsert, or authorization.
+- No global circuit-breaker semantic changes.
+- No transactional or response-contract redesign for post-save audit writes.
+- Do not claim other mutation routes are protected.
+
+## Validation
+
+Run the focused route test first, related circuit-breaker tests, then formatting, lint, type-check, repository checks, and the full Vitest suite before delivery.

--- a/tests/api/admin/save.test.ts
+++ b/tests/api/admin/save.test.ts
@@ -4,6 +4,13 @@ import { createMockRequest, parseResponse } from "../../utils/api-test-utils"
 import { assertAdminRole } from "@/lib/auth/authorization"
 // createServerClient import removed
 
+const mockWithCircuitBreaker = vi.hoisted(() => vi.fn())
+const observedBreakerErrors: unknown[] = []
+
+vi.mock("@/lib/resilience/supabase-breaker", () => ({
+  withCircuitBreaker: mockWithCircuitBreaker,
+}))
+
 // Mock next/headers
 vi.mock("next/headers", () => ({
   cookies: vi.fn().mockReturnValue({
@@ -40,6 +47,15 @@ vi.mock("@/lib/auth/authorization", () => ({
 describe("Admin Save API", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    observedBreakerErrors.length = 0
+    mockWithCircuitBreaker.mockImplementation(async (operation: () => Promise<unknown>) => {
+      try {
+        return await operation()
+      } catch (error) {
+        observedBreakerErrors.push(error)
+        throw error
+      }
+    })
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: "admin-id" } }, error: null })
     vi.mocked(assertAdminRole).mockResolvedValue(undefined as any)
 
@@ -101,6 +117,72 @@ describe("Admin Save API", () => {
         operation: "UPDATE",
       })
     )
+    expect(mockWithCircuitBreaker).toHaveBeenCalledTimes(2)
+    expect(mockWithCircuitBreaker.mock.calls.every((call) => call.length === 1)).toBe(true)
+    expect(mockSupabase.rpc).toHaveBeenCalledWith("log_admin_action", expect.any(Object))
+  })
+
+  it("returns 500 and stops the mutation when the circuit breaker rejects", async () => {
+    mockWithCircuitBreaker.mockRejectedValueOnce(new Error("Circuit open"))
+
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ service: { id: "1", name: "New" } }),
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(500)
+    expect(mockQueryBuilder.upsert).not.toHaveBeenCalled()
+  })
+
+  it("returns 500 and skips audit writes when the upsert circuit is open", async () => {
+    mockWithCircuitBreaker
+      .mockImplementationOnce((operation: () => Promise<unknown>) => operation())
+      .mockRejectedValueOnce(new Error("Circuit open"))
+
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ service: { id: "1", name: "New" } }),
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(500)
+    expect(mockQueryBuilder.upsert).not.toHaveBeenCalled()
+    expect(mockQueryBuilder.insert).not.toHaveBeenCalled()
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
+  })
+
+  it("returns 500 when the service read resolves with a database error", async () => {
+    mockQueryBuilder.single.mockResolvedValue({ data: null, error: { code: "XX000", message: "read failed" } })
+
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ service: { id: "1", name: "New" } }),
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(500)
+    expect(mockQueryBuilder.upsert).not.toHaveBeenCalled()
+    expect(observedBreakerErrors).toEqual([expect.objectContaining({ code: "XX000", message: "read failed" })])
+  })
+
+  it("returns 500 and skips audit writes when the upsert resolves with a database error", async () => {
+    mockQueryBuilder.upsert.mockResolvedValue({ error: { code: "XX000", message: "upsert failed" } })
+
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ service: { id: "1", name: "New" } }),
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(500)
+    expect(mockQueryBuilder.insert).not.toHaveBeenCalled()
+    expect(mockSupabase.rpc).not.toHaveBeenCalled()
+    expect(observedBreakerErrors).toEqual([expect.objectContaining({ code: "XX000", message: "upsert failed" })])
   })
 
   it("adds new service if not found (CREATE)", async () => {


### PR DESCRIPTION
## Summary
- protect the admin service read and upsert with the shared Supabase circuit breaker
- convert resolved Supabase database errors into breaker-visible failures while preserving the expected not-found create path
- add route tests for read/upsert circuit rejection and resolved database errors
- record partial ADR-016 rollout progress and the remaining audit-transaction decision

## Validation
- `npm test -- --run tests/api/admin/save.test.ts tests/lib/resilience/circuit-breaker.test.ts tests/integration/circuit-breaker-db.test.ts` (35 passed)
- `npm test -- --run` (218 files; 1,737 passed; 24 credential-gated skips)
- `npm run lint`
- `npm run type-check`
- `npm run format:check`
- `npm run check:refs` (156 files)
- `npm run check:root`
- pre-commit and pre-push hooks

## Boundaries
- no service-data, schema, migration, RBAC, environment, or production changes
- post-save audit calls retain their existing mixed non-transactional semantics; ADR-016 keeps that decision and other routes open
- independently reviewed after two correction passes; final review has no findings