### PR TITLE
Handle invalid notification request JSON

### DIFF
--- a/app/api/v1/notifications/subscribe/route.ts
+++ b/app/api/v1/notifications/subscribe/route.ts
@@ -7,7 +7,21 @@ import { checkRateLimit, createRateLimitHeaders, getClientIp } from "@/lib/rate-
 
 export async function POST(req: NextRequest) {
   try {
-    const { subscription, categories, locale } = (await req.json()) as {
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+      }
+      throw error
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return NextResponse.json({ error: "Invalid subscription payload" }, { status: 400 })
+    }
+
+    const { subscription, categories, locale } = body as {
       subscription: { endpoint: string; keys: { p256dh: string; auth: string } }
       categories: NotificationCategory[]
       locale: string

--- a/app/api/v1/notifications/unsubscribe/route.ts
+++ b/app/api/v1/notifications/unsubscribe/route.ts
@@ -6,7 +6,21 @@ import { checkRateLimit, createRateLimitHeaders, getClientIp } from "@/lib/rate-
 
 export async function POST(req: NextRequest) {
   try {
-    const { endpoint } = (await req.json()) as { endpoint: string }
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+      }
+      throw error
+    }
+
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return NextResponse.json({ error: "Missing endpoint" }, { status: 400 })
+    }
+
+    const { endpoint } = body as { endpoint: string }
 
     if (!endpoint) {
       return NextResponse.json({ error: "Missing endpoint" }, { status: 400 })

--- a/docs/maintenance-audit.md
+++ b/docs/maintenance-audit.md
@@ -475,12 +475,15 @@ New untracked files to review:
 
 Generated files: `npm run build` regenerated embeddings during postbuild, but `data/embeddings.json` remained unchanged in `git diff --stat`.
 
+## Completed Follow-up
+
+- **Notification JSON errors (2026-07-10):** The subscribe and unsubscribe routes now return their existing flat `400` envelopes for malformed or non-object JSON before rate limiting or database setup. A shared parser was intentionally not added because the two routes use flat envelopes that are incompatible with the shared nested API-error helper; revisit an abstraction only when enough routes share the same response and validation contract.
+
 ## Remaining Recommendations
 
 - Install Python docs dependencies from `requirements.txt` and run `mkdocs build`.
 - Run Playwright/accessibility checks during an intentional browser validation window or via CI/manual dispatch.
 - Review `npm outdated --long` through Dependabot or a focused dependency-upgrade branch with migration notes and full verification.
-- Consider a focused API ergonomics pass to add a shared safe JSON parsing helper to routes with custom response shapes.
 - Consider a focused CSP hardening pass for nonce/inline-script reduction while preserving WebLLM support.
 
 ## Risks, Assumptions, And Intentionally Unchanged Areas

--- a/docs/superpowers/plans/2026-07-10-notification-json-errors.md
+++ b/docs/superpowers/plans/2026-07-10-notification-json-errors.md
@@ -1,0 +1,56 @@
+# Notification JSON Error Handling Implementation Plan
+
+**Goal:** Return stable client errors for malformed and non-object JSON on notification subscription routes without changing existing response envelopes.
+
+**Architecture:** Keep parsing local to each flat-envelope route. Separate syntax failure from payload-shape validation, and reject both before rate limiting or database work.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest.
+
+---
+
+### Task 1: Add failing request-contract tests
+
+**Files:**
+
+- Modify: `tests/api/v1/notifications/subscribe.test.ts`
+- Modify: `tests/api/v1/notifications/unsubscribe.test.ts`
+
+**Steps:**
+
+1. Send malformed JSON and require exact `400 { error: "Invalid JSON" }` responses.
+2. Send JSON `null` and require each route's existing invalid-payload response.
+3. Assert invalid bodies do not reach rate limiting or Supabase setup.
+4. Run both route suites and confirm the new tests fail before implementation.
+
+### Task 2: Handle JSON input locally
+
+**Files:**
+
+- Modify: `app/api/v1/notifications/subscribe/route.ts`
+- Modify: `app/api/v1/notifications/unsubscribe/route.ts`
+
+**Steps:**
+
+1. Parse the request body in a nested `try/catch`.
+2. Return the flat malformed-JSON response on parse failure.
+3. Reject non-object JSON through existing payload-specific responses.
+4. Preserve all downstream route behavior.
+
+### Task 3: Close the maintenance recommendation
+
+**Files:**
+
+- Modify: `docs/maintenance-audit.md`
+
+**Steps:**
+
+1. Record the two-route malformed-JSON correction.
+2. Record why a shared helper remains intentionally deferred.
+
+### Task 4: Validate and deliver
+
+**Steps:**
+
+1. Run focused route tests, format, lint, type-check, references, root hygiene, and the full suite.
+2. Confirm no data, schema, RBAC, environment, or unrelated API changes.
+3. Obtain independent review, address findings, commit, push, and open a focused PR.

--- a/docs/superpowers/specs/2026-07-10-notification-json-errors-design.md
+++ b/docs/superpowers/specs/2026-07-10-notification-json-errors-design.md
@@ -1,0 +1,23 @@
+# Notification JSON Error Handling Design
+
+## Context
+
+The notification subscribe and unsubscribe routes cast `await req.json()` directly inside broad server-error handlers. Malformed JSON and the valid JSON value `null` therefore produce `500` responses even though both are client-input errors.
+
+The routes intentionally use flat `{ error: string }` envelopes. The shared API error helper uses a different nested envelope, so adopting it here would be a public contract change.
+
+## Decision
+
+Parse each request body in a small route-local `try/catch` before rate limiting or database access:
+
+- malformed JSON returns `400 { "error": "Invalid JSON" }`;
+- a non-object JSON value follows the route's existing invalid-payload response;
+- valid object, rate-limit, database, and success behavior remains unchanged.
+
+Do not add content-type enforcement in this batch. These routes currently accept syntactically valid JSON regardless of the header, and changing that compatibility contract is separate work.
+
+Do not add a shared parser abstraction for two routes with flat envelopes. Record the decision against the maintenance recommendation; revisit a shared helper only when enough routes share compatible response and validation contracts.
+
+## Validation
+
+Add failing regression tests first for malformed and `null` bodies, including proof that rate limiting and Supabase setup are not reached. Run both route suites, formatting, lint, type-check, repository checks, and the full Vitest suite before delivery.

--- a/tests/api/v1/notifications/subscribe.test.ts
+++ b/tests/api/v1/notifications/subscribe.test.ts
@@ -68,6 +68,35 @@ describe("Notifications Subscribe API", () => {
     expect(res.status).toBe(400)
   })
 
+  it("returns 400 for malformed JSON before rate limiting or database setup", async () => {
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: "{",
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON" })
+    expect(res.headers.get("content-type")).toContain("application/json")
+    expect(checkRateLimit).not.toHaveBeenCalled()
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
+  it("returns the existing invalid-payload response for JSON null", async () => {
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: "null",
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "Invalid subscription payload" })
+    expect(checkRateLimit).not.toHaveBeenCalled()
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
   it("inserts new subscription if not found", async () => {
     mockBuilder.single.mockResolvedValue({ data: null, error: null })
     // Insert needs to behave as a promise resolving to null error

--- a/tests/api/v1/notifications/unsubscribe.test.ts
+++ b/tests/api/v1/notifications/unsubscribe.test.ts
@@ -42,6 +42,35 @@ describe("Notifications Unsubscribe API", () => {
     expect(res.status).toBe(400)
   })
 
+  it("returns 400 for malformed JSON before rate limiting or database setup", async () => {
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: "{",
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "Invalid JSON" })
+    expect(res.headers.get("content-type")).toContain("application/json")
+    expect(checkRateLimit).not.toHaveBeenCalled()
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
+  it("returns the existing missing-endpoint response for JSON null", async () => {
+    const req = createMockRequest("http://localhost", {
+      method: "POST",
+      body: "null",
+      headers: { "Content-Type": "application/json" },
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "Missing endpoint" })
+    expect(checkRateLimit).not.toHaveBeenCalled()
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
   it("deletes subscription and returns 200", async () => {
     mockSupabase.eq.mockResolvedValue({ error: null })
 


### PR DESCRIPTION
## Summary
- return flat 400 errors for malformed notification request JSON
- route valid non-object JSON through the existing payload-specific errors
- ensure invalid bodies stop before rate limiting and Supabase setup
- close the maintenance recommendation with the reason a shared parser is not yet appropriate

## Validation
- `npm test -- --run tests/api/v1/notifications/subscribe.test.ts tests/api/v1/notifications/unsubscribe.test.ts` (13 passed)
- `npm test -- --run` (218 files; 1,737 passed; 24 credential-gated skips)
- `npm run lint`
- `npm run type-check`
- `npm run format:check`
- `npm run check:refs` (156 files)
- `npm run check:root`
- pre-commit and pre-push hooks

## Boundaries
- preserves flat response envelopes, valid-object behavior, rate-limit headers, database behavior, and content-type compatibility
- no shared API envelope migration or nested schema redesign
- no data, schema, RBAC, environment, or production changes
- independently reviewed with no findings