### PR TITLE
Reconcile ADR-017 with authorization resilience behavior

### DIFF
--- a/docs/adr/017-authorization-resilience-strategy.md
+++ b/docs/adr/017-authorization-resilience-strategy.md
@@ -2,43 +2,68 @@
 
 ## Status
 
-Accepted
+Accepted and implemented
 
 ## Context
 
-Our application relies on Supabase for data storage and authorization checks (Row Level Security and application-level role checks). When the database is experiencing high latency or downtime, authorization checks typically fail, causing the entire application to become unusable (Fail-Closed).
+CareConnect relies on Supabase for data storage and application-level authorization checks in addition to Row Level Security. When Supabase is unavailable, authorization checks must fail quickly without turning a resilience fallback into an authorization bypass.
 
-We recently implemented a Circuit Breaker pattern to protect the system from cascading failures during database outages. We need to decide how authorization checks should behave when the circuit is OPEN (fast-failing).
+The shared Supabase circuit breaker can reject an operation with `CircuitOpenError`. Authorization helpers therefore need explicit, reviewable behavior for high-, medium-, and low-risk callers.
 
 ## Decision
 
-We will implement a **Tiered Circuit Breaker Protection** strategy for authorization checks.
+Use tiered circuit-breaker handling in `lib/auth/authorization.ts`:
 
-### 1. High-Risk Operations (Mutations)
+1. **High risk** defaults to fail-closed. Mutation, permission, ownership, and admin assertions do not authorize access when the circuit is open.
+2. **Medium risk** also fails closed. The distinct label records intent for organization-membership checks without weakening the current security behavior.
+3. **Low risk** may handle `CircuitOpenError` with a helper-specific fallback for non-authoritative UI/read behavior. Other errors are not converted into low-risk success by the shared fallback handler.
 
-**Strategy:** Fail-Closed
-**Rationale:** Security takes precedence. We cannot allow users to modify, delete, or transfer resources if we cannot verify their permissions with 100% certainty.
-**Behavior:** When the circuit is OPEN, `assertServiceOwnership` and similar mutation checks will throw a `CircuitOpenError` (or wrap it in an `AuthorizationError`), effectively blocking the action.
+Low risk is not permission to authorize a mutation. Production call sites must not pass `"low"` to admin, permission, ownership, membership, or other access-gating assertions. The current source-policy test detects direct, unaliased calls to `assertAdminRole`, `assertPermission`, and `assertServiceOwnership` when they contain a literal `"low"` argument. Aliased imports, namespace/property calls, nonliteral risk arguments, and other helpers still depend on code review.
 
-### 2. Low-Risk Operations (Reads/Navigation)
+### Implemented defaults and circuit-open outcomes
 
-**Strategy:** Fail-Closed (Default) with Future Option for Fail-Open
-**Rationale:** Currently, most read operations also require the database to fetch the data being authorized. If the DB is down to the point of tripping the breaker, the data fetch will likely fail anyway. Therefore, failing closed on auth is safe and consistent.
-**Future Proofing:** We will structure the code to allow "Low Risk" checks to potentially fail-open (log only) in the future if we move to cached data or search-index based reads where the DB might be down but data is still accessible.
+| Helper                         | Default risk | Circuit-open outcome at default                                    | Outcome if explicitly overridden to `low`                     |
+| ------------------------------ | ------------ | ------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `assertServiceOwnership`       | `high`       | Throws; the mutation/access assertion fails closed.                | Returns `true`; forbidden for protected or mutating paths.    |
+| `assertOrganizationMembership` | `medium`     | Throws; membership cannot be asserted.                             | Returns `true`; forbidden for access-gating paths.            |
+| `assertAdminRole`              | `high`       | Denies admin access through an `AuthorizationError`.               | Returns `true`; forbidden for protected or mutating paths.    |
+| `getEffectivePermissions`      | `low`        | Returns no edit/delete/private-view permissions and a `null` role. | Same restrictive fallback.                                    |
+| `assertPermission`             | `high`       | Throws; the requested permission is not granted.                   | Returns `viewer`; forbidden as proof of requested permission. |
+| `getUserOrganizationRole`      | `low`        | Returns `null`.                                                    | Same restrictive fallback.                                    |
+| `isUserAdmin`                  | `high`       | Returns `false`; non-circuit errors also deny admin status.        | Returns `true`; forbidden for protected or mutating paths.    |
+
+Some assertion helpers retain an explicit low-risk parameter for non-authoritative presentation or navigation use. Their permissive fallback values must never be used to gate a write or protected resource. The default risk levels, production-call-site policy, and Row Level Security remain the security boundary.
+
+## Implementation Evidence
+
+- `lib/auth/authorization.ts` wraps its Supabase table-backed checks with `withCircuitBreaker` and applies helper-specific risk defaults and fallbacks. `assertAdminRole` calls `supabase.auth.getUser()` outside the breaker before delegating its table lookup to `isUserAdmin`.
+- `tests/lib/auth/authorization.test.ts` covers high- and medium-risk fail-closed behavior plus representative low-risk fallbacks; it does not exercise every explicit override shown in the source-derived matrix.
+- `tests/lib/auth/authorization-policy.test.ts` rejects direct, unaliased calls with a literal `"low"` argument for `assertAdminRole`, `assertPermission`, and `assertServiceOwnership` under `app`, `lib`, and `scripts`. It does not detect aliases, property calls, or computed/nonliteral risk arguments.
+- Protected server actions and routes continue to call mutation/admin helpers at their fail-closed defaults.
 
 ## Consequences
 
 ### Positive
 
-- **Security:** Strict security guarantees are maintained. No unauthorized mutations can occur during outages.
-- **Resilience:** Fast failure prevents authorization checks from hanging and consuming resources when the DB is down.
-- **Observability:** Authorization failures due to circuit breaking are distinctly logged.
+- Mutations and protected access remain denied when authorization cannot be verified.
+- Circuit-open failures return quickly instead of waiting on repeated database timeouts.
+- Non-authoritative permission/role display can degrade to restrictive values.
+- Explicit defaults and a limited source-policy test make common direct low-risk mutation-authorization mistakes reviewable.
 
 ### Negative
 
-- **Availability:** During database glitches, users will not be able to manage their services. This is acceptable as the alternative (security vulnerability) is worse.
+- Users cannot manage services or enter protected areas during a database outage.
+- Low-risk parameters remain powerful and require call-site discipline; the current source-policy guard does not cover every helper or call shape that can carry a risk override and must be extended if those forms become access gates or new helpers are added.
+- Fallback state is process-local because the underlying circuit breaker is process-local.
 
-## Implementation
+## Validation
 
-We will modify `lib/auth/authorization.ts` to wrap Supabase calls in `withCircuitBreaker`.
-We will add a `riskLevel` parameter to authorization functions to support the tiered approach, defaulting to `'high'`.
+Run:
+
+```bash
+npm test -- --run tests/lib/auth/authorization.test.ts tests/lib/auth/authorization-policy.test.ts
+npm run type-check
+npm run lint
+```
+
+Any future change that permits a low-risk fallback in a protected or mutating path requires a separate security review and an update to this ADR and its policy tests.

--- a/docs/superpowers/plans/2026-07-10-adr017-authorization-resilience-truth.md
+++ b/docs/superpowers/plans/2026-07-10-adr017-authorization-resilience-truth.md
@@ -1,0 +1,39 @@
+# ADR-017 Authorization Resilience Truth Implementation Plan
+
+**Goal:** Make ADR-017 accurately describe the implemented authorization resilience policy without changing runtime behavior.
+
+**Architecture:** Derive the documented matrix directly from `lib/auth/authorization.ts` defaults and fallback branches, then verify it against focused unit and source-policy tests.
+
+**Tech Stack:** Markdown, TypeScript authorization helpers, Vitest documentation and policy tests.
+
+---
+
+### Task 1: Reconcile the ADR
+
+**Files:**
+
+- Modify: `docs/adr/017-authorization-resilience-strategy.md`
+
+**Steps:**
+
+1. Mark the accepted decision as implemented.
+2. Document high-, medium-, and low-risk behavior.
+3. Add the helper default/outcome matrix.
+4. Record the low-risk assertion boundary and source-policy guard.
+5. Replace future-tense implementation statements with current evidence and validation commands.
+
+### Task 2: Validate documentation truth
+
+**Steps:**
+
+1. Run focused authorization and authorization-policy tests.
+2. Run documentation hygiene, formatting, lint, type-check, references, and root checks.
+3. Confirm the diff contains no runtime, RBAC, service-data, schema, or environment changes.
+
+### Task 3: Review and deliver
+
+**Steps:**
+
+1. Obtain an independent evidence review of the ADR matrix and safety wording.
+2. Address findings and rerun affected checks.
+3. Commit, push, and open a focused pull request if validation is green.

--- a/docs/superpowers/specs/2026-07-10-adr017-authorization-resilience-truth-design.md
+++ b/docs/superpowers/specs/2026-07-10-adr017-authorization-resilience-truth-design.md
@@ -1,0 +1,15 @@
+# ADR-017 Authorization Resilience Truth Design
+
+## Context
+
+ADR-017 describes low-risk authorization fallback as future work and says all reads currently fail closed. The implementation already has high-, medium-, and low-risk defaults, restrictive low-risk query fallbacks, explicit permissive assertion fallbacks, and a limited source-policy guard for direct literal-low calls to three high-risk helpers.
+
+## Decision
+
+Reconcile ADR-017 with the current implementation and tests. Document the helper-by-helper default matrix, distinguish circuit-open handling from ordinary errors, and state that low-risk assertion fallbacks are never valid for mutation or protected-resource authorization.
+
+Keep this batch documentation-only. Do not change RBAC, authorization behavior, fallback values, call sites, or the circuit breaker.
+
+## Validation
+
+Run the focused authorization and policy tests to verify the cited behavior, then formatting, lint, type-check, documentation hygiene, reference, and root checks. Inspect the diff to confirm no runtime or RBAC files changed.


### PR DESCRIPTION
## Summary
- reconcile ADR-017 with the implemented high/medium/low authorization-resilience policy
- document each helper's default and explicit-low circuit-open outcome
- state the exact limits of low-risk policy-test and unit-test coverage
- preserve all runtime, RBAC, call-site, and fallback behavior

## Validation
- `npm test -- --run tests/lib/auth/authorization.test.ts tests/lib/auth/authorization-policy.test.ts tests/unit/documentation-hygiene.test.ts` (39 passed)
- `npm test -- --run` (218 files; 1,733 passed; 24 credential-gated skips)
- `npm run lint`
- `npm run type-check`
- `npm run format:check`
- `npm run check:refs` (156 files)
- `npm run check:root`
- pre-commit and pre-push hooks

## Boundaries
- documentation only; no authorization, RBAC, data, schema, environment, or production changes
- explicitly records that the current source-policy guard is limited to direct unaliased literal-low calls for three helpers
- independently reviewed twice; final review has no findings