### PR TITLE
docs: archive completed roadmap audit

### DIFF
--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -92,6 +92,10 @@ This directory contains planning and strategy documents for CareConnect.
   - Completed repo-health maintenance report covering scoped code fixes, docs updates, verification status, and remaining follow-ups
   - **Reading time:** 10-15 minutes
 
+- [Roadmap Audit Archive (2026-02-11)](archive/2026-02-11-roadmap-audit.md)
+  - Historical public summary of the roadmap findings that informed the later v20-v22 work
+  - **Reading time:** 5 minutes
+
 - **[v22.0 Approval Checklist](v22-0-approval-checklist.md)**
   - Canonical sign-off record for Gate 0 decisions
   - **Reading time:** 10 minutes

--- a/docs/planning/archive/2026-02-11-roadmap-audit.md
+++ b/docs/planning/archive/2026-02-11-roadmap-audit.md
@@ -1,3 +1,10 @@
+---
+status: archived
+last_updated: 2026-07-13
+owner: jer
+tags: [planning, roadmap, audit, governance]
+---
+
 # Roadmap Audit Summary - 2026-02-11
 
 This public summary preserves the technical and governance outcomes from the February 2026 roadmap audit while excluding private personal strategy and application-planning content.

--- a/docs/planning/archive/README.md
+++ b/docs/planning/archive/README.md
@@ -24,3 +24,4 @@ Recent maintenance archives:
 - `2026-04-23-v20-0-quiet-github-automation-and-url-health-hardening.md` — quiet-by-default GitHub governance automation, bot-issue reconciliation, and URL-health false-positive hardening
 - `2026-03-30-v20-0-runtime-hardening-and-performance-remediation.md` — privacy, authorization, performance, coverage, and workflow follow-through from the March audit
 - `2026-03-29-v20-0-repo-audit-remediation.md` — repo hygiene, typing, privacy, and dependency cleanup follow-through
+- `2026-02-11-roadmap-audit.md` — public summary of the roadmap findings that informed the later v20-v22 work


### PR DESCRIPTION
## Summary
- archive the completed February 2026 roadmap audit under the planning archive naming convention
- add required archived-document metadata
- index the historical record from the planning and archive READMEs
- leave current roadmap priorities, service data, runtime behavior, and operations unchanged

## Validation
- npm run lint
- npm run type-check
- npm run format:check
- npm run check:refs
- npm run check:root
- npm test -- --run tests/unit/documentation-hygiene.test.ts
- npm run build
- full pre-push Vitest suite: 219 files, 1,746 passed, 24 credential-gated skipped