### PR TITLE
test: verify pilot replay against disposable database

### DIFF
--- a/docs/runbooks/pilot-event-replay.md
+++ b/docs/runbooks/pilot-event-replay.md
@@ -1,6 +1,6 @@
 # Runbook Summary: Pilot Event Replay and Duplicate Suppression
 
-**Last Updated:** 2026-06-12
+**Last Updated:** 2026-07-10
 
 This public summary defines replay criteria for v22 pilot event submissions.
 It intentionally excludes production database access steps, private dashboard
@@ -59,7 +59,7 @@ as idempotent duplicate retries.
 
 ## Verification Standard
 
-F3 remains unverified until both conditions are true:
+F3 requires both conditions:
 
 1. Unit/API/storage tests confirm deterministic, privacy-safe replay
    fingerprints and supplied-ID duplicate handling.
@@ -67,6 +67,12 @@ F3 remains unverified until both conditions are true:
    by storage, such as through a database unique constraint, conflict-handling
    write path, or an equivalent trusted persistence mechanism.
 
-The current repo-local policy satisfies the first condition only. Live repeated
-submission evidence against a real backing store is still required before F3 can
-be marked verified.
+Both conditions are now covered. `tests/db/pilot-replay.test.ts` races two
+authenticated writes with the same supplied UUID against the disposable
+Supabase integration stack. The test requires exactly one successful insert,
+one idempotent duplicate result, and exactly one persisted row. GitHub's
+`test-db-integration` job passed this evidence on 2026-07-10.
+
+This closes the repository's F3 verification method for the disposable test
+stack only. It is not production-schema evidence; production assumptions still
+require a separate read-only live-schema preflight before any operational use.

--- a/docs/security/v22-0-offline-local-threat-model.md
+++ b/docs/security/v22-0-offline-local-threat-model.md
@@ -1,6 +1,6 @@
 ---
 status: stable
-last_updated: 2026-06-12
+last_updated: 2026-07-10
 owner: jer
 tags: [security, v22.0, threat-model, offline, privacy]
 ---
@@ -58,7 +58,7 @@ Out of scope:
 | ---------- | -------- | ---------------------------------------------------------------------------------------------- | --------------------- | ---------- | --------------------------------------------------------- | -------- |
 | F1         | high     | Enforce local queue payload minimization (no personal contact fields, no free-text notes)      | Engineering           | 2026-03-21 | Schema + payload inspection against pilot event contracts | no       |
 | F2         | high     | Confirm expiry and clear-on-sign-out behavior for pilot drafts in local storage                | Engineering           | 2026-03-21 | Manual QA scenario + unit tests around storage cleanup    | no       |
-| F3         | medium   | Add replay detection criteria (idempotency key + duplicate event suppression) to pilot runbook | Engineering           | 2026-03-21 | Integration test using repeated submission payload        | no       |
+| F3         | medium   | Add replay detection criteria (idempotency key + duplicate event suppression) to pilot runbook | Engineering           | 2026-03-21 | Integration test using repeated submission payload        | yes      |
 | F4         | medium   | Ensure stale data timestamp surfacing in pilot UI/operations process                           | Product + Engineering | 2026-03-21 | Focused component tests + offline UI walkthrough evidence | yes      |
 | F5         | medium   | Define local corruption recovery steps in runbook (resync + queued item audit)                 | Engineering           | 2026-03-21 | Documented runbook step + dry-run execution               | no       |
 
@@ -75,6 +75,12 @@ production-readiness evidence gates.
 | F3         | `lib/pilot/event-replay-policy.ts`, `lib/pilot/storage.ts`, pilot event routes, `tests/lib/pilot/event-replay-policy.test.ts`, `tests/lib/pilot/storage.test.ts`, route tests                                                                                                                                                                                                 | Replay criteria, deterministic privacy-safe fingerprints, and supplied-ID primary-key retry handling are unit/API/storage covered. Non-primary duplicate constraints are not suppressed as idempotent retries. Live repeated-submission integration evidence remains missing, so `Verified` stays `no`.                                          |
 | F4         | Existing threat-model record                                                                                                                                                                                                                                                                                                                                                  | Previously verified stale-state surfacing remains recorded as `yes`; this pass did not re-open it.                                                                                                                                                                                                                                               |
 | F5         | `docs/runbooks/offline-local-recovery.md`, `lib/offline/local-recovery-audit.ts`, `tests/lib/offline/local-recovery-audit.test.ts`, `lib/offline/feedback.ts`, `tests/lib/offline/feedback.test.ts`, `lib/offline/db.ts`, `lib/offline/sync.ts`, `tests/unit/lib/offline/sync.test.ts`, `components/offline/OfflineSync.tsx`, `tests/components/offline/OfflineSync.test.tsx` | A public-safe recovery workflow and aggregate audit helper now cover queue counts, cache counts, sync metadata, non-destructive re-sync, destructive-clearing safeguards, API-schema validation before feedback queue storage/replay, and sanitized sync failure metadata. Dry-run execution evidence remains missing, so `Verified` stays `no`. |
+
+## 2026-07-10 F3 Backing-Store Evidence
+
+`tests/db/pilot-replay.test.ts` now runs in the disposable Supabase integration lane. It launches two authenticated owner writes concurrently with the same client-supplied event UUID, verifies exactly one succeeds and one real primary-key conflict is classified as an idempotent duplicate, and confirms through a service-role read that exactly one row persists. GitHub's `test-db-integration` job passed this test on 2026-07-10, satisfying F3's stated integration verification method.
+
+This evidence verifies the repository's deterministic disposable-database contract. It does not assert that any production schema or environment matches the tested migrations.
 
 ## Validation Checklist
 

--- a/docs/superpowers/plans/2026-07-10-pilot-replay-db-evidence.md
+++ b/docs/superpowers/plans/2026-07-10-pilot-replay-db-evidence.md
@@ -6,6 +6,8 @@
 
 **Tech Stack:** TypeScript, Vitest, Supabase JS, disposable local Supabase/PostgreSQL.
 
+**Status:** Completed on 2026-07-10. GitHub's disposable `test-db-integration` lane passed the concurrent replay test; the regular suite passed 1,733 tests with 24 skips, and lint, type-check, format, references, root hygiene, and the threat-model consistency guard passed locally.
+
 ---
 
 ### Task 1: Add the failing DB integration contract

--- a/docs/superpowers/plans/2026-07-10-pilot-replay-db-evidence.md
+++ b/docs/superpowers/plans/2026-07-10-pilot-replay-db-evidence.md
@@ -1,0 +1,56 @@
+# Pilot Replay Database Evidence Implementation Plan
+
+**Goal:** Close the repo-local evidence gap for F3 supplied-ID replay suppression against a disposable real backing store.
+
+**Architecture:** Exercise the existing `insertContactAttempt` storage path through an authenticated local Supabase client, verify the actual primary-key conflict is mapped to an idempotent duplicate, and query the table with the disposable service-role client to prove only one row persists.
+
+**Tech Stack:** TypeScript, Vitest, Supabase JS, disposable local Supabase/PostgreSQL.
+
+---
+
+### Task 1: Add the failing DB integration contract
+
+**Files:**
+
+- Modify: `tests/db/helpers.ts`
+- Create: `tests/db/pilot-replay.test.ts`
+
+**Steps:**
+
+1. Expose the deterministic seeded organization ID from the DB helper.
+2. Add a privacy-safe fixed contact-attempt payload.
+3. Clean up the fixed event before the test.
+4. Launch two identical `insertContactAttempt` writes concurrently with the seeded authenticated owner.
+5. Assert exactly one success, one duplicate classification, and one persisted row.
+6. Clean up in `finally` for repeatability.
+
+### Task 2: Validate against the real disposable stack
+
+**Steps:**
+
+1. Run `npm run test:db -- tests/db/pilot-replay.test.ts`.
+2. Run the full `npm run test:db` lane.
+3. If local Docker remains unavailable, push only after static/local validation and require the GitHub `test-db-integration` result before documenting F3 as complete.
+
+### Task 3: Update evidence truth
+
+**Files:**
+
+- Modify: `docs/security/v22-0-offline-local-threat-model.md`
+- Modify: `docs/runbooks/pilot-event-replay.md`
+
+**Steps:**
+
+1. Mark F3 verified only after the real DB integration test passes.
+2. Cite the exact test and clarify that evidence is disposable/local, not production.
+3. Preserve all other finding statuses.
+4. Run `npm run check:v22-threat-model` and documentation checks.
+
+### Task 4: Validate and deliver
+
+**Steps:**
+
+1. Run focused storage tests, full Vitest, lint, type-check, format, references, root hygiene, and diff checks.
+2. Obtain independent review.
+3. Commit the test and evidence in one reviewable commit.
+4. Push, open a focused PR, and wait for all CI including the DB integration lane.

--- a/docs/superpowers/specs/2026-07-10-pilot-replay-db-evidence-design.md
+++ b/docs/superpowers/specs/2026-07-10-pilot-replay-db-evidence-design.md
@@ -1,0 +1,30 @@
+# Pilot Replay Database Evidence Design
+
+## Context
+
+Threat-model finding F3 requires integration evidence that a repeated pilot event submission is atomically suppressed by a real backing store. The storage layer already treats a supplied-ID primary-key conflict as an idempotent duplicate, but current coverage mocks the Supabase response.
+
+The repository already provides a disposable Supabase DB lane with deterministic organizations, users, services, migrations, and service-role cleanup access. This batch uses that lane without changing schema, seed data, production configuration, or replay policy.
+
+## Decision
+
+Add one serial DB integration test for `insertContactAttempt`:
+
+1. Use the seeded owner identity and organization so the write traverses the existing authenticated RLS policy.
+2. Submit a fixed, privacy-safe contact-attempt payload with a client-supplied UUID.
+3. Submit two copies concurrently through the same storage function so the primary-key race is exercised.
+4. Verify exactly one insert succeeds, the other is classified as `duplicate: true` with no exposed error, and exactly one row exists.
+5. Delete the fixed row before and after the assertion through the disposable service-role client so reruns remain isolated.
+
+If the real DB test passes, update the F3 threat-model row and replay runbook to cite the disposable backing-store evidence. Do not claim production validation.
+
+## Boundaries
+
+- No migrations, grants, policies, generated types, or production database access.
+- No changes to replay fingerprints, response contracts, or storage behavior.
+- No user-derived text or personal contact data in the fixture.
+- Do not mark F1, F2, or F5 verified.
+
+## Validation
+
+Run the focused DB test in the disposable Supabase lane, then the full DB lane, focused unit coverage, lint, type-check, formatting, reference checks, and the regular Vitest suite. Local Docker Desktop is currently unhealthy, so GitHub's existing `test-db-integration` CI lane is the authoritative backing-store run if the local engine remains unavailable.

--- a/tests/db/helpers.ts
+++ b/tests/db/helpers.ts
@@ -1,5 +1,6 @@
 import { createHmac } from "node:crypto"
 import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
 
 const env = {
   url: process.env.SUPABASE_URL!,
@@ -32,8 +33,8 @@ function createJwt(userId: string, role: "authenticated" | "service_role" = "aut
   return `${encodedHeader}.${encodedPayload}.${base64UrlEncode(signature)}`
 }
 
-function createBaseClient(key: string, authorization?: string): SupabaseClient {
-  return createClient(env.url, key, {
+function createBaseClient(key: string, authorization?: string): SupabaseClient<Database> {
+  return createClient<Database>(env.url, key, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,
@@ -72,4 +73,8 @@ export const seededIds = {
 export const seededUsers = {
   owner: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
   viewer: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+}
+
+export const seededOrganizations = {
+  primary: "11111111-1111-1111-1111-111111111111",
 }

--- a/tests/db/pilot-replay.test.ts
+++ b/tests/db/pilot-replay.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { insertContactAttempt } from "@/lib/pilot/storage"
+import {
+  createAuthenticatedClient,
+  createServiceRoleClient,
+  seededIds,
+  seededOrganizations,
+  seededUsers,
+} from "./helpers"
+
+const replayEventId = "33333333-3333-4333-8333-333333333333"
+const replayPayload = {
+  id: replayEventId,
+  pilot_cycle_id: "db-pilot-replay-evidence",
+  service_id: seededIds.food,
+  recorded_by_org_id: seededOrganizations.primary,
+  entity_key_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  attempt_channel: "phone" as const,
+  attempt_outcome: "no_response" as const,
+  attempted_at: "2026-07-10T16:00:00.000Z",
+}
+
+describe("pilot replay persistence", () => {
+  it("atomically suppresses concurrent supplied-ID contact attempt retries", async () => {
+    const serviceClient = createServiceRoleClient()
+    const ownerClient = createAuthenticatedClient(seededUsers.owner)
+    const cleanupReplayEvent = async () => {
+      const { error } = await serviceClient.from("pilot_contact_attempt_events").delete().eq("id", replayEventId)
+      if (error) throw new Error(`Failed to clean up pilot replay fixture: ${error.message}`)
+    }
+
+    await cleanupReplayEvent()
+
+    try {
+      const writes = await Promise.all([
+        insertContactAttempt(ownerClient, replayPayload),
+        insertContactAttempt(ownerClient, replayPayload),
+      ])
+      const successfulWrites = writes.filter((result) => !result.duplicate)
+      const duplicateWrites = writes.filter((result) => result.duplicate)
+      const persisted = await serviceClient.from("pilot_contact_attempt_events").select("id").eq("id", replayEventId)
+
+      expect(successfulWrites).toHaveLength(1)
+      expect(successfulWrites[0]).toMatchObject({
+        data: { id: replayEventId },
+        duplicate: false,
+        error: null,
+        missingTable: false,
+      })
+      expect(duplicateWrites).toEqual([
+        {
+          data: null,
+          duplicate: true,
+          error: null,
+          missingTable: false,
+        },
+      ])
+      expect(persisted.error).toBeNull()
+      expect(persisted.data).toEqual([{ id: replayEventId }])
+    } finally {
+      await cleanupReplayEvent()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- add a disposable-Supabase integration test that races two identical client-supplied pilot event IDs
- exercise the existing authenticated owner RLS path and storage-layer duplicate classification
- prove exactly one success, one idempotent duplicate, and one persisted row
- type DB helpers against the generated `Database` contract instead of using unsafe casts
- mark threat-model finding F3 verified for the repository's disposable database contract

## Scope
- no migrations, schema changes, production access, service data, or replay-policy changes
- evidence is explicitly limited to the tested disposable migration contract and does not claim production-schema parity

## Validation
- GitHub `test-db-integration`: passed twice, before and after evidence docs
- GitHub static analysis, unit, build, and Docker smoke: passed
- local regular Vitest: 1,733 passed, 24 skipped (DB tests live in their separate lane)
- `npm run lint`
- `npm run type-check`
- `npm run format:check`
- `npm run check:refs`
- `npm run check:root`
- `npm run check:v22-threat-model`
- independent implementation and documentation review: no findings after concurrent-race and generated-client typing fixes

## Local environment note
Local Docker Desktop's Linux engine returned HTTP 500 for both API v1.54 and v1.44. The GitHub disposable DB lane therefore supplied the authoritative backing-store evidence; no production or private environment was accessed.